### PR TITLE
Fix superlat construction bug + minor refactors

### DIFF
--- a/src/Ewald.jl
+++ b/src/Ewald.jl
@@ -179,9 +179,7 @@ function ewald_sum_dipole(lattice::Lattice, spins::Array{Vec3, 4}; extent=2, η=
 
     # Vectors spanning the axes of the entire system
     superlat_vecs = lattice.size' .* lattice.lat_vecs
-    # Rescale lattice vectors to be superlattice
-    # (Not duplicating basis sites does not matter here -- we don't care)
-    superlat = Lattice(superlat_vecs, lattice.basis_vecs, (1,1,1))
+    superlat = Lattice(superlat_vecs, [[0.0, 0.0, 0.0]], (1,1,1))
     recip = gen_reciprocal(superlat)
     
     vol = volume(lattice)
@@ -349,7 +347,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
 
     # Vectors spanning the axes of the entire system
     superlat_vecs = lattice.size' .* lattice.lat_vecs
-    superlat = Lattice(superlat_vecs, lattice.basis_vecs, (1,1,1))
+    superlat = Lattice(superlat_vecs, [[0.0, 0.0, 0.0]], (1,1,1))
     recip = gen_reciprocal(superlat)
 
     vol = volume(lattice)
@@ -371,7 +369,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
 
     for idx in delta_idxs
         for b1 in 1:nb
-            @inbounds rᵢ = lattice.basis_vecs[b1]
+            @inbounds rᵢ = lattice[b1, 0, 0, 0]
             for b2 in 1:nb
                 @inbounds rⱼ = lattice[b2, idx]
                 rᵢⱼ = rⱼ - rᵢ

--- a/src/Lattice.jl
+++ b/src/Lattice.jl
@@ -9,9 +9,9 @@
 
 A type holding geometry information about a 3D lattice in a simulation box.
 """
-struct Lattice <: AbstractArray{SVector{3, Float64}, 4}
-    lat_vecs      :: SMatrix{3, 3, Float64, 9}       # Columns are lattice vectors
-    basis_vecs    :: Vector{SVector{3, Float64}}     # Each SVector gives a basis vector
+struct Lattice <: AbstractArray{Vec3, 4}
+    lat_vecs      :: Mat3                            # Columns are lattice vectors
+    basis_vecs    :: Vector{Vec3}                    # Each SVector gives a basis vector
     types         :: Vector{String}                  # Indices labeling atom types
     size          :: SVector{3, Int}                 # Number of cells along each dimension
 
@@ -37,8 +37,8 @@ struct Lattice <: AbstractArray{SVector{3, Float64}, 4}
         @assert length(basis_vecs) == length(types)      "Length of basis_vecs and types should match"
         @assert all(v->all(0 .<= v .< 1), basis_vecs)    "All basis_vecs should be given in fractional coordinates [0, 1)"
         @assert length(latsize) == 3                     "latsize should be length 3"
-        lat_vecs = convert(SMatrix{3, 3, Float64, 9}, lat_vecs)
-        basis_vecs = [lat_vecs * convert(SVector{3, Float64}, b) for b in basis_vecs]
+        lat_vecs = convert(Mat3, lat_vecs)
+        basis_vecs = [lat_vecs * convert(Vec3, b) for b in basis_vecs]
         latsize = SVector{3, Int}(latsize)
         new(lat_vecs, basis_vecs, types, latsize)
     end
@@ -100,15 +100,15 @@ end
 #=== Indexing returns absolute coordinates of lattice points ===#
 
 @inline function Base.getindex(lat::Lattice, b::Int64, brav::CartesianIndex{3})
-    return lat.lat_vecs * convert(SVector{3, Float64}, brav) + lat.basis_vecs[b]
+    return muladd(lat.lat_vecs, convert(Vec3, brav), lat.basis_vecs[b])
 end
 
 @inline function Base.getindex(lat::Lattice, b::Int64, brav::NTuple{3, Int64})
-    return lat.lat_vecs * convert(SVector{3, Float64}, brav) + lat.basis_vecs[b]
+    return muladd(lat.lat_vecs, convert(Vec3, brav), lat.basis_vecs[b])
 end
 
 @inline function Base.getindex(lat::Lattice, b::Int64, brav::Vararg{Int64, 3})
-    return lat.lat_vecs * convert(SVector{3, Float64}, brav) + lat.basis_vecs[b]
+    return muladd(lat.lat_vecs, convert(Vec3, brav), lat.basis_vecs[b])
 end
 
 # TODO: Should just be another Lattice

--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -238,7 +238,7 @@ function apply_dipole_factor(struct_factor::OffsetArray{ComplexF64}, lattice::La
     T = size(struct_factor)[end]
     result = zeros(Float64, axes(struct_factor)[3:end])
     for q_idx in CartesianIndices(axes(struct_factor)[3:end-1])
-        q = recip.lat_vecs * SVector{3, Float64}(Tuple(q_idx) ./ lattice.size)
+        q = recip.lat_vecs * Vec3(Tuple(q_idx) ./ lattice.size)
         q = q / (norm(q) + 1e-12)
         dip_factor = reshape(I(3) - q * q', 3, 3, 1)
         for t in 0:T-1
@@ -467,7 +467,7 @@ function phase_weight_basis!(res::OffsetArray{ComplexF64},
 
     fill!(res, 0.0)
     for q_idx in CartesianIndices(axes(res)[2:end-1])
-        q = recip.lat_vecs * SVector{3, Float64}(Tuple(q_idx) ./ lattice.size)
+        q = recip.lat_vecs * Vec3(Tuple(q_idx) ./ lattice.size)
         wrap_q_idx = modc(q_idx, spat_size) + one(CartesianIndex{3})
         for (b_idx, b) in enumerate(lattice.basis_vecs)
             phase = exp(-im * (b ⋅ q))
@@ -568,7 +568,7 @@ accumulates the structure factor from `S` with the dipole factor applied into `r
 function accum_dipole_factor!(res, S, lattice::Lattice)
     recip = gen_reciprocal(lattice)
     for q_idx in CartesianIndices(axes(res)[end-3:end-1])
-        q = recip.lat_vecs * SVector{3, Float64}(Tuple(q_idx) ./ lattice.size)
+        q = recip.lat_vecs * Vec3(Tuple(q_idx) ./ lattice.size)
         q = q / (norm(q) + 1e-12)
         dip_factor = I(3) - q * q'
 
@@ -594,7 +594,7 @@ function accum_dipole_factor_wbasis!(res, S, lattice::Lattice)
     Sβ = reshape(S, _outersizeβ(axes(S), 2))  # Size [3, B, 1, ...]
 
     for q_idx in CartesianIndices(axes(res)[end-3:end-1])
-        q = recip.lat_vecs * SVector{3, Float64}(Tuple(q_idx) ./ lattice.size)
+        q = recip.lat_vecs * Vec3(Tuple(q_idx) ./ lattice.size)
         q = q / (norm(q) + 1e-12)
         dip_factor = I(3) - q * q'
 

--- a/src/Symmetry/Bond.jl
+++ b/src/Symmetry/Bond.jl
@@ -12,8 +12,8 @@ end
 
 "Represents a bond expressed as two fractional coordinates"
 struct BondRaw
-    ri::SVector{3, Float64}
-    rj::SVector{3, Float64}
+    ri::Vec3
+    rj::Vec3
 end
 
 function Bond(cryst::Crystal, b::BondRaw)


### PR DESCRIPTION
Fixes a bug in the Ewald code left over from the transition to using fractional coordinates. When creating the superlattice `Lattice` in the Ewald summation, the absolute (non-fractional) basis vectors were being passed. This would silently work when these basis vectors had coordinates in [0.0, 1.0], but would error otherwise. However, these basis vectors were not actually used by any computation using the superlattice, so previous calculations should be correct.

Also perform some minor refactors surrounding the bugfix.