### PR TITLE
Indexing refactor and related optimizations

### DIFF
--- a/src/Anisotropies.jl
+++ b/src/Anisotropies.jl
@@ -31,7 +31,7 @@ end
 function energy(dipoles::Array{Vec3, 4}, aniso::DipolarQuadraticAnisotropyCPU)
     E = 0.0
     latsize = size(dipoles)[1:3]
-    for (site, J) in zip(aniso.sites, aniso.Js)
+    @inbounds for (site, J) in zip(aniso.sites, aniso.Js)
         for cell in CartesianIndices(latsize)
             # NOTE: Investigate alternate loop orders / alternate array layouts for cache speedups
             s = dipoles[cell, site]
@@ -45,7 +45,7 @@ end
 function energy(dipoles::Array{Vec3, 4}, aniso::DipolarQuarticAnisotropyCPU)
     E = 0.0
     latsize = size(dipoles)[1:3]
-    for (site, J) in zip(aniso.sites, aniso.Js)
+    @inbounds for (site, J) in zip(aniso.sites, aniso.Js)
         for cell in CartesianIndices(latsize)
             s = dipoles[cell, site]
             E += contract(J, s)
@@ -57,7 +57,7 @@ end
 function energy(coherents::Array{CVec{N}, 4}, aniso::SUNAnisotropyCPU, spin_mags::Vector{Float64}) where {N}
     E = 0.0
     latsize = size(coherents)[1:3]
-    for (site, Λ) in zip(aniso.sites, aniso.Λs)
+    @inbounds for (site, Λ) in zip(aniso.sites, aniso.Λs)
         for cell in CartesianIndices(latsize)
             Z = coherents[cell, site]
             E += spin_mags[site]*real(Z' * Λ * Z)
@@ -68,7 +68,7 @@ end
 
 function _accum_neggrad!(B::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, aniso::DipolarQuadraticAnisotropyCPU)
     latsize = size(dipoles)[1:3]
-    for (site, J) in zip(aniso.sites, aniso.Js)
+    @inbounds for (site, J) in zip(aniso.sites, aniso.Js)
         for cell in CartesianIndices(latsize)
             s = dipoles[cell, site]
             B[cell, site] = B[cell, site] - 2 * J * s
@@ -80,7 +80,7 @@ function _neggrad(dipoles::Array{Vec3, 4}, aniso::DipolarQuadraticAnisotropyCPU,
     B = Vec3(0,0,0)
     cell, i = splitidx(idx) 
 
-    for (site, J) in zip(aniso.sites, aniso.Js)
+    @inbounds for (site, J) in zip(aniso.sites, aniso.Js)
         if site == i
             B -= 2 * J * dipoles[cell, site]
         end
@@ -91,7 +91,7 @@ end
 
 function _accum_neggrad!(B::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, aniso::DipolarQuarticAnisotropyCPU)
     latsize = size(dipoles)[1:3]
-    for (site, J) in zip(aniso.sites, aniso.Js)
+    @inbounds for (site, J) in zip(aniso.sites, aniso.Js)
         for cell in CartesianIndices(latsize)
             s = dipoles[cell, site]
             B[cell, site] = B[cell, site] - grad_contract(J, s) 
@@ -103,7 +103,7 @@ function _neggrad(dipoles::Array{Vec3, 4}, aniso::DipolarQuarticAnisotropyCPU, i
     B = Vec3(0,0,0)
     cell, i = splitidx(idx) 
 
-    for (site, J) in zip(aniso.sites, aniso.Js)
+    @inbounds for (site, J) in zip(aniso.sites, aniso.Js)
         if site == i
             B -= grad_contract(J, dipoles[cell, site])
         end

--- a/src/Anisotropies.jl
+++ b/src/Anisotropies.jl
@@ -11,7 +11,7 @@ Upon creation of a SpinSystem, all pair interactions get converted into their
 # Q: Why don't we do the same for pair interactions as well?
 
 struct DipolarQuadraticAnisotropyCPU <: AbstractInteractionCPU
-    Js    :: Vector{Mat3}  
+    Js    :: Vector{Mat3}
     sites :: Vector{Int}
     label :: String
 end
@@ -77,7 +77,7 @@ function _accum_neggrad!(B::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, aniso::Dipo
     end
 end
 
-function _neggrad(dipoles::Array{Vec3, 4}, aniso::DipolarQuadraticAnisotropyCPU, idx)
+function (dipoles::Array{Vec3, 4}, aniso::DipolarQuadraticAnisotropyCPU, idx)
     B = Vec3(0,0,0)
     cell, i = splitidx(idx) 
 

--- a/src/Anisotropies.jl
+++ b/src/Anisotropies.jl
@@ -11,7 +11,7 @@ Upon creation of a SpinSystem, all pair interactions get converted into their
 # Q: Why don't we do the same for pair interactions as well?
 
 struct DipolarQuadraticAnisotropyCPU <: AbstractInteractionCPU
-    Js    :: Vector{Mat3}
+    Js    :: Vector{Mat3}  
     sites :: Vector{Int}
     label :: String
 end
@@ -23,7 +23,7 @@ struct DipolarQuarticAnisotropyCPU <: AbstractInteractionCPU
 end
 
 struct SUNAnisotropyCPU <: AbstractInteractionCPU
-    Λs    :: Vector{Matrix{ComplexF64}}
+    Λs    :: Array{ComplexF64, 3} 
     sites :: Vector{Int}
     label :: String
 end
@@ -57,7 +57,8 @@ end
 function energy(coherents::Array{CVec{N}, 4}, aniso::SUNAnisotropyCPU, spin_mags::Vector{Float64}) where {N}
     E = 0.0
     latsize = size(coherents)[1:3]
-    @inbounds for (site, Λ) in zip(aniso.sites, aniso.Λs)
+    @inbounds for site in aniso.sites
+        Λ = @view(aniso.Λs[:,:,site])
         for cell in CartesianIndices(latsize)
             Z = coherents[cell, site]
             E += spin_mags[site]*real(Z' * Λ * Z)

--- a/src/Ewald.jl
+++ b/src/Ewald.jl
@@ -310,7 +310,7 @@ function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: Offse
                     end
                     recip_site_sum += exp(-k2 / 4η^2) * cos(k ⋅ rᵢⱼ) / k2
                 end
-                @inbounds A[idx, b2, b1] += 2π / vol * recip_site_sum  # confirm b1, b2 order
+                @inbounds A[idx, b1, b2] += 2π / vol * recip_site_sum  # confirm b1, b2 order
             end
         end
     end
@@ -328,7 +328,7 @@ function contract_monopole(charges::Array{Float64, 4}, A::OffsetArray{Float64}) 
             for j in CartesianIndices(latsize)
                 for jb in 1:nb
                     @inbounds qⱼ = charges[j, jb]
-                    @inbounds U += qᵢ * A[i - j, jb, ib] * qⱼ   # confirm jb, ib order
+                    @inbounds U += qᵢ * A[i - j, ib, jb] * qⱼ   # confirm jb, ib order
                 end
             end
         end
@@ -400,7 +400,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
                     @. real_tensor += prefactor * (rᵢⱼ_n * rᵢⱼ_n')
                 end
                 @inbounds real_tensor .+= real_site_sum * iden
-                @inbounds A[idx, b2, b1] = A[idx, b2, b1] .+ 0.5 * real_tensor  # confirm b1, b2 order
+                @inbounds A[idx, b1, b2] = A[idx, b1, b2] .+ 0.5 * real_tensor  # confirm b1, b2 order
 
                 # Reciprocal-space sum
                 fill!(recip_tensor, 0.0)
@@ -416,7 +416,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
                     prefactor = exp(-k2 / 4η^2) * cos(k ⋅ rᵢⱼ) / k2
                     @. recip_tensor += prefactor * (k * k')
                 end
-                @inbounds A[idx, b2, b1] = A[idx, b2, b1] .+ 2π / vol * recip_tensor # confirm b1, b2 order
+                @inbounds A[idx, b1, b2] = A[idx, b1, b2] .+ 2π / vol * recip_tensor # confirm b1, b2 order
             end
         end
     end
@@ -435,7 +435,7 @@ function contract_dipole(spins::Array{Vec3, 4}, A::OffsetArray{Mat3, 5}) :: Floa
             for j in CartesianIndices(latsize)
                 for jb in 1:nb
                     @inbounds pⱼ = spins[j, jb]
-                    @inbounds U += dot(pᵢ, A[modc(i - j, latsize), jb, ib], pⱼ)  # confirm jb, ib order
+                    @inbounds U += dot(pᵢ, A[modc(i - j, latsize), ib, jb], pⱼ)  # confirm jb, ib order
                 end
             end
         end
@@ -464,7 +464,7 @@ function DipoleRealCPU(dip::DipoleDipole, crystal::Crystal, latsize, site_infos:
         for b2 in 1:nbasis(crystal)
             g2 = site_infos[b2].g
             for ijk in CartesianIndices(axes(A)[3:end])
-                A[ijk, b2, b1] = g1' * A[ijk, b2, b1] * g2
+                A[ijk, b1, b2] = g1' * A[ijk, b1, b2] * g2
             end
         end
     end
@@ -478,7 +478,7 @@ end
 "Accumulates the local -∇ℋ coming from dipole-dipole couplings into `B`"
 function _accum_neggrad!(H::Array{Vec3, 4}, spins::Array{Vec3, 4}, dip::DipoleRealCPU)
     A = dip.int_mat
-    nb = size(spins, 1)
+    nb = size(spins, 4)
     latsize = size(spins)[1:3]
 
     for j in CartesianIndices(latsize)
@@ -486,7 +486,7 @@ function _accum_neggrad!(H::Array{Vec3, 4}, spins::Array{Vec3, 4}, dip::DipoleRe
             @inbounds pⱼ = spins[j, jb]
             for i in CartesianIndices(latsize)
                 for ib in 1:nb
-                    @inbounds H[i, ib] = H[i, ib] - 2 * (A[modc(i - j, latsize), jb, ib] * pⱼ)  # confirm jb, ib order
+                    @inbounds H[i, ib] = H[i, ib] - 2 * (A[modc(i - j, latsize), ib, jb] * pⱼ)  # confirm jb, ib order
                 end
             end
         end

--- a/src/Ewald.jl
+++ b/src/Ewald.jl
@@ -21,7 +21,7 @@ Base.setindex!(sys::ChargeSystem, v, i::Int) = setindex!(sys.charges, v, i)
 Construct a `ChargeSystem` on the given lattice, initialized to all zero charges.
 """
 function ChargeSystem(lat::Lattice)
-    sites_size = (nbasis(lat), lat.size...)
+    sites_size = (lat.size..., nbasis(lat))
     sites = zeros(sites_size)
 
     return ChargeSystem(lat, sites)
@@ -250,8 +250,8 @@ end
 "Precompute the dipole interaction matrix, not yet in ± compressed form."
 function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: OffsetArray{5, Float64} where {D}
     nb = nbasis(lattice)
-    A = zeros(Float64, nb, nb, map(n->2*(n-1)+1, lattice.size)...)
-    A = OffsetArray(A, 1:nb, 1:nb, map(n->-(n-1):n-1, lattice.size)...)
+    A = zeros(Float64, map(n->2*(n-1)+1, lattice.size)..., nb, nb)
+    A = OffsetArray(A, map(n->-(n-1):n-1, lattice.size)..., 1:nb, 1:nb)
 
     extent_idxs = CartesianIndices((-extent:extent, -extent:extent, -extent:extent))
     delta_idxs = CartesianIndices(ntuple(n->-(lattice.size[n]-1):(lattice.size[n]-1), Val(3)))
@@ -266,7 +266,7 @@ function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: Offse
     # Handle charge-squared and total charge terms
     A .+= -π / (2 * vol * η^2)
     for i in 1:nb
-        @inbounds A[i, i, 0, 0, 0] += -η / √π
+        @inbounds A[0, 0, 0, i, i] += -η / √π
     end
 
     real_space_sum, recip_space_sum = 0.0, 0.0
@@ -279,7 +279,7 @@ function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: Offse
         for b1 in 1:nb
             @inbounds rᵢ = lattice.basis_vecs[b1]
             for b2 in 1:nb
-                @inbounds rⱼ = lattice[b2, idx]
+                @inbounds rⱼ = lattice[idx, b2]
                 rᵢⱼ = rⱼ - rᵢ
 
                 # TODO: Either merge into one sum, or separately control extents
@@ -296,7 +296,7 @@ function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: Offse
                     dist = norm(rᵢⱼ + n)
                     real_site_sum += erfc(η * dist) / dist
                 end
-                @inbounds A[b2, b1, idx] += 0.5 * real_site_sum
+                @inbounds A[idx, b2, b1] += 0.5 * real_site_sum
 
                 # Reciprocal-space sum
                 recip_site_sum = 0.0
@@ -310,7 +310,7 @@ function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: Offse
                     end
                     recip_site_sum += exp(-k2 / 4η^2) * cos(k ⋅ rᵢⱼ) / k2
                 end
-                @inbounds A[b2, b1, idx] += 2π / vol * recip_site_sum
+                @inbounds A[idx, b2, b1] += 2π / vol * recip_site_sum  # confirm b1, b2 order
             end
         end
     end
@@ -319,16 +319,16 @@ function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: Offse
 end
 
 function contract_monopole(charges::Array{Float64, 4}, A::OffsetArray{Float64}) :: Float64
-    nb = size(charges, 1)
-    latsize = size(charges)[2:end]
+    nb = size(charges, 4)
+    latsize = size(charges)[1:3]
     U = 0.0
     for i in CartesianIndices(latsize)
         for ib in 1:nb
-            @inbounds qᵢ = charges[ib, i]
+            @inbounds qᵢ = charges[i, ib]
             for j in CartesianIndices(latsize)
                 for jb in 1:nb
-                    @inbounds qⱼ = charges[jb, j]
-                    @inbounds U += qᵢ * A[ib, jb, i - j] * qⱼ
+                    @inbounds qⱼ = charges[j, jb]
+                    @inbounds U += qᵢ * A[i - j, jb, ib] * qⱼ   # confirm jb, ib order
                 end
             end
         end
@@ -339,8 +339,8 @@ end
 "Precompute the dipole interaction matrix, in ± compressed form."
 function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetArray{Mat3, 5}
     nb = nbasis(lattice)
-    A = zeros(Mat3, nb, nb, lattice.size...)
-    A = OffsetArray(A, 1:nb, 1:nb, map(n->0:n-1, lattice.size)...)
+    A = zeros(Mat3, lattice.size..., nb, nb)
+    A = OffsetArray(A, map(n->0:n-1, lattice.size)..., 1:nb, 1:nb)
 
     extent_idxs = CartesianIndices((-extent:extent, -extent:extent, -extent:extent))
     delta_idxs = eachcellindex(lattice) .- oneunit(CartesianIndex{3})
@@ -356,7 +356,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
 
     # Put the dipole-squared term on the zero-difference matrix
     for i in 1:nb
-        A[i, i, 0, 0, 0] = A[i, i, 0, 0, 0] .+ -2η^3 / (3 * √π) * iden
+        A[0, 0, 0, i, i] = A[0, 0, 0, i, i] .+ -2η^3 / (3 * √π) * iden
     end
 
     real_space_sum, recip_space_sum = 0.0, 0.0
@@ -369,9 +369,9 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
 
     for idx in delta_idxs
         for b1 in 1:nb
-            @inbounds rᵢ = lattice[b1, 0, 0, 0]
+            @inbounds rᵢ = lattice[0, 0, 0, b1]
             for b2 in 1:nb
-                @inbounds rⱼ = lattice[b2, idx]
+                @inbounds rⱼ = lattice[idx, b2]
                 rᵢⱼ = rⱼ - rᵢ
 
                 # TODO: Either merge into one sum, or separately control extents
@@ -400,7 +400,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
                     @. real_tensor += prefactor * (rᵢⱼ_n * rᵢⱼ_n')
                 end
                 @inbounds real_tensor .+= real_site_sum * iden
-                @inbounds A[b2, b1, idx] = A[b2, b1, idx] .+ 0.5 * real_tensor
+                @inbounds A[idx, b2, b1] = A[idx, b2, b1] .+ 0.5 * real_tensor  # confirm b1, b2 order
 
                 # Reciprocal-space sum
                 fill!(recip_tensor, 0.0)
@@ -416,7 +416,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
                     prefactor = exp(-k2 / 4η^2) * cos(k ⋅ rᵢⱼ) / k2
                     @. recip_tensor += prefactor * (k * k')
                 end
-                @inbounds A[b2, b1, idx] = A[b2, b1, idx] .+ 2π / vol * recip_tensor
+                @inbounds A[idx, b2, b1] = A[idx, b2, b1] .+ 2π / vol * recip_tensor # confirm b1, b2 order
             end
         end
     end
@@ -426,16 +426,16 @@ end
 
 "Contracts a system of dipoles with a precomputed interaction tensor A, in ± compressed format"
 function contract_dipole(spins::Array{Vec3, 4}, A::OffsetArray{Mat3, 5}) :: Float64
-    nb = size(spins, 1)
-    latsize = size(spins)[2:end]
+    nb = size(spins, 4)
+    latsize = size(spins)[1:3]
     U = 0.0
     for i in CartesianIndices(latsize)
         for ib in 1:nb
-            @inbounds pᵢ = spins[ib, i]
+            @inbounds pᵢ = spins[i, ib]
             for j in CartesianIndices(latsize)
                 for jb in 1:nb
-                    @inbounds pⱼ = spins[jb, j]
-                    @inbounds U += dot(pᵢ, A[ib, jb, modc(i - j, latsize)], pⱼ)
+                    @inbounds pⱼ = spins[j, jb]
+                    @inbounds U += dot(pᵢ, A[modc(i - j, latsize), jb, ib], pⱼ)  # confirm jb, ib order
                 end
             end
         end
@@ -464,7 +464,7 @@ function DipoleRealCPU(dip::DipoleDipole, crystal::Crystal, latsize, site_infos:
         for b2 in 1:nbasis(crystal)
             g2 = site_infos[b2].g
             for ijk in CartesianIndices(axes(A)[3:end])
-                A[b1, b2, ijk] = g1' * A[b1, b2, ijk] * g2
+                A[ijk, b2, b1] = g1' * A[ijk, b2, b1] * g2
             end
         end
     end
@@ -479,14 +479,14 @@ end
 function _accum_neggrad!(H::Array{Vec3, 4}, spins::Array{Vec3, 4}, dip::DipoleRealCPU)
     A = dip.int_mat
     nb = size(spins, 1)
-    latsize = size(spins)[2:end]
+    latsize = size(spins)[1:3]
 
     for j in CartesianIndices(latsize)
         for jb in 1:nb
-            @inbounds pⱼ = spins[jb, j]
+            @inbounds pⱼ = spins[j, jb]
             for i in CartesianIndices(latsize)
                 for ib in 1:nb
-                    @inbounds H[ib, i] = H[ib, i] - 2 * (A[ib, jb, modc(i - j, latsize)] * pⱼ)
+                    @inbounds H[i, ib] = H[i, ib] - 2 * (A[modc(i - j, latsize), jb, ib] * pⱼ)  # confirm jb, ib order
                 end
             end
         end

--- a/src/Ewald.jl
+++ b/src/Ewald.jl
@@ -310,7 +310,7 @@ function precompute_monopole_ewald(lattice::Lattice; extent=10, η=1.0) :: Offse
                     end
                     recip_site_sum += exp(-k2 / 4η^2) * cos(k ⋅ rᵢⱼ) / k2
                 end
-                @inbounds A[idx, b1, b2] += 2π / vol * recip_site_sum  # confirm b1, b2 order
+                @inbounds A[idx, b2, b1] += 2π / vol * recip_site_sum  # confirm b1, b2 order
             end
         end
     end
@@ -400,7 +400,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
                     @. real_tensor += prefactor * (rᵢⱼ_n * rᵢⱼ_n')
                 end
                 @inbounds real_tensor .+= real_site_sum * iden
-                @inbounds A[idx, b1, b2] = A[idx, b1, b2] .+ 0.5 * real_tensor  # confirm b1, b2 order
+                @inbounds A[idx, b2, b1] = A[idx, b2, b1] .+ 0.5 * real_tensor  # confirm b1, b2 order
 
                 # Reciprocal-space sum
                 fill!(recip_tensor, 0.0)
@@ -416,7 +416,7 @@ function precompute_dipole_ewald(lattice::Lattice; extent=3, η=1.0) :: OffsetAr
                     prefactor = exp(-k2 / 4η^2) * cos(k ⋅ rᵢⱼ) / k2
                     @. recip_tensor += prefactor * (k * k')
                 end
-                @inbounds A[idx, b1, b2] = A[idx, b1, b2] .+ 2π / vol * recip_tensor # confirm b1, b2 order
+                @inbounds A[idx, b2, b1] = A[idx, b2, b1] .+ 2π / vol * recip_tensor # confirm b1, b2 order
             end
         end
     end
@@ -435,7 +435,7 @@ function contract_dipole(spins::Array{Vec3, 4}, A::OffsetArray{Mat3, 5}) :: Floa
             for j in CartesianIndices(latsize)
                 for jb in 1:nb
                     @inbounds pⱼ = spins[j, jb]
-                    @inbounds U += dot(pᵢ, A[modc(i - j, latsize), ib, jb], pⱼ)  # confirm jb, ib order
+                    @inbounds U += dot(pᵢ, A[modc(i - j, latsize), ib, jb], pⱼ) 
                 end
             end
         end
@@ -463,7 +463,7 @@ function DipoleRealCPU(dip::DipoleDipole, crystal::Crystal, latsize, site_infos:
         g1 = site_infos[b1].g
         for b2 in 1:nbasis(crystal)
             g2 = site_infos[b2].g
-            for ijk in CartesianIndices(axes(A)[3:end])
+            for ijk in CartesianIndices(axes(A)[1:3])
                 A[ijk, b1, b2] = g1' * A[ijk, b1, b2] * g2
             end
         end

--- a/src/FourierAccel.jl
+++ b/src/FourierAccel.jl
@@ -40,10 +40,10 @@ function DipoleFourierCPU(dip::DipoleDipole, crystal::Crystal, latsize, site_inf
 
     A = (μ0/4π) * μB^2 .* precompute_dipole_ewald(lattice; extent, η)
     # Conjugate each matrix by the correct g matrices
-    for b1 in 1:nbasis(crystal)
-        g1 = site_infos[b1].g
-        for b2 in 1:nbasis(crystal)
-            g2 = site_infos[b2].g
+    for b2 in 1:nbasis(crystal)
+        g2 = site_infos[b2].g
+        for b1 in 1:nbasis(crystal)
+            g1 = site_infos[b1].g
             for ijk in CartesianIndices(axes(A)[1:end-2])
                 A[ijk, b1, b2] = g1' * A[ijk, b1, b2] * g2
             end
@@ -56,7 +56,7 @@ function DipoleFourierCPU(dip::DipoleDipole, crystal::Crystal, latsize, site_inf
     rftdim = div(size(lattice, 1), 2) + 1   
 
     # Since only 3D lattice, size(lattice)[3:end] = size(lattice)[3:4]. This corresponded to y/b and z/c indices. 
-    # Note: Always moving nb after other lattice dims.
+    # Spin components up front (to keep memory layout), by basis indices moved to end.
     spins_ft = Array{ComplexF64, 5}(undef, 3, rftdim, size(lattice)[2:3]..., nb)  
     field_ft = Array{ComplexF64, 5}(undef, 3, rftdim, size(lattice)[2:3]..., nb)
     field_real = Array{Float64, 5}(undef, 3, size(lattice)...)

--- a/src/FourierAccel.jl
+++ b/src/FourierAccel.jl
@@ -3,13 +3,15 @@
 "Computes the Fourier transform of a (spatially compressed) dipole interaction matrix"
 function _rfft_dipole_tensor(A::OffsetArray{Mat3}) :: Array{Complex{Float64}}
     A = _reinterpret_dipole_tensor(A)
-    rfft(A, 5:ndims(A))
+    # rfft(A, 5:ndims(A))
+    rfft(A, 3:5)
 end
 
 "Fourier transforms a dipole system"
 function _rfft_dipole_sys(dipoles::Array{Vec3}) :: Array{Complex{Float64}}
     Sr = reinterpret(reshape, Float64, dipoles)
-    rfft(Sr, 3:ndims(Sr))
+    # rfft(Sr, 3:ndims(Sr))
+    rfft(Sr, 2:4)
 end
 
 # FFTW types for various relevant Fourier transform plans using in this file
@@ -42,43 +44,49 @@ function DipoleFourierCPU(dip::DipoleDipole, crystal::Crystal, latsize, site_inf
         g1 = site_infos[b1].g
         for b2 in 1:nbasis(crystal)
             g2 = site_infos[b2].g
-            for ijk in CartesianIndices(axes(A)[3:end])
-                A[b1, b2, ijk] = g1' * A[b1, b2, ijk] * g2
+            for ijk in CartesianIndices(axes(A)[1:end-2])
+                A[ijk, b2, b1] = g1' * A[ijk, b2, b1] * g2
             end
         end
     end
     FA = _rfft_dipole_tensor(A)
     nb = nbasis(lattice)
-    rftdim = div(size(lattice, 2), 2) + 1
-    spins_ft = Array{ComplexF64, 5}(undef, 3, nb, rftdim, size(lattice)[3:end]...)
-    field_ft = Array{ComplexF64, 5}(undef, 3, nb, rftdim, size(lattice)[3:end]...)
+
+    # Note: size(lattice) ≠ lattice.size. size(lattice, 2) was formerly x/a index. This is now `size(lattice, 1)`
+    rftdim = div(size(lattice, 1), 2) + 1   
+
+    # Since only 3D lattice, size(lattice)[3:end] = size(lattice)[3:4]. This corresponded to y/b and z/c indices. 
+    # Note: Always moving nb after other lattice dims.
+    spins_ft = Array{ComplexF64, 5}(undef, 3, rftdim, size(lattice)[2:3]..., nb)  
+    field_ft = Array{ComplexF64, 5}(undef, 3, rftdim, size(lattice)[2:3]..., nb)
     field_real = Array{Float64, 5}(undef, 3, size(lattice)...)
 
     mock_spins = zeros(3, size(lattice)...)
-    plan = plan_rfft(mock_spins, 3:ndims(mock_spins); flags=FFTW.MEASURE)
-    ift_plan = plan_irfft(spins_ft, size(lattice, 2), 3:ndims(mock_spins); flags=FFTW.MEASURE)
+    # plan = plan_rfft(mock_spins, 3:ndims(mock_spins); flags=FFTW.MEASURE)
+    plan = plan_rfft(mock_spins, 2:4; flags=FFTW.MEASURE)
+    # ift_plan = plan_irfft(spins_ft, size(lattice, 2), 3:ndims(mock_spins); flags=FFTW.MEASURE)
+    ift_plan = plan_irfft(spins_ft, size(lattice, 1), 2:4; flags=FFTW.MEASURE)
+
     DipoleFourierCPU(FA, spins_ft, field_ft, field_real, plan, ift_plan)
 end
 
 function energy(dipoles::Array{Vec3, 4}, dip::DipoleFourierCPU)
     FA = dip.int_mat
     FS = dip._spins_ft
-    nb = size(dipoles, 1)
-    latsize = size(dipoles)[2:end]
+    latsize = size(dipoles)[1:3]
     even_rft_size = latsize[1] % 2 == 0
-    Fsize = size(FS)[3:end]
     spins = _reinterpret_from_spin_array(dipoles)
 
     U = 0.0
     mul!(FS, dip._plan, spins)
     # Need to add a normalization factor to some components due to rfft usage
     if even_rft_size
-        @views FS[:, :, 2:end-1, :, :] .*= √2
+        @views FS[:, 2:end-1, :, :, :] .*= √2
     else
-        @views FS[:, :, 2:end, :, :] .*= √2
+        @views FS[:, 2:end, :, :, :] .*= √2
     end
     @tullio U += real(
-        conj(FS[is, ib, j, k, l]) * FA[is, js, ib, jb, j, k, l] * FS[js, jb, j, k, l]
+        conj(FS[is, j, k, l, ib]) * FA[is, js, j, k, l, jb, ib] * FS[js, j, k, l, jb]  # check jb ib order
     )
     return U / prod(latsize)
 end
@@ -93,7 +101,7 @@ function _accum_neggrad!(H::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, dipdip::Dip
     fill!(Fϕ, 0.0)
     spins = _reinterpret_from_spin_array(dipoles)
     mul!(FS, dipdip._plan, spins)
-    @tullio grad=false Fϕ[s1,b1,i,j,k] += FA[s1,s2,b1,b2,i,j,k] * FS[s2,b2,i,j,k]
+    @tullio grad=false Fϕ[s1,i,j,k,b1] += FA[s1,s2,i,j,k,b2,b1] * FS[s2,i,j,k,b2] # test b2 b1 order
     mul!(ϕ, dipdip._ift_plan, Fϕ)
     ϕ = _reinterpret_to_spin_array(ϕ)
     for i in eachindex(H)

--- a/src/FourierAccel.jl
+++ b/src/FourierAccel.jl
@@ -45,7 +45,7 @@ function DipoleFourierCPU(dip::DipoleDipole, crystal::Crystal, latsize, site_inf
         for b2 in 1:nbasis(crystal)
             g2 = site_infos[b2].g
             for ijk in CartesianIndices(axes(A)[1:end-2])
-                A[ijk, b2, b1] = g1' * A[ijk, b2, b1] * g2
+                A[ijk, b1, b2] = g1' * A[ijk, b1, b2] * g2
             end
         end
     end
@@ -86,7 +86,7 @@ function energy(dipoles::Array{Vec3, 4}, dip::DipoleFourierCPU)
         @views FS[:, 2:end, :, :, :] .*= √2
     end
     @tullio U += real(
-        conj(FS[is, j, k, l, ib]) * FA[is, js, j, k, l, jb, ib] * FS[js, j, k, l, jb]  # check jb ib order
+        conj(FS[is, j, k, l, ib]) * FA[is, js, j, k, l, ib, jb] * FS[js, j, k, l, jb]  # check jb ib order
     )
     return U / prod(latsize)
 end
@@ -101,7 +101,7 @@ function _accum_neggrad!(H::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, dipdip::Dip
     fill!(Fϕ, 0.0)
     spins = _reinterpret_from_spin_array(dipoles)
     mul!(FS, dipdip._plan, spins)
-    @tullio grad=false Fϕ[s1,i,j,k,b1] += FA[s1,s2,i,j,k,b2,b1] * FS[s2,i,j,k,b2] # test b2 b1 order
+    @tullio grad=false Fϕ[s1,i,j,k,b1] += FA[s1,s2,i,j,k,b1,b2] * FS[s2,i,j,k,b2] # test b2 b1 order
     mul!(ϕ, dipdip._ift_plan, Fϕ)
     ϕ = _reinterpret_to_spin_array(ϕ)
     for i in eachindex(H)

--- a/src/FourierAccel.jl
+++ b/src/FourierAccel.jl
@@ -38,10 +38,10 @@ function DipoleFourierCPU(dip::DipoleDipole, crystal::Crystal, latsize, site_inf
 
     A = (μ0/4π) * μB^2 .* precompute_dipole_ewald(lattice; extent, η)
     # Conjugate each matrix by the correct g matrices
-    for b1 in 1:nbasis(crystal)
-        g1 = site_infos[b1].g
-        for b2 in 1:nbasis(crystal)
-            g2 = site_infos[b2].g
+    for b2 in 1:nbasis(crystal)
+        g2 = site_infos[b2].g
+        for b1 in 1:nbasis(crystal)
+            g1 = site_infos[b1].g
             for ijk in CartesianIndices(axes(A)[1:end-2])
                 A[ijk, b1, b2] = g1' * A[ijk, b1, b2] * g2
             end
@@ -78,7 +78,7 @@ function energy(dipoles::Array{Vec3, 4}, dip::DipoleFourierCPU)
         @views FS[:, 2:end, :, :, :] .*= √2
     end
     @tullio U += real(
-        conj(FS[is, j, k, l, ib]) * FA[is, js, j, k, l, ib, jb] * FS[js, j, k, l, jb]  # check jb ib order
+        conj(FS[is, j, k, l, ib]) * FA[is, js, j, k, l, ib, jb] * FS[js, j, k, l, jb]
     )
     return U / prod(latsize)
 end
@@ -93,7 +93,7 @@ function _accum_neggrad!(H::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, dipdip::Dip
     fill!(Fϕ, 0.0)
     spins = _reinterpret_from_spin_array(dipoles)
     mul!(FS, dipdip._plan, spins)
-    @tullio grad=false Fϕ[s1,i,j,k,b1] += FA[s1,s2,i,j,k,b1,b2] * FS[s2,i,j,k,b2] # test b2 b1 order
+    @tullio grad=false Fϕ[s1,i,j,k,b1] += FA[s1,s2,i,j,k,b1,b2] * FS[s2,i,j,k,b2]
     mul!(ϕ, dipdip._ift_plan, Fϕ)
     ϕ = _reinterpret_to_spin_array(ϕ)
     for i in eachindex(H)

--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -76,8 +76,15 @@ end
 
 function merge(anisos::Vector{SUNAnisotropy})
     (length(anisos) == 0) && (return nothing)
-    SUNAnisotropyCPU([a.Λ for a in anisos],
-                     [a.site for a in anisos],
+    N = size(anisos[1].Λ)[1]
+    sites = Int[]
+    Λs = zeros(ComplexF64, N, N, length(anisos))
+    for (i, aniso) in enumerate(anisos)
+        Λs[:,:,i] .= aniso.Λ
+        push!(sites, aniso.site)
+    end
+    SUNAnisotropyCPU(Λs,
+                     sites,
                      ""
     )
 end

--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -303,11 +303,12 @@ Calculates the local field, `Bᵢ`, for a single site, `i`:
 
 This is useful for some sampling methods.
 """
-function field(dipoles::Array{Vec3, 4}, ℋ::HamiltonianCPU, i) 
+function field(dipoles::Array{Vec3, 4}, ℋ::HamiltonianCPU, i::CartesianIndex) 
     B = SA[0.0, 0.0, 0.0]
+    site = i[end]
 
     if !isnothing(ℋ.ext_field)
-        B += ℋ.ext_field.effBs[i[1]] 
+        B += ℋ.ext_field.effBs[site] 
     end
     for heisen in ℋ.heisenbergs
         B += _neggrad(dipoles, heisen, i)

--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -312,7 +312,7 @@ This is useful for some sampling methods.
 """
 function field(dipoles::Array{Vec3, 4}, ℋ::HamiltonianCPU, i::CartesianIndex) 
     B = SA[0.0, 0.0, 0.0]
-    site = i[end]
+    _, site = splitidx(i) 
 
     if !isnothing(ℋ.ext_field)
         B += ℋ.ext_field.effBs[site] 

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -308,7 +308,6 @@ end
         (; hamiltonian, site_infos, lattice, S) = sys
         aniso = hamiltonian.sun_aniso
         rhs′ = reinterpret(reshape, ComplexF64, rhs) 
-        # Sˣ, Sʸ, Sᶻ = @view(S[:,:,1]), @view(S[:,:,2]), @view(S[:,:,3]) 
         Sˣ, Sʸ, Sᶻ = S[:,:,1], S[:,:,2], S[:,:,3] # Cheaper to take the allocations than use views.
 
         @inbounds for s in aniso.sites

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -5,6 +5,7 @@
 """
 
 abstract type Integrator end
+abstract type LangevinIntegrator <: Integrator end
 
 # TODO: These integrators should verify that the system is in
 #        "dipole-mode". Or, is there some nice way to make them
@@ -38,7 +39,7 @@ magnitude -- this is done internally.
 
 Uses the 2nd-order Heun + projection scheme."
 """
-mutable struct LangevinHeunP <: Integrator
+mutable struct LangevinHeunP <: LangevinIntegrator
     α   :: Float64        # Damping coeff
     D   :: Float64        # Stochastic strength
     sys :: SpinSystem
@@ -91,7 +92,7 @@ If sys has type `SpinSystem{0}`, will revert to the `LangevinHeunP` integrator.
 
 Uses the 2nd-order Heun + projection scheme."
 """
-mutable struct LangevinHeunPSUN{N, L} <: Integrator
+mutable struct LangevinHeunPSUN{N} <: LangevinIntegrator
     kT    :: Float64
     α     :: Float64
     sys   :: SpinSystem{N}
@@ -102,28 +103,16 @@ mutable struct LangevinHeunPSUN{N, L} <: Integrator
     _ξ    :: Array{CVec{N}, 4}
     _B    :: Array{Vec3, 4}
     _ℌ    :: Matrix{ComplexF64}  # Just a buffer
-    _Λs   :: Union{Vector{SArray{Tuple{N, N}, ComplexF64, 2, L}}, Nothing}
 end
 
-@generated function LangevinHeunPSUN(sys::SpinSystem{N}, kT::Float64, α::Float64) where N
-    # Use StaticArrays for onsite anisotropies if N is 5 or less. Otherwise use regular arrays.
-    L = N*N
-    if N < 6
-        Λs = :( SArray{Tuple{N,N}, ComplexF64, 2, $L}.(sys.hamiltonian.sun_aniso.Λs) ) 
-    else
-        L = 0
-        Λs = :( nothing ) 
-    end
-
-    return quote
-        LangevinHeunPSUN{N, $L}(
-            kT, α, sys,
-            zero(sys._coherents), zero(sys._coherents),
-            zero(sys._coherents), zero(sys._coherents),
-            zero(sys._coherents), zero(sys._dipoles),
-            zeros(ComplexF64, (N,N)), $Λs
-        )
-    end
+function LangevinHeunPSUN(sys::SpinSystem{N}, kT::Float64, α::Float64) where N
+    LangevinHeunPSUN{N}(
+        kT, α, sys,
+        zero(sys._coherents), zero(sys._coherents),
+        zero(sys._coherents), zero(sys._coherents),
+        zero(sys._coherents), zero(sys._dipoles),
+        zeros(ComplexF64, (N,N))
+    )
 end
 
 # Constructor so SU(N) integrator can be used with identical interface to LL LangevinHeunP integrator
@@ -139,7 +128,7 @@ Implements Generalized Spin Dynamics using the Schrodinger Midpoint method. No
 noise or damping. Only works for SU(N) systems (N != 0). Will revert to SphericalMidpoint
 method if sys has a type of `SpinSystem{0}`.
 """
-mutable struct SchrodingerMidpoint{N, L} <: Integrator
+mutable struct SchrodingerMidpoint{N} <: Integrator
     sys :: SpinSystem{N}
     _ΔZ  :: Array{CVec{N}, 4}
     _ℌZ  :: Array{CVec{N}, 4}
@@ -148,28 +137,16 @@ mutable struct SchrodingerMidpoint{N, L} <: Integrator
     _Z″  :: Array{CVec{N}, 4}
     _B   :: Array{Vec3, 4}
     _ℌ    :: Matrix{ComplexF64}  # Just a buffer
-    _Λs   :: Union{Vector{SArray{Tuple{N, N}, ComplexF64, 2, L}}, Nothing}
 end
 
-@generated function SchrodingerMidpoint(sys::SpinSystem{N}) where N
-    # Use StaticArrays for onsite anisotropies if N is 5 or less. Otherwise use regular arrays.
-    L = N*N
-    if N < 6
-        Λs = :( SArray{Tuple{N,N}, ComplexF64, 2, $L}.(sys.hamiltonian.sun_aniso.Λs) ) 
-    else
-        L = 0
-        Λs = :( nothing ) 
-    end
-
-    return quote
-        SchrodingerMidpoint{N, $L}(
-            sys, 
-            zero(sys._coherents), zero(sys._coherents),
-            zero(sys._coherents), zero(sys._coherents),
-            zero(sys._coherents), zero(sys._dipoles),
-            zeros(ComplexF64, (N,N)), $Λs
-        )
-    end
+function SchrodingerMidpoint(sys::SpinSystem{N}) where N
+    SchrodingerMidpoint{N}(
+        sys, 
+        zero(sys._coherents), zero(sys._coherents),
+        zero(sys._coherents), zero(sys._coherents),
+        zero(sys._coherents), zero(sys._dipoles),
+        zeros(ComplexF64, (N,N))
+    )
 end
 
 function SchrodingerMidpoint(sys::SpinSystem{0})
@@ -293,22 +270,33 @@ end
     (a - ((Z' * a) * Z))  
 end
 
-#= Construct and apply the local Hamiltonian for Landau-Lifshitz (LL) dynamics (no noise) =#
-# function _apply_ℌ_LL!(rhs::Array{CVec{N}, 4}, sys::SpinSystem{N}, B::Array{Vec3, 4}, Z::Array{CVec{N}, 4}, ℌ) where N
-@generated function _apply_ℌ_LL!(rhs::Array{CVec{N}, 4}, B::Array{Vec3, 4}, Z::Array{CVec{N}, 4}, integrator::SchrodingerMidpoint{N, L}) where {N, L}
+
+@generated function _apply_ℌ!(rhs::Array{CVec{N}, 4}, B::Array{Vec3, 4}, Z::Array{CVec{N}, 4}, integrator)  where {N}
+
+    if integrator <: LangevinIntegrator
+        scale_expr = :(site_infos[s].spin_rescaling)
+    else
+        scale_expr = :(1.0)
+    end
+
     if N < 6 
         S = gen_spin_ops(N) .|> SArray{Tuple{N, N}, ComplexF64, 2, N*N}
 
         return quote
-            (; sys, _Λs) = integrator
-            (; hamiltonian, site_infos) = sys
+            (; sys) = integrator
+            (; hamiltonian, site_infos, lattice) = sys
             sites = hamiltonian.sun_aniso.sites
-            latsize = size(B)[1:3]
+            Λs′ = hamiltonian.sun_aniso.Λs
+            sites = hamiltonian.sun_aniso.sites
+            Λs = reinterpret(SArray{Tuple{N, N}, ComplexF64, 2, N*N},
+                             reshape(Λs′, N*N, length(sites))
+            )
 
-            @inbounds for (site, Λ) in zip(sites, _Λs) 
-                @inbounds for cell in CartesianIndices(latsize)
-                    ℌ = Λ - B[cell,site] ⋅ $(S)
-                    rhs[cell, site] = ℌ*Z[cell, site]
+            @inbounds for s in sites 
+                κ = $scale_expr
+                for c in eachcellindex(lattice)
+                    ℌ = κ * (Λs[s] - B[c,s] ⋅ $(S))
+                    rhs[c, s] = ℌ*Z[c, s]
                 end
             end
             nothing
@@ -320,11 +308,15 @@ end
         (; hamiltonian, site_infos, lattice, S) = sys
         aniso = hamiltonian.sun_aniso
         rhs′ = reinterpret(reshape, ComplexF64, rhs) 
+        # Sˣ, Sʸ, Sᶻ = @view(S[:,:,1]), @view(S[:,:,2]), @view(S[:,:,3]) 
+        Sˣ, Sʸ, Sᶻ = S[:,:,1], S[:,:,2], S[:,:,3] # Cheaper to take the allocations than use views.
 
-        @inbounds for (site, Λ) in zip(aniso.sites, aniso.Λs) # There is one Λ per site 
-            @inbounds for cell in CartesianIndices(lattice.size)
-                _ℌ .= Λ - B[cell,site] ⋅ S
-                mul!(@view(rhs′[:, cell, site]), _ℌ, Z[cell, site])
+        @inbounds for s in aniso.sites
+            κ = $scale_expr 
+            Λ = @view(aniso.Λs[:,:,s])
+            for c in eachcellindex(lattice)
+                @. _ℌ = κ * (Λ - (B[c,s][1]*Sˣ + B[c,s][2]*Sʸ + B[c,s][3]*Sᶻ))
+                mul!(@view(rhs′[:, c, s]), _ℌ, Z[c, s])
             end
         end
         nothing
@@ -332,52 +324,13 @@ end
 end
 
 
-@generated function _apply_ℌ_LD!(rhs::Array{CVec{N}, 4}, B::Array{Vec3, 4}, Z::Array{CVec{N}, 4}, integrator::LangevinHeunPSUN{N, L})  where {N, L}
-    if N < 6 
-        S = gen_spin_ops(N) .|> SArray{Tuple{N, N}, ComplexF64, 2, N*N}
-
-        return quote
-            (; sys, _Λs) = integrator
-            (; hamiltonian, site_infos) = sys
-            sites = hamiltonian.sun_aniso.sites
-            latsize = size(B)[1:3]
-
-            @inbounds for (site, Λ) in zip(sites, _Λs) 
-                spin_rescaling = site_infos[site].spin_rescaling
-                @inbounds for cell in CartesianIndices(latsize)
-                    ℌ = spin_rescaling * (Λ - B[cell,site] ⋅ $(S))
-                    rhs[cell, site] = ℌ*Z[cell, site]
-                end
-            end
-            nothing
-        end
-    end
-
-    return quote
-        (; sys, _ℌ) = integrator
-        (; hamiltonian, site_infos, lattice, S) = sys
-        aniso = hamiltonian.sun_aniso
-        rhs′ = reinterpret(reshape, ComplexF64, rhs) 
-
-        @inbounds for (site, Λ) in zip(aniso.sites, aniso.Λs) # There is one Λ per site 
-            spin_rescaling = site_infos[site].spin_rescaling
-            @inbounds for cell in CartesianIndices(lattice.size)
-                _ℌ .= spin_rescaling * (Λ - B[cell,site] ⋅ S)
-                mul!(@view(rhs′[:, cell, site]), _ℌ, Z[cell, site])
-            end
-        end
-        nothing
-    end
-end
-
-
-function _rhs_langevin!(ΔZ::Array{CVec{N}, 4}, Z::Array{CVec{N}, 4}, integrator, Δt::Float64) where N
+function _rhs_langevin!(ΔZ::Array{CVec{N}, 4}, Z::Array{CVec{N}, 4}, integrator::LangevinHeunPSUN, Δt::Float64) where N
     (; kT, α, sys, _ℌZ, _ξ, _B, _ℌ) = integrator
     (; _dipoles) = sys
 
     set_expected_spins!(_dipoles, Z, sys) 
     field!(_B, _dipoles, sys.hamiltonian)
-    _apply_ℌ_LD!(_ℌZ, _B, Z, integrator)
+    _apply_ℌ!(_ℌZ, _B, Z, integrator)
 
     @inbounds for i in eachindex(Z)
         ΔZ′ = -im*√(2*Δt*kT*α)*_ξ[i] - Δt*(im+α)*_ℌZ[i]    
@@ -393,7 +346,7 @@ function _rhs_ll!(ΔZ, Z, integrator, Δt)
 
     set_expected_spins!(_dipoles, Z, sys) # temporarily de-synchs _dipoles and _coherents
     field!(_B, _dipoles, sys.hamiltonian)
-    _apply_ℌ_LL!(_ℌZ, _B, Z, integrator)
+    _apply_ℌ!(_ℌZ, _B, Z, integrator)
 
     @inbounds for i in eachindex(Z)
         ΔZ[i] = - Δt*im*_ℌZ[i]    

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -277,7 +277,7 @@ function _apply_ℌ_LL!(rhs::Array{CVec{N}, 4}, sys::SpinSystem{N}, B::Array{Vec
 
     for (site, Λ) in zip(aniso.sites, aniso.Λs) # There is one Λ per site 
         for cell in CartesianIndices(latsize)
-            @. ℌ = Λ - (B[cell, site][1] * sys.S[1] + B[cell, site][2] * sys.S[2] + B[cell, site][3] * sys.S[3])
+            @. ℌ = Λ - (B[cell, site][1]*sys.S[1] + B[cell, site][2]*sys.S[2] + B[cell, site][3]*sys.S[3])
             mul!(@view(rhs′[:, cell, site]), ℌ, Z[cell, site])
         end
     end
@@ -293,9 +293,9 @@ function _apply_ℌ_LD!(rhs::Array{CVec{N}, 4}, sys::SpinSystem{N}, B::Array{Vec
     for (site, Λ) in zip(aniso.sites, aniso.Λs) # There is one Λ per site 
         spin_rescaling = sys.site_infos[site].spin_rescaling
         for cell in CartesianIndices(latsize)
-            @. ℌ = spin_rescaling * (Λ - (B[cell, site][1] * sys.S[1] +
-                                          B[cell, site][2] * sys.S[2] +
-                                          B[cell, site][3] * sys.S[3]))
+            @. ℌ = spin_rescaling * (Λ - (B[cell,site][1]*sys.S[1] +
+                                          B[cell,site][2]*sys.S[2] +
+                                          B[cell,site][3]*sys.S[3]))
             mul!(@view(rhs′[:, cell, site]), ℌ, Z[cell, site])
         end
     end

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -245,6 +245,15 @@ function gen_spin_ops(N::Int) :: NTuple{3, Matrix{ComplexF64}}
     return Sx, Sy, Sz
 end
 
+function gen_spin_ops_packed(N::Int) :: Array{ComplexF64, 3}
+    Ss = gen_spin_ops(N)
+    S_packed = zeros(ComplexF64, N, N, 3)
+    for i ∈ 1:3
+        S_packed[:,:,i] .= Ss[i]
+    end
+    S_packed
+end
+
 
 """
     SUN_anisotropy(mat, site)

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -252,7 +252,6 @@ end
 Creates an SU(N) anisotropy, specified as an NxN operator, `mat`.
 """
 function SUN_anisotropy(mat, site, label="SUNAniso")
-    # TODO: Basic symmetry / validity checks?
     SUNAnisotropy(mat, site, label)
 end
 
@@ -328,9 +327,9 @@ end
 
 function energy(dipoles::Array{Vec3, 4}, field::ExternalFieldCPU)
     E = 0.0
-    for b in 1:size(dipoles, 1)
-        effB = field.effBs[b]
-        for s in selectdim(dipoles, 1, b)
+    for site in 1:size(dipoles)[end]
+        effB = field.effBs[site]
+        for s in selectdim(dipoles, 4, site)
             E += effB ⋅ s
         end
     end
@@ -339,10 +338,10 @@ end
 
 "Accumulates the negative local Hamiltonian gradient coming from the external field"
 @inline function _accum_neggrad!(B::Array{Vec3, 4}, field::ExternalFieldCPU)
-    for b in 1:size(B, 1)
-        effB = field.effBs[b]
-        for idx in CartesianIndices(size(B)[2:end])
-            B[b, idx] = B[b, idx] + effB
+    for site in 1:size(B)[end]
+        effB = field.effBs[site]
+        for cell in CartesianIndices(size(B)[1:3])
+            B[cell, site] = B[cell, site] + effB
         end
     end
 end

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -327,7 +327,7 @@ end
 
 function energy(dipoles::Array{Vec3, 4}, field::ExternalFieldCPU)
     E = 0.0
-    for site in 1:size(dipoles)[end]
+    @inbounds for site in 1:size(dipoles)[end]
         effB = field.effBs[site]
         for s in selectdim(dipoles, 4, site)
             E += effB ⋅ s
@@ -338,7 +338,7 @@ end
 
 "Accumulates the negative local Hamiltonian gradient coming from the external field"
 @inline function _accum_neggrad!(B::Array{Vec3, 4}, field::ExternalFieldCPU)
-    for site in 1:size(B)[end]
+    @inbounds for site in 1:size(B)[end]
         effB = field.effBs[site]
         for cell in CartesianIndices(size(B)[1:3])
             B[cell, site] = B[cell, site] + effB

--- a/src/Lattice.jl
+++ b/src/Lattice.jl
@@ -93,21 +93,25 @@ lattice_params(lat::Lattice) = lattice_params(lat.lat_vecs)
     return CartesianIndices(Tuple(lat.size))
 end
 
+# Perhaps it's confusing to have the Lattice.size field refer to just the Bravais
+# lattice dimensions (3 numbers), but to have size(lat::Lattice) return dimensions 
+# of the whole thing including sites within each unit cell (4 numbers).
 @inline function Base.size(lat::Lattice)
-    return (nbasis(lat), lat.size...)
+    return (lat.size..., nbasis(lat))
 end
 
 #=== Indexing returns absolute coordinates of lattice points ===#
 
-@inline function Base.getindex(lat::Lattice, b::Int64, brav::CartesianIndex{3})
+@inline function Base.getindex(lat::Lattice, brav::CartesianIndex{3}, b::Int64)
     return muladd(lat.lat_vecs, convert(Vec3, brav), lat.basis_vecs[b])
 end
 
-@inline function Base.getindex(lat::Lattice, b::Int64, brav::NTuple{3, Int64})
+@inline function Base.getindex(lat::Lattice, brav::NTuple{3, Int64}, b::Int64)
     return muladd(lat.lat_vecs, convert(Vec3, brav), lat.basis_vecs[b])
 end
 
-@inline function Base.getindex(lat::Lattice, b::Int64, brav::Vararg{Int64, 3})
+@inline function Base.getindex(lat::Lattice, idx::Vararg{Int64, 4})
+    brav, b = idx[1:3], idx[end]
     return muladd(lat.lat_vecs, convert(Vec3, brav), lat.basis_vecs[b])
 end
 

--- a/src/Metropolis.jl
+++ b/src/Metropolis.jl
@@ -73,7 +73,7 @@ Each single-spin update attempts to completely randomize the spin. One call to
  `sample!` will attempt to flip each spin `nsweeps` times.
 """
 mutable struct MetropolisSampler{N} <: AbstractSampler
-    system     :: SpinSystem{N}
+    sys     :: SpinSystem{N}
     β          :: Float64
     nsweeps    :: Int
     E          :: Float64
@@ -98,7 +98,7 @@ Before constructing, be sure that your `SpinSystem` is initialized so that each
 spin points along its "Ising-like" axis.
 """
 mutable struct IsingSampler{N} <: AbstractSampler
-    system     :: SpinSystem{N}
+    sys     :: SpinSystem{N}
     β          :: Float64
     nsweeps    :: Int
     E          :: Float64
@@ -111,7 +111,7 @@ end
 
 
 mutable struct MeanFieldSampler{N} <: AbstractSampler
-    system     :: SpinSystem{N}
+    sys     :: SpinSystem{N}
     β          :: Float64
     nsweeps    :: Int
     E          :: Float64
@@ -152,11 +152,13 @@ get_temp(sampler::MeanFieldSampler) = 1 / sampler.β
 
 Returns the `SpinSystem` being updated by the `sampler`.
 """
-get_system(sampler::MetropolisSampler) = sampler.system
-get_system(sampler::IsingSampler) = sampler.system
+get_system(sampler::MetropolisSampler) = sampler.sys
+get_system(sampler::MeanFieldSampler) = sampler.sys
+get_system(sampler::IsingSampler) = sampler.sys
 
-Random.rand!(sampler::MetropolisSampler) = rand!(sampler.system)
-Random.rand!(sampler::IsingSampler) = rand!(sampler.system)
+Random.rand!(sampler::MetropolisSampler) = rand!(sampler.sys)
+Random.rand!(sampler::MeanFieldSampler) = rand!(sampler.sys)
+Random.rand!(sampler::IsingSampler) = rand!(sampler.sys)
 
 
 """ The following functions have been added or modified to permit code reuse
@@ -190,19 +192,12 @@ end
 # For mean field sampler. Return to this for optimzation.
 function _local_hamiltonian(sys::SpinSystem{N}, idx) where N
     aniso = sys.hamiltonian.sun_aniso
-    _, i = splitidx(idx)
+    _, site = splitidx(idx)
 
     B = field(sys._dipoles, sys.hamiltonian, idx)
     S = reinterpret(SArray{Tuple{N,N}, ComplexF64, 2, N*N}, reshape(sys.S, N*N, 3)) # Make sure this works!
     ℌ = SMatrix{N,N,ComplexF64,N*N}(-(B[1]*S[1] + B[2]*S[2] + B[3]*S[3]))
-    ℌ += aniso.Λs[:,:,i]
-
-    # This is annoying, suggests modifying SUNAnisotropy type on backend
-    # for (site, Λ) in zip(aniso.sites, aniso.Λs)
-    #     if site == i
-    #         ℌ += Λ
-    #     end
-    # end
+    ℌ += @view(aniso.Λs[:,:,site])
     
     return ℌ
 end
@@ -237,27 +232,27 @@ end
 """
     sample!(sampler)
 
-Samples `sampler.system` to a new state, under the Boltzmann distribution
- as defined by `sampler.system.hamiltonian`.
+Samples `sampler.sys` to a new state, under the Boltzmann distribution
+ as defined by `sampler.sys.hamiltonian`.
 """
 function sample!(sampler::MetropolisSampler{N}) where N
-    sys = sampler.system
+    sys = sampler.sys
     for _ in 1:sampler.nsweeps
-        for idx in CartesianIndices(sampler.system._dipoles)
+        for idx in CartesianIndices(sys._dipoles)
             # Try to rotate this spin to somewhere randomly on the unit sphere
             _, b = splitidx(idx)
             new_spin = _random_spin(sys.rng, Val(N), sys.site_infos[b].spin_rescaling)
-            ΔE = local_energy_change(sampler.system, idx, new_spin)
+            ΔE = local_energy_change(sys, idx, new_spin)
 
             if rand(sys.rng) < exp(-sampler.β * ΔE)
                 new_ket = ket(new_spin)
                 new_dipole = dipole(new_spin, sys, idx)
 
                 sampler.E += ΔE
-                sampler.M += (new_dipole - sampler.system._dipoles[idx])
+                sampler.M += (new_dipole - sys._dipoles[idx])
 
-                sampler.system._dipoles[idx] = new_dipole 
-                sampler.system._coherents[idx] = new_ket
+                sys._dipoles[idx] = new_dipole 
+                sys._coherents[idx] = new_ket
             end
         end
     end
@@ -265,12 +260,12 @@ end
 
 
 function sample!(sampler::IsingSampler{N}) where N
-    sys = sampler.system
+    sys = sampler.sys
     for _ in 1:sampler.nsweeps
         for idx in CartesianIndices(sys._dipoles)
             # Try to completely flip this spin
-            new_spin = _flipped_spin(sampler.system, idx)
-            ΔE = local_energy_change(sampler.system, idx, new_spin)
+            new_spin = _flipped_spin(sys, idx)
+            ΔE = local_energy_change(sys, idx, new_spin)
 
             if rand(sys.rng) < exp(-sampler.β * ΔE)
                 new_ket = ket(new_spin)
@@ -279,8 +274,8 @@ function sample!(sampler::IsingSampler{N}) where N
                 sampler.E += ΔE
                 sampler.M += 2 * new_dipole   # check this is still sensible...
 
-                sampler.system._dipoles[idx] = new_dipole 
-                sampler.system._coherents[idx] = new_ket
+                sys._dipoles[idx] = new_dipole 
+                sys._coherents[idx] = new_ket
             end
         end
     end
@@ -288,11 +283,11 @@ end
 
 
 function sample!(sampler::MeanFieldSampler{N}) where N
-    sys = sampler.system
+    sys = sampler.sys
     for _ in 1:sampler.nsweeps
         for idx in CartesianIndices(sys._dipoles)
-            new_spin = _rand_mf_spin(sampler.system, idx)
-            ΔE = local_energy_change(sampler.system, idx, new_spin)
+            new_spin = _rand_mf_spin(sys, idx)
+            ΔE = local_energy_change(sys, idx, new_spin)
 
             if rand(sys.rng) < exp(-sampler.β * ΔE)
                 new_ket = ket(new_spin)
@@ -301,8 +296,8 @@ function sample!(sampler::MeanFieldSampler{N}) where N
                 sampler.E += ΔE
                 sampler.M += 2 * new_dipole   # assuming 2 is g-factor 
 
-                sampler.system._dipoles[idx] = new_dipole 
-                sampler.system._coherents[idx] = new_ket
+                sys._dipoles[idx] = new_dipole 
+                sys._coherents[idx] = new_ket
             end
         end
     end
@@ -310,12 +305,12 @@ end
 
 @inline running_energy(sampler::MetropolisSampler) = sampler.E
 @inline running_mag(sampler::MetropolisSampler) = sampler.M
-@inline reset_running_energy!(sampler::MetropolisSampler) = (sampler.E = energy(sampler.system); nothing)
-@inline reset_running_mag!(sampler::MetropolisSampler) = (sampler.M = sum(sampler.system._dipoles); nothing)
+@inline reset_running_energy!(sampler::MetropolisSampler) = (sampler.E = energy(sampler.sys); nothing)
+@inline reset_running_mag!(sampler::MetropolisSampler) = (sampler.M = sum(sampler.sys._dipoles); nothing)
 @inline running_energy(sampler::IsingSampler) = sampler.E
 @inline running_mag(sampler::IsingSampler) = sampler.M
-@inline reset_running_energy!(sampler::IsingSampler) = (sampler.E = energy(sampler.system); nothing)
-@inline reset_running_mag!(sampler::IsingSampler) = (sampler.M = sum(sampler.system._dipoles); nothing)
+@inline reset_running_energy!(sampler::IsingSampler) = (sampler.E = energy(sampler.sys); nothing)
+@inline reset_running_mag!(sampler::IsingSampler) = (sampler.M = sum(sampler.sys._dipoles); nothing)
 
 
 """
@@ -389,12 +384,6 @@ function local_energy_change(sys::SpinSystem{N}, idx, newspin) where N
         old_ket = sys._coherents[idx]
         Λ = @view(aniso.Λs[:,:,i])
         ΔE += real(new_ket' * Λ * new_ket) - real(old_ket' * Λ * old_ket)
-        # for (site, Λ) in zip(aniso.sites, aniso.Λs)
-        #     if site == i
-        #         old_ket = sys._coherents[idx]
-        #         ΔE += real(new_ket' * Λ * new_ket) - real(old_ket' * Λ * old_ket)
-        #     end
-        # end
     end
     if !isnothing(ℋ.dipole_int)
         throw("Local energy changes not implemented yet for dipole interactions")

--- a/src/PairInteractions.jl
+++ b/src/PairInteractions.jl
@@ -207,9 +207,10 @@ function _neggrad(dipoles::Array{Vec3}, heisen::HeisenbergCPU, i)
     bondtable = heisen.bondtable
     B = Vec3(0,0,0)
     J = first(bondtable.data)
+    _, site = splitidx(i)
 
     latsize = size(dipoles)[1:3]
-    @inbounds for (bond, _) in sublat_bonds(bondtable, i)
+    @inbounds for (bond, _) in sublat_bonds(bondtable, site)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
         B -= J * dipoles[offsetcell, j]
@@ -236,10 +237,10 @@ end
 function _neggrad(dipoles::Array{Vec3}, diag_coup::DiagonalCouplingCPU, i)
     bondtable = diag_coup.bondtable
     B = Vec3(0,0,0)
-    (i, cell) = splitidx(i)
+    cell, site = splitidx(i)
 
     latsize = size(dipoles)[1:3]
-    @inbounds for (bond, J) ∈ sublat_bonds(bondtable, i)
+    @inbounds for (bond, J) ∈ sublat_bonds(bondtable, site)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
         B -= J .* dipoles[offsetcell, j]
@@ -267,10 +268,10 @@ end
 function _neggrad(dipoles::Array{Vec3}, gen_coup::GeneralCouplingCPU, idx)
     bondtable = gen_coup.bondtable
     B = Vec3(0,0,0)
-    (i, cell) = splitidx(idx)
+    cell, site = splitidx(idx)
 
     latsize = size(dipoles)[1:3]
-    @inbounds for (bond, J) ∈ sublat_bonds(bondtable, i)
+    @inbounds for (bond, J) ∈ sublat_bonds(bondtable, site)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
         B -= J * dipoles[offsetcell, j]

--- a/src/PairInteractions.jl
+++ b/src/PairInteractions.jl
@@ -138,49 +138,49 @@ function convert_quadratic(int::QuadraticInteraction, cryst::Crystal, site_infos
     end
 end
 
-function energy(spins::Array{Vec3}, heisenberg::HeisenbergCPU)
+function energy(dipoles::Array{Vec3}, heisenberg::HeisenbergCPU)
     bondtable = heisenberg.bondtable
     effJ = first(bondtable.data)
     E = 0.0
 
-    latsize = size(spins)[2:end]
+    latsize = size(dipoles)[1:3]
     for (bond, _) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
-            sᵢ = spins[i, cell]
-            sⱼ = spins[j, offset(cell, n, latsize)]
+            sᵢ = dipoles[cell, i]
+            sⱼ = dipoles[offset(cell, n, latsize), j]
             E += sᵢ ⋅ sⱼ
         end
     end
     return effJ * E
 end
 
-function energy(spins::Array{Vec3}, diag_coup::DiagonalCouplingCPU)
+function energy(dipoles::Array{Vec3}, diag_coup::DiagonalCouplingCPU)
     bondtable = diag_coup.bondtable
     E = 0.0
 
-    latsize = size(spins)[2:end]
+    latsize = size(dipoles)[1:3]
     for (bond, J) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
-            sᵢ = spins[i, cell]
-            sⱼ = spins[j, offset(cell, n, latsize)]
+            sᵢ = dipoles[cell, i]
+            sⱼ = dipoles[offset(cell, n, latsize), j]
             E += (J .* sᵢ) ⋅ sⱼ
         end
     end
     return E
 end
 
-function energy(spins::Array{Vec3}, gen_coup::GeneralCouplingCPU)
+function energy(dipoles::Array{Vec3}, gen_coup::GeneralCouplingCPU)
     bondtable = gen_coup.bondtable
     E = 0.0
 
-    latsize = size(spins)[2:end]
+    latsize = size(dipoles)[1:3]
     for (bond, J) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
-            sᵢ = spins[i, cell]
-            sⱼ = spins[j, offset(cell, n, latsize)]
+            sᵢ = dipoles[cell, i]
+            sⱼ = dipoles[offset(cell, n, latsize), j]
             E += dot(sᵢ, J, sⱼ)
         end
     end
@@ -188,17 +188,17 @@ function energy(spins::Array{Vec3}, gen_coup::GeneralCouplingCPU)
 end
 
 "Accumulates the local -∇ℋ coming from Heisenberg couplings into `B`"
-function _accum_neggrad!(B::Array{Vec3}, spins::Array{Vec3}, heisen::HeisenbergCPU)
+function _accum_neggrad!(B::Array{Vec3}, dipoles::Array{Vec3}, heisen::HeisenbergCPU)
     bondtable = heisen.bondtable
     effJ = first(bondtable.data)
 
-    latsize = size(spins)[2:end]
+    latsize = size(dipoles)[1:3]
     for (bond, _) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             offsetcell = offset(cell, n, latsize)
-            B[i, cell] = B[i, cell] - effJ * spins[j, offsetcell]
-            B[j, offsetcell] = B[j, offsetcell] - effJ * spins[i, cell]
+            B[cell, i] = B[cell, i] - effJ * dipoles[offsetcell, j]
+            B[offsetcell, j] = B[offsetcell, j] - effJ * dipoles[cell, i]
         end
     end
 end
@@ -208,27 +208,27 @@ function _neggrad(dipoles::Array{Vec3}, heisen::HeisenbergCPU, i)
     B = Vec3(0,0,0)
     J = first(bondtable.data)
 
-    latsize = size(dipoles)[2:end]
-    for (bond, _) ∈ sublat_bonds(bondtable, i)
+    latsize = size(dipoles)[1:3]
+    for (bond, _) in sublat_bonds(bondtable, i)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
-        B -= J * dipoles[j, offsetcell]
+        B -= J * dipoles[offsetcell, j]
     end
 
     return B
 end
 
 "Accumulates the local -∇ℋ coming from diagonal couplings into `B`"
-function _accum_neggrad!(B::Array{Vec3}, spins::Array{Vec3}, diag_coup::DiagonalCouplingCPU)
+function _accum_neggrad!(B::Array{Vec3}, dipoles::Array{Vec3}, diag_coup::DiagonalCouplingCPU)
     bondtable = diag_coup.bondtable
 
-    latsize = size(spins)[2:end]
+    latsize = size(dipoles)[1:3]
     for (bond, J) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             offsetcell = offset(cell, n, latsize)
-            B[i, cell] = B[i, cell] - J .* spins[j, offsetcell]
-            B[j, offsetcell] = B[j, offsetcell] - J .* spins[i, cell]
+            B[cell, i] = B[cell, i] - J .* dipoles[offsetcell, j]
+            B[offsetcell, j] = B[offsetcell, j] - J .* dipoles[cell, i]
         end
     end
 end
@@ -238,27 +238,27 @@ function _neggrad(dipoles::Array{Vec3}, diag_coup::DiagonalCouplingCPU, i)
     B = Vec3(0,0,0)
     (i, cell) = splitidx(i)
 
-    latsize = size(dipoles)[2:end]
+    latsize = size(dipoles)[1:3]
     for (bond, J) ∈ sublat_bonds(bondtable, i)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
-        B -= J .* dipoles[j, offsetcell]
+        B -= J .* dipoles[offsetcell, j]
     end
 
     return B
 end
 
 "Accumulates the local -∇ℋ coming from general couplings into `B`"
-function _accum_neggrad!(B::Array{Vec3}, spins::Array{Vec3}, gen_coup::GeneralCouplingCPU)
+function _accum_neggrad!(B::Array{Vec3}, dipoles::Array{Vec3}, gen_coup::GeneralCouplingCPU)
     bondtable = gen_coup.bondtable
 
-    latsize = size(spins)[2:end]
+    latsize = size(dipoles)[1:3]
     for (bond, J) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             offsetcell = offset(cell, n, latsize)
-            B[i, cell] = B[i, cell] - J * spins[j, offsetcell]
-            B[j, offsetcell] = B[j, offsetcell] - J * spins[i, cell]
+            B[cell, i] = B[cell, i] - J * dipoles[offsetcell, j]
+            B[offsetcell, j] = B[offsetcell, j] - J * dipoles[cell, i]
         end
     end
 end
@@ -269,11 +269,11 @@ function _neggrad(dipoles::Array{Vec3}, gen_coup::GeneralCouplingCPU, idx)
     B = Vec3(0,0,0)
     (i, cell) = splitidx(idx)
 
-    latsize = size(dipoles)[2:end]
+    latsize = size(dipoles)[1:3]
     for (bond, J) ∈ sublat_bonds(bondtable, i)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
-        B -= J * dipoles[j, offsetcell]
+        B -= J * dipoles[offsetcell, j]
     end
 
     return B

--- a/src/PairInteractions.jl
+++ b/src/PairInteractions.jl
@@ -144,7 +144,7 @@ function energy(dipoles::Array{Vec3}, heisenberg::HeisenbergCPU)
     E = 0.0
 
     latsize = size(dipoles)[1:3]
-    for (bond, _) in culled_bonds(bondtable)
+    @inbounds for (bond, _) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             sᵢ = dipoles[cell, i]
@@ -160,7 +160,7 @@ function energy(dipoles::Array{Vec3}, diag_coup::DiagonalCouplingCPU)
     E = 0.0
 
     latsize = size(dipoles)[1:3]
-    for (bond, J) in culled_bonds(bondtable)
+    @inbounds for (bond, J) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             sᵢ = dipoles[cell, i]
@@ -176,7 +176,7 @@ function energy(dipoles::Array{Vec3}, gen_coup::GeneralCouplingCPU)
     E = 0.0
 
     latsize = size(dipoles)[1:3]
-    for (bond, J) in culled_bonds(bondtable)
+    @inbounds for (bond, J) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             sᵢ = dipoles[cell, i]
@@ -193,7 +193,7 @@ function _accum_neggrad!(B::Array{Vec3}, dipoles::Array{Vec3}, heisen::Heisenber
     effJ = first(bondtable.data)
 
     latsize = size(dipoles)[1:3]
-    for (bond, _) in culled_bonds(bondtable)
+    @inbounds for (bond, _) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             offsetcell = offset(cell, n, latsize)
@@ -209,7 +209,7 @@ function _neggrad(dipoles::Array{Vec3}, heisen::HeisenbergCPU, i)
     J = first(bondtable.data)
 
     latsize = size(dipoles)[1:3]
-    for (bond, _) in sublat_bonds(bondtable, i)
+    @inbounds for (bond, _) in sublat_bonds(bondtable, i)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
         B -= J * dipoles[offsetcell, j]
@@ -223,7 +223,7 @@ function _accum_neggrad!(B::Array{Vec3}, dipoles::Array{Vec3}, diag_coup::Diagon
     bondtable = diag_coup.bondtable
 
     latsize = size(dipoles)[1:3]
-    for (bond, J) in culled_bonds(bondtable)
+    @inbounds for (bond, J) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             offsetcell = offset(cell, n, latsize)
@@ -239,7 +239,7 @@ function _neggrad(dipoles::Array{Vec3}, diag_coup::DiagonalCouplingCPU, i)
     (i, cell) = splitidx(i)
 
     latsize = size(dipoles)[1:3]
-    for (bond, J) ∈ sublat_bonds(bondtable, i)
+    @inbounds for (bond, J) ∈ sublat_bonds(bondtable, i)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
         B -= J .* dipoles[offsetcell, j]
@@ -253,7 +253,7 @@ function _accum_neggrad!(B::Array{Vec3}, dipoles::Array{Vec3}, gen_coup::General
     bondtable = gen_coup.bondtable
 
     latsize = size(dipoles)[1:3]
-    for (bond, J) in culled_bonds(bondtable)
+    @inbounds for (bond, J) in culled_bonds(bondtable)
         @unpack i, j, n = bond
         for cell in CartesianIndices(latsize)
             offsetcell = offset(cell, n, latsize)
@@ -270,7 +270,7 @@ function _neggrad(dipoles::Array{Vec3}, gen_coup::GeneralCouplingCPU, idx)
     (i, cell) = splitidx(idx)
 
     latsize = size(dipoles)[1:3]
-    for (bond, J) ∈ sublat_bonds(bondtable, i)
+    @inbounds for (bond, J) ∈ sublat_bonds(bondtable, i)
         (; j, n) = bond
         offsetcell = offset(cell, n, latsize)
         B -= J * dipoles[offsetcell, j]

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -74,7 +74,7 @@ function plot_bonds(lattice::Lattice, ints::Vector{<:AbstractInteractionCPU};
     toggles = Vector{GLMakie.Toggle}()
     labels = Vector{GLMakie.Label}()
     cent_cell = CartesianIndex(div.(lattice.size .+ 1, 2)...)
-    cent_pt = lattice[basis_idx, cent_cell]
+    cent_pt = lattice[cent_cell, basis_idx]
     for (n, int) in enumerate(sorted_ints)
         if !isa(int, AbstractPairIntCPU)
             continue
@@ -83,7 +83,7 @@ function plot_bonds(lattice::Lattice, ints::Vector{<:AbstractInteractionCPU};
         pts = Vector{GLMakie.Point3f0}()
         for (bond, _) in sublat_bonds(int.bondtable, basis_idx)
             new_cell = offset(cent_cell, bond.n, lattice.size)
-            bond_pt = lattice[bond.j, new_cell]
+            bond_pt = lattice[new_cell, bond.j]
             push!(pts, GLMakie.Point3f0(cent_pt))
             push!(pts, GLMakie.Point3f0(bond_pt))
         end
@@ -203,19 +203,19 @@ function plot_cells!(ax, lattice::Lattice; color=:grey, linewidth=1.0, kwargs...
     nx, ny, nz = lattice.size
     for j in 1:ny
         for k in 1:nz
-            bot_pt, top_pt = lattice[1, 1, j, k], lattice[1, nx, j, k]
+            bot_pt, top_pt = lattice[1, j, k, 1], lattice[nx, j, k, 1]
             push!(pts, GLMakie.Point3f0(bot_pt))
             push!(pts, GLMakie.Point3f0(top_pt))
         end
         for i in 1:nx
-            left_pt, right_pt = lattice[1, i, j, 1], lattice[1, i, j, nz]
+            left_pt, right_pt = lattice[i, j, 1, 1], lattice[i, j, nz, 1]
             push!(pts, GLMakie.Point3f0(left_pt))
             push!(pts, GLMakie.Point3f0(right_pt))
         end
     end
     for k in 1:nz
         for i in 1:nx
-            left_pt, right_pt = lattice[1, i, 1, k], lattice[1, i, ny, k]
+            left_pt, right_pt = lattice[i, 1, k, 1], lattice[i, ny, k, 1]
             push!(pts, GLMakie.Point3f0(left_pt))
             push!(pts, GLMakie.Point3f0(right_pt))
         end

--- a/src/ReplicaExchangeMC.jl
+++ b/src/ReplicaExchangeMC.jl
@@ -92,17 +92,17 @@ function replica_exchange!(replica::Replica)
     S_curr = running_energy(replica.sampler) / get_temp(replica.sampler)
 
     # Backup current configuration
-    backup_spins = deepcopy(replica.sampler.system._dipoles)
+    backup_spins = deepcopy(replica.sampler.sys._dipoles)
 
     # Swap trial configuration with partner
     MPI.Sendrecv!(
                            backup_spins, rex_rank, 1,
-        replica.sampler.system._dipoles, rex_rank, 1,
+        replica.sampler.sys._dipoles, rex_rank, 1,
         MPI.COMM_WORLD
     )
 
     # This rank's action with partner's configuration
-    S_exch = energy(replica.sampler.system) / get_temp(replica.sampler)
+    S_exch = energy(replica.sampler.sys) / get_temp(replica.sampler)
 
     # change in action due to exchange
     ΔS = S_curr - S_exch
@@ -127,7 +127,7 @@ function replica_exchange!(replica::Replica)
 
     # Reject exchange
     if !rex_accept
-        replica.sampler.system._dipoles .= backup_spins
+        replica.sampler.sys._dipoles .= backup_spins
         return false
     end
 
@@ -651,7 +651,7 @@ function run_REMC!(
     C  = 0.0
     X  = 0.0
 
-    system_size = length(replica.sampler.system)
+    system_size = length(replica.sampler.sys)
     E_hist = BinnedArray{Float64, Int64}(bin_size=bin_size)
     m_hist = BinnedArray{Float64, Int64}(bin_size=1.0)
     rex_accepts = zeros(Int64, 2)
@@ -709,7 +709,7 @@ function run_REMC!(
         end
 
         if (encode_ising_interval > 0) && (mcs % encode_ising_interval == 0)
-            encode_ising_to_file(replica.sampler.system, ising_output)
+            encode_ising_to_file(replica.sampler.sys, ising_output)
         end
 
         # Measurements
@@ -727,7 +727,7 @@ function run_REMC!(
                 # Overwrite Emin coordinates in saved file
                 if replica.rank in print_xyz_ranks
                     xyz_output = open(@sprintf("Emin_T=%f.xyz", T), "w")
-                    xyz_to_file(replica.sampler.system, xyz_output)
+                    xyz_to_file(replica.sampler.sys, xyz_output)
                     close(xyz_output)
                 end
             end

--- a/src/Systems.jl
+++ b/src/Systems.jl
@@ -10,7 +10,7 @@ struct SpinSystem{N}
     _dipoles    :: Array{Vec3, 4}                   # Holds dipole moments: Axes are [Basis, CellA, CellB, CellC]
     _coherents  :: Array{SVector{N, ComplexF64}, 4} # Coherent states
     site_infos  :: Vector{SiteInfo}                 # Characterization of each basis site
-    S           :: NTuple{3, Matrix{ComplexF64}}
+    S           :: Array{ComplexF64, 3}    
     rng         :: Random.AbstractRNG
 end
 
@@ -155,7 +155,7 @@ function SpinSystem(crystal::Crystal, ints::Vector{<:AbstractInteraction}, latsi
 
     (all_site_infos, N) = _propagate_site_info(crystal, site_infos)
     ℋ_CPU = HamiltonianCPU(ints, crystal, latsize, all_site_infos; μB, μ0)
-    S = gen_spin_ops(N)
+    S = gen_spin_ops_packed(N)
 
     # Initialize sites to all spins along +z
     sys_size = (lattice.size..., nbasis(lattice))

--- a/src/Systems.jl
+++ b/src/Systems.jl
@@ -85,24 +85,17 @@ end
 end
 
 
-function set_expected_spins!(sys::SpinSystem)
-    (; _dipoles, _coherents) = sys
-    for b in 1:size(_dipoles, 1)
-        spin_rescaling = sys.site_infos[b].spin_rescaling
-        for i in CartesianIndices(size(_dipoles)[2:end])
-            _dipoles[b, i] = spin_rescaling * expected_spin(_coherents[b, i])
+function set_expected_spins!(dipoles::Array{Vec3, 4}, coherents::Array{CVec{N}, 4}, sys::SpinSystem) where N
+    (a, b, c, num_sites)= size(dipoles) 
+    for l in 1:num_sites
+        spin_rescaling = sys.site_infos[l].spin_rescaling
+        for k ∈ 1:c, j ∈ 1:b, i ∈ 1:a
+            dipoles[i,j,k,l] = spin_rescaling * expected_spin(coherents[i,j,k,l])
         end
     end
 end
 
-function set_expected_spins!(dipoles::Array{Vec3, 4}, coherents::Array{CVec{N}, 4}, sys::SpinSystem) where N
-    for b in 1:size(dipoles, 1)
-        spin_rescaling = sys.site_infos[b].spin_rescaling
-        for i in CartesianIndices(size(dipoles)[2:end])
-            dipoles[b, i] = spin_rescaling * expected_spin(coherents[b, i])
-        end
-    end
-end
+set_expected_spins!(sys::SpinSystem) = set_expected_spins!(sys._dipoles, sys._coherents, sys)
 
 
 """
@@ -165,7 +158,7 @@ function SpinSystem(crystal::Crystal, ints::Vector{<:AbstractInteraction}, latsi
     S = gen_spin_ops(N)
 
     # Initialize sites to all spins along +z
-    sys_size = (nbasis(lattice), lattice.size...)
+    sys_size = (lattice.size..., nbasis(lattice))
     up = SA[0.0, 0.0, 1.0]
     dipoles = fill(up, sys_size)
     coherents = fill(_get_coherent_from_dipole(up, Val(N)), sys_size)
@@ -181,7 +174,7 @@ function Base.show(io::IO, ::MIME"text/plain", sys::SpinSystem{N}) where {N}
     sys_type = N > 0 ? "SU($N)" : "Dipolar"
     printstyled(io, "Spin System [$sys_type]\n"; bold=true, color=:underline)
     sz = size(sys)
-    println(io, "Basis $(sz[1]), Lattice dimensions $(sz[2:end])")
+    println(io, "Basis $(sz[end]), Lattice dimensions $(sz[1:3])")
 end
 
 """
@@ -198,12 +191,13 @@ function Random.rand!(sys::SpinSystem{N}) where N
     set_expected_spins!(sys)
     nothing
 end
+
 function Random.rand!(sys::SpinSystem{0})  
     dip_view = DipoleView(sys)
     dip_view .= randn(sys.rng, Vec3, size(dip_view))
     @. dip_view /= norm(dip_view)
     for b ∈ 1:nbasis(sys)
-        dip_view[b,:,:,:] .*= sys.site_infos[b].spin_rescaling
+        dip_view[:,:,:,b] .*= sys.site_infos[b].spin_rescaling
     end
     nothing
 end
@@ -220,9 +214,9 @@ flip corresponds to sign reversal, ``𝐒_i → -𝐒_i``. In the general case
 rotation about the ``y``-axis by π/2.
 """
 function randflips!(sys::SpinSystem{N}) where N
-    Z, Sy = sys._coherents, sys.S[2]
+    Z = sys._coherents
     for i in eachindex(Z)
-        rand((true, false)) && (Z[i] = flip_ket(Z[i], Sy))
+        rand((true, false)) && (Z[i] = flip_ket(Z[i]))
     end
     set_expected_spins!(sys)
 end
@@ -230,12 +224,13 @@ function randflips!(sys::SpinSystem{0})
     dip_view = DipoleView(sys)
     dip_view .*= rand(sys.rng, (-1, 1), size(dip_view))
 end
-#= On my computer this takes about 50 μs, whereas the regular randflips! takes
-about 2 μs. I assume most of the cost is matrix exponentiation. TODO: Use a
-generated function to cache the matrix exponentiation for each N.
-=#
-@inline function flip_ket(Z::CVec{N}, Sy::Matrix{ComplexF64}) where N
-    exp(-im*π*Sy)*conj(Z)
+
+@generated function flip_ket(Z::CVec{N}) where N
+    (_, Sʸ, _) = gen_spin_ops(N)
+    op = SMatrix{N, N, ComplexF64, N*N}(exp(-im*π*Sʸ))
+    return quote
+        $op * conj(Z)
+    end
 end
 
 

--- a/src/Systems.jl
+++ b/src/Systems.jl
@@ -86,11 +86,11 @@ end
 
 
 function set_expected_spins!(dipoles::Array{Vec3, 4}, coherents::Array{CVec{N}, 4}, sys::SpinSystem) where N
-    (a, b, c, num_sites)= size(dipoles) 
-    for l in 1:num_sites
-        spin_rescaling = sys.site_infos[l].spin_rescaling
-        for k ∈ 1:c, j ∈ 1:b, i ∈ 1:a
-            dipoles[i,j,k,l] = spin_rescaling * expected_spin(coherents[i,j,k,l])
+    num_sites= size(dipoles)[end]
+    for site in 1:num_sites
+        spin_rescaling = sys.site_infos[site].spin_rescaling
+        for cell in CartesianIndices(size(dipoles)[1:3]) 
+            dipoles[cell,site] = spin_rescaling * expected_spin(coherents[cell,site])
         end
     end
 end

--- a/src/Util.jl
+++ b/src/Util.jl
@@ -6,11 +6,11 @@ end
     CartesianIndex(mod1.(Tuple(i), Tuple(m)))
 end
 @inline function offset(i::CartesianIndex{D}, n::SVector{D,Int}, m) :: CartesianIndex{D} where {D}
-    CartesianIndex(Tuple(mod1.(Tuple(i) .+ n, Tuple(m))))
+    CartesianIndex( Tuple(mod1.(Tuple(i) .+ n, Tuple(m))) )
 end
 "Splits a CartesianIndex into its first index, and the rest"
 @inline function splitidx(i::CartesianIndex{D}) where {D}
-    return (i[1], CartesianIndex(Tuple(i)[2:end]))
+    return (CartesianIndex(Tuple(i)[1:3]), i[4])
 end
 
 # Taken from:
@@ -36,7 +36,7 @@ end
 "Reinterprets an array of Mat3 to an equivalent array of Float64"
 @inline function _reinterpret_dipole_tensor(A::OffsetArray{Mat3}) :: Array{Float64}
     Ar = reinterpret(reshape, Float64, parent(A))
-    return reshape(Ar, 3, 3, size(A)...)
+    return reshape(Ar, 3, 3, size(A)...)    # make sure this doesn't mess up indexing
 end
 
 "Generalize dot product so works on vector of operators"

--- a/src/Util.jl
+++ b/src/Util.jl
@@ -44,6 +44,10 @@ function LinearAlgebra.dot(a::Vec3, b::NTuple{3, Matrix{ComplexF64}}) where T
     a[1]*b[1] + a[2]*b[2] + a[3]*b[3]
 end
 
+function LinearAlgebra.dot(a::Vec3, b::NTuple{3, SArray{Tuple{N,N}, ComplexF64, 2, L}}) where {N, L}
+    a[1]*b[1] + a[2]*b[2] + a[3]*b[3]
+end
+
 "Sparse tensor type for quartic anisotropies. (Could be used for quadratic as well.)"
 struct SparseTensor{R,N}
     indices :: NTuple{N, NTuple{R, Int64}}    

--- a/test/test_ewald.jl
+++ b/test/test_ewald.jl
@@ -8,7 +8,7 @@ function test_ewald_NaCl()
     latsize = [2, 2, 2]
     lattice = Sunny.Lattice(lat_vecs, b_vecs, latsize)
     sys = ChargeSystem(lattice)
-    sys.charges .= reshape([1, -1, -1, 1, -1, 1, 1, -1], (1, 2, 2, 2))
+    sys.charges .= reshape([1, -1, -1, 1, -1, 1, 1, -1], (2, 2, 2, 1))
 
     ewald_result = Sunny.ewald_sum_monopole(lattice, sys.charges, extent=30)
     
@@ -27,9 +27,10 @@ function test_ewald_CsCl()
     latsize = [1, 1, 1]
     lattice = Sunny.Lattice(lat_vecs, b_vecs, latsize)
     sys = ChargeSystem(lattice)
-    sys.charges .= reshape([1, -1], (2, 1, 1, 1))
+    sys.charges .= reshape([1, -1], (1, 1, 1, 2))
 
     ewald_result = Sunny.ewald_sum_monopole(lattice, sys.charges, extent=30)
+    println(size(ewald_result))
     
     # Madelung constants are reported relative to the
     #  nearest-neighbor distance in the crystal

--- a/test/test_ewald.jl
+++ b/test/test_ewald.jl
@@ -30,7 +30,6 @@ function test_ewald_CsCl()
     sys.charges .= reshape([1, -1], (1, 1, 1, 2))
 
     ewald_result = Sunny.ewald_sum_monopole(lattice, sys.charges, extent=30)
-    println(size(ewald_result))
     
     # Madelung constants are reported relative to the
     #  nearest-neighbor distance in the crystal
@@ -51,7 +50,7 @@ function test_ewald_ZnS()
     latsize = [1, 1, 1]
     lattice = Sunny.Lattice(lat_vecs, b_vecs, latsize)
     sys = ChargeSystem(lattice)
-    sys.charges .= reshape([1, -1], (2, 1, 1, 1))
+    sys.charges .= reshape([1, -1], (1, 1, 1, 2))
 
     ewald_result = Sunny.ewald_sum_monopole(lattice, sys.charges, extent=30)
     
@@ -84,7 +83,7 @@ function test_ewald_ZnSB4()
     latsize = [1, 1, 1]
     lattice = Sunny.Lattice(lat_vecs, b_vecs, latsize)
     sys = ChargeSystem(lattice)
-    sys.charges .= reshape([1, 1, -1, -1], (4, 1, 1, 1))
+    sys.charges .= reshape([1, 1, -1, -1], (1, 1, 1, 4))
 
     ewald_result = Sunny.ewald_sum_monopole(lattice, sys.charges, extent=30)
     
@@ -119,7 +118,7 @@ function _approx_dip_as_mono(sys::SpinSystem; ϵ::Float64=0.1) :: ChargeSystem
     frac_transform = inv(new_lat_vecs)
 
     new_nbasis = 2 * prod(size(dipoles))
-    new_sites = zeros(new_nbasis, 1, 1, 1)
+    new_sites = zeros(1, 1, 1, new_nbasis)
     new_basis = empty(lattice.basis_vecs)
     sizehint!(new_basis, new_nbasis)
 
@@ -133,8 +132,8 @@ function _approx_dip_as_mono(sys::SpinSystem; ϵ::Float64=0.1) :: ChargeSystem
         push!(new_basis, frac_transform * (r - ϵ * p))
 
         # Set these charges to ±1/2ϵ
-        new_sites[ib, 1, 1, 1]   =  1 / (2ϵ)
-        new_sites[ib+1, 1, 1, 1] = -1 / (2ϵ)
+        new_sites[1, 1, 1, ib]   =  1 / (2ϵ)
+        new_sites[1, 1, 1, ib+1] = -1 / (2ϵ)
 
         ib += 2
     end

--- a/test/test_fourier.jl
+++ b/test/test_fourier.jl
@@ -12,7 +12,7 @@ function test_energy_consistency(crystal, latsize)
     dip_fourier = Sunny.DipoleFourierCPU(dipdip, crystal, latsize, sys.site_infos; μB, μ0)
 
     scales = [μB*info.spin_rescaling*info.g for info in sys.site_infos]
-    moments = reshape(scales, nbasis(sys), 1, 1, 1) .* sys._dipoles
+    moments = reshape(scales, 1, 1, 1, nbasis(sys)) .* sys._dipoles
     direct_energy = (μ0/4π) * Sunny.ewald_sum_dipole(sys.lattice, moments; extent=5, η=0.5)
     real_energy = Sunny.energy(sys._dipoles, dip_real)
     fourier_energy = Sunny.energy(sys._dipoles, dip_fourier)

--- a/test/test_langevin.jl
+++ b/test/test_langevin.jl
@@ -65,7 +65,7 @@ end
 
 function calc_mean_energy(integrator, Δt, dur)
     sys = integrator.sys
-    L = size(sys._dipoles)[2]
+    L = size(sys._dipoles)[1]
     numsteps = round(Int, dur/Δt)
     Es = zeros(numsteps)
     for i in 1:numsteps


### PR DESCRIPTION
PR contains the following changes:
- The first three indices (of a lattice, `_dipoles`, etc.) now refer to the unit cell. The fourth index specifies the site within the cell.
- SU(_N_) integrators now use StaticArrays when _N_ < 6. 
- Various other minor optimizations. 

@mswwilson Could you try running something that uses `WangLandau.jl` and `ReplicaExchangeMC.jl`? I don't think they are tested in the test suite. Note that I changed the name of the `SpinSystem` in the samplers from `system` to `sys` for consistency with the integrators. I updated those to files to account for this, but they should be tested. It would also be good to make sure the new indexing didn't mess anything up with your code.