### PR TITLE
Sf ff revisions

### DIFF
--- a/examples/reproduce_testcases.jl
+++ b/examples/reproduce_testcases.jl
@@ -19,9 +19,7 @@ function test_diamond_heisenberg_sf()
     ]
     dims = (8, 8, 8)
     spin_rescaling = 3/2
-    ff_elem = "Fe2"
-    # ff_elem = nothing 
-    sys = SpinSystem(crystal, interactions, dims, [SiteInfo(1; spin_rescaling, ff_elem, ff_lande=5/2)])
+    sys = SpinSystem(crystal, interactions, dims, [SiteInfo(1; spin_rescaling)])
     rand!(sys)
 
     Δt = 0.02 / (spin_rescaling^2 * J)     # Units of 1/meV
@@ -36,7 +34,7 @@ function test_diamond_heisenberg_sf()
                            # from trajectories as much as possible while staying above this limit. 
     num_omegas = 200       # Total number of frequencies we'd like to resolve
     dynsf = dynamic_structure_factor(
-        sys, sampler; nsamples=2, dt = dynΔt, omega_max, num_omegas,
+        sys, sampler; nsamples=10, dt = dynΔt, omega_max, num_omegas,
         bz_size=(1,1,2), thermalize=10, verbose=true,
         reduce_basis=true, dipole_factor=true,
     )

--- a/examples/reproduce_testcases.jl
+++ b/examples/reproduce_testcases.jl
@@ -19,7 +19,9 @@ function test_diamond_heisenberg_sf()
     ]
     dims = (8, 8, 8)
     spin_rescaling = 3/2
-    sys = SpinSystem(crystal, interactions, dims, [SiteInfo(1; spin_rescaling)])
+    ff_elem = "Fe2"
+    # ff_elem = nothing 
+    sys = SpinSystem(crystal, interactions, dims, [SiteInfo(1; spin_rescaling, ff_elem, ff_lande=5/2)])
     rand!(sys)
 
     Δt = 0.02 / (spin_rescaling^2 * J)     # Units of 1/meV
@@ -34,7 +36,7 @@ function test_diamond_heisenberg_sf()
                            # from trajectories as much as possible while staying above this limit. 
     num_omegas = 200       # Total number of frequencies we'd like to resolve
     dynsf = dynamic_structure_factor(
-        sys, sampler; nsamples=10, dt = dynΔt, omega_max, num_omegas,
+        sys, sampler; nsamples=2, dt = dynΔt, omega_max, num_omegas,
         bz_size=(1,1,2), thermalize=10, verbose=true,
         reduce_basis=true, dipole_factor=true,
     )

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -87,16 +87,21 @@ function SphericalMidpoint(sys::SpinSystem{N}; atol=1e-12) where N
     SchrodingerMidpoint(sys)
 end
 
+@doc raw"""
+    ImplicitMidpoint(sys::SpinSystem{N}; atol=1e-12) where N
 
+Returns an implicit midpoint integrator for any type of `SpinSystem{N}`. If
+`N=0`, it returns a `SphericalMidpoint` integrator, otherwise a `SchrodingerMidpoint`
+integrator. Both integrators are sympletic, i.e. they guarantee that the error
+in the system's energy is bounded.
+
+For dissipative dynamics in a themal bath, use the `LangevinHeunP` integrator.
 """
-    LangevinHeunPSUN(sys::SpinSystem{N}, kT::Float64, α::Float64)
+function ImplicitMidpoint(sys::SpinSystem{N}; atol=1e-12) where N
+    N == 0 ? SphericalMidpoint(sys; atol) : SchrodingerMidpoint(sys)
+end
 
-Implements Langevin dynamics on `sys` targeting a temperature `kT`, with a
-damping coefficient `α`. This integrator is only for Generalized Spin Dynamics.
-If sys has type `SpinSystem{0}`, will revert to the `LangevinHeunP` integrator.
 
-Uses the 2nd-order Heun + projection scheme."
-"""
 mutable struct LangevinHeunPSUN{N} <: LangevinIntegrator
     kT    :: Float64
     α     :: Float64
@@ -110,6 +115,15 @@ mutable struct LangevinHeunPSUN{N} <: LangevinIntegrator
     _ℌ    :: Matrix{ComplexF64}  # Just a buffer
 end
 
+"""
+    LangevinHeunPSUN(sys::SpinSystem{N}, kT::Float64, α::Float64)
+
+Implements Langevin dynamics on `sys` targeting a temperature `kT`, with a
+damping coefficient `α`. This integrator is only for Generalized Spin Dynamics.
+If sys has type `SpinSystem{0}`, will revert to the `LangevinHeunP` integrator.
+
+Uses the 2nd-order Heun + projection scheme."
+"""
 function LangevinHeunPSUN(sys::SpinSystem{N}, kT::Float64, α::Float64) where N
     LangevinHeunPSUN{N}(
         kT, α, sys,

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -83,22 +83,24 @@ mutable struct SphericalMidpoint <: Integrator
 end
 
 function SphericalMidpoint(sys::SpinSystem{N}; atol=1e-12) where N
-    @warn "SphericalMidpoint integrator is not available for SU(N) systems. Using SchrodingerMidpoint integrator."
-    SchrodingerMidpoint(sys)
+    @error "SphericalMidpoint integrator is not available for SU(N) systems. Use ImplicitMidpoint integrator."
+    nothing
 end
 
 @doc raw"""
-    ImplicitMidpoint(sys::SpinSystem{N}; atol=1e-12) where N
+    ImplicitMidpoint(sys::SpinSystem{N}) where N
 
-Returns an implicit midpoint integrator for any type of `SpinSystem{N}`. If
-`N=0`, it returns a `SphericalMidpoint` integrator, otherwise a `SchrodingerMidpoint`
-integrator. Both integrators are sympletic, i.e. they guarantee that the error
-in the system's energy is bounded.
+Returns an implicit midpoint integrator a `SpinSystem{N}`, where N may be any integer. If
+`N=0` (traditional Landua-Lifshitz), it returns a `SphericalMidpoint` integrator,
+otherwise a `SchrodingerMidpoint` integrator. Both integrators are sympletic, i.e. they
+guarantee that energy error is bounded.
 
 For dissipative dynamics in a themal bath, use the `LangevinHeunP` integrator.
 """
-function ImplicitMidpoint(sys::SpinSystem{N}; atol=1e-12) where N
-    N == 0 ? SphericalMidpoint(sys; atol) : SchrodingerMidpoint(sys)
+# Not exposing atol option here. If user wants to fiddle with the tolerance, they'LL
+# have to use the actual integrator interface (i.e., SchrodingerMidpoint or SphericalMidpoint.)
+function ImplicitMidpoint(sys::SpinSystem{N}) where N
+    N == 0 ? SphericalMidpoint(sys) : SchrodingerMidpoint(sys)
 end
 
 
@@ -155,22 +157,23 @@ mutable struct SchrodingerMidpoint{N} <: Integrator
     _Z′  :: Array{CVec{N}, 4}
     _Z″  :: Array{CVec{N}, 4}
     _B   :: Array{Vec3, 4}
-    _ℌ    :: Matrix{ComplexF64}  # Just a buffer
+    _ℌ   :: Matrix{ComplexF64}  # Just a buffer
+    atol :: Float64
 end
 
-function SchrodingerMidpoint(sys::SpinSystem{N}) where N
+function SchrodingerMidpoint(sys::SpinSystem{N}; atol=1e-14) where N
     SchrodingerMidpoint{N}(
         sys, 
         zero(sys._coherents), zero(sys._coherents),
         zero(sys._coherents), zero(sys._coherents),
         zero(sys._coherents), zero(sys._dipoles),
-        zeros(ComplexF64, (N,N))
+        zeros(ComplexF64, (N,N)), atol
     )
 end
 
-function SchrodingerMidpoint(sys::SpinSystem{0})
-    @warn "SchrodingerMidpoint integration is only available for SU(N) systems. Using SphericalMidpoint integrator."
-    SphericalMidpoint(sys)
+function SchrodingerMidpoint(sys::SpinSystem{0}; atol=1e-14)
+    @error "SchrodingerMidpoint integration is only available for SU(N) systems. Use ImplicitMidpoint integrator."
+    nothing
 end
 
 
@@ -392,8 +395,8 @@ function evolve!(integrator::LangevinHeunPSUN, Δt::Float64)
 end
 
 
-function evolve!(integrator::SchrodingerMidpoint, Δt::Float64; tol=1e-14, max_iters=100)
-    (; sys, _ΔZ, _Zb, _Z′, _Z″) = integrator
+function evolve!(integrator::SchrodingerMidpoint, Δt::Float64; max_iters=100)
+    (; sys, _ΔZ, _Zb, _Z′, _Z″, atol) = integrator
     Z = sys._coherents
 
     @. _Z′ = Z 
@@ -406,7 +409,7 @@ function evolve!(integrator::SchrodingerMidpoint, Δt::Float64; tol=1e-14, max_i
 
         @. _Z″ = Z + _ΔZ
 
-        if norm(_Z′ - _Z″) < tol    # NOTE: This causes allocations.
+        if norm(_Z′ - _Z″) < atol    # NOTE: This causes allocations.
             @. Z = _Z″
             set_expected_spins!(sys)
             return

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -76,6 +76,15 @@ classical spins); a g-tensor, `g`; and an overall scaling factor for the spin
 magnitude, `spin_rescaling`. When provided to a `SpinSystem`, this information is automatically
 propagated to all symmetry-equivalent sites. An error will be thrown if multiple
 SiteInfos are given for symmetry-equivalent sites.
+
+In order to calculate form factor corrections, `ff_elem` must be given a valid argument
+specifying a magnetic ion. A list of valid names is provided in tables available
+at: https://www.ill.eu/sites/ccsl/ffacts/ffachtml.html . To calculate second-order form
+factor corrections, it is also necessary to provide a Lande g-factor (as a numerical
+value) to `ff_lande`. For example: `SiteInfo(1; ff_elem="Fe2", ff_lande=3/2`. Note that
+for the form factor to be calculated, these keywords must be given values for all
+unique sites in the unit cell. Please see the documentation to `calculate_form` for more
+information on the form factor calculation.
     
 NOTE: Currently, `N` must be uniform for all sites. All sites will be upconverted
 to the largest specified `N`.

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -93,6 +93,11 @@ function SiteInfo(site::Int; N=0, g=2*I(3), spin_rescaling=1.0, ff_elem=nothing,
     # Create diagonal g-tensor from number (if not given full array)
     (typeof(g) <: Number) && (g = Float64(g)*I(3))
 
+    # Make sure a valid element is given if a g_lande value is given. 
+    if isnothing(ff_elem) && !isnothing(ff_lande)
+        @warn "When creating a SiteInfo, you must provide valid `ff_elem` if you are also assigning a value to `ff_lande`. No form factor corrections will be applied."
+    end
+
     # Read all relevant form factor data if an element name is provided
     ff_params = !isnothing(ff_elem) ? FormFactorParams(ff_elem; g_lande = ff_lande) : nothing
 

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -69,11 +69,11 @@ end
 """
     SiteInfo(site::Int; N=0, g=2*I(3), spin_rescaling=1.0, ff_elem=nothing, ff_lande=nothing)
 
-Characterizes the degree of freedom located at a given `site` index with three 
-pieces of information: N (as in SU(N)), characterizing the complex dimension of the
+Characterizes the degree of freedom located at a given `site` index. 
+`N` (as in SU(N)), specifies the complex dimension of the
 generalized spins (where N=0 corresponds to traditional, three-component, real
-classical spins); a g-tensor, `g`; and an overall scaling factor for the spin
-magnitude, `spin_rescaling`. When provided to a `SpinSystem`, this information is automatically
+classical spins). `g` is the g-tensor. `spin_rescaling` is an overall scaling factor for the spin
+magnitude. When provided to a `SpinSystem`, this information is automatically
 propagated to all symmetry-equivalent sites. An error will be thrown if multiple
 SiteInfos are given for symmetry-equivalent sites.
 
@@ -81,9 +81,9 @@ In order to calculate form factor corrections, `ff_elem` must be given a valid a
 specifying a magnetic ion. A list of valid names is provided in tables available
 at: https://www.ill.eu/sites/ccsl/ffacts/ffachtml.html . To calculate second-order form
 factor corrections, it is also necessary to provide a Lande g-factor (as a numerical
-value) to `ff_lande`. For example: `SiteInfo(1; ff_elem="Fe2", ff_lande=3/2`. Note that
+value) to `ff_lande`. For example: `SiteInfo(1; ff_elem="Fe2", ff_lande=3/2)`. Note that
 for the form factor to be calculated, these keywords must be given values for all
-unique sites in the unit cell. Please see the documentation to `calculate_form` for more
+unique sites in the unit cell. Please see the documentation to `compute_form` for more
 information on the form factor calculation.
     
 NOTE: Currently, `N` must be uniform for all sites. All sites will be upconverted

--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -277,9 +277,9 @@ function apply_dipole_factor(struct_factor::OffsetArray{ComplexF64}, lattice::La
 end
 
 """
-    dynamic_structure_factor(sys, sampler; nsamples=10, dt=0.01, meas_period=10,
-                             num_omegas=100, bz_size, thermalize=10, reduce_basis=true,
-                             verbose=false)
+    dynamic_structure_factor(sys::SpinSystem, sampler::S;
+        nsamples::Int=10, thermalize::Int=10, dt::Float64=0.01, num_omegas::Int=100, omega_max=nothing, 
+        bz_size=(1,1,1), reduce_basis::Bool=true, dipole_factor::Bool=false, verbose::Bool=false)
 
 Measures the full dynamic structure factor tensor of a spin system, for the requested range
 of 𝐪-space and range of frequencies ω. Returns ``𝒮^{αβ}(𝐪, ω) = ⟨S^α(𝐪, ω) S^β(𝐪, ω)^∗⟩``,
@@ -297,10 +297,9 @@ where `B = nbasis(sys)` is the number of basis sites in the unit cell.
  `thermalize` times before any measurements are made.
 
 The maximum frequency sampled is `ωmax = 2π / (dt * meas_period)`, and the frequency resolution
- is set by `num_omegas` (the number of spin snapshots measured during dynamics). However, beyond
- increasing the resolution, `num_omegas` will also make all frequencies become more accurate. Note
- that `meas_period` is determined automatically by Sunny based on what the user assigns to `dt` and
- `omega_max`. If no value is given to `omega_max`, `meas_period` is set to 1.
+ is set by `num_omegas` (the number of spin snapshots measured during dynamics). `num_omegas` defaults
+ to 100. Note that `meas_period` is determined automatically by Sunny based on what the user
+ assigns to `dt` and `omega_max`. If no value is given to `omega_max`, `meas_period` is set to 1.
 
 Indexing the result at `(α, β, q1, ..., qd, w)` gives ``S^{αβ}(𝐪, ω)`` at
     `𝐪 = q1 * a⃰ + q2 * b⃰ + q3 * c⃰`, and `ω = maxω * w / T`, where `a⃰, b⃰, c⃰`
@@ -321,7 +320,7 @@ function dynamic_structure_factor(
 ) where {S <: AbstractSampler}
 
     if isnothing(omega_max)
-        meas_period = 10    # Reduce maximum resolved energy (determined by dt) by factor of 10 if no cutoff specified
+        meas_period = 1    # If no maximum frequency is specified, don't downsample. 
     else
         @assert π/dt > omega_max "Maximum ω with chosen step size is $(π/dt). Please choose smaller dt or larger omega_max."
         meas_period = floor(Int, π/(dt * omega_max))
@@ -353,7 +352,7 @@ function dynamic_structure_factor(
 end
 
 """
-    static_structure_factor(sys, sampler; nsamples, dt, bz_size, thermalize, verbose)
+    static_structure_factor(sys, sampler; nsamples, bz_size, thermalize, verbose)
 
 Measures the static structure factor tensor of a spin system, for the requested range
 of 𝐪-space. Returns ``𝒮^{αβ}(𝐪) = ⟨S^α(𝐪) S^β(𝐪)^∗⟩``,

--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -899,7 +899,7 @@ function sf_slice(sf::StructureFactor, points::Vector;
     slice_idx = slice_indexer_func(sf)
     sf_idx = sf_indexer_func(sf)
     itp = interpolate(sfdata, interp_method)
-    sitp = scale(itp, indexer2(q_scales..., ω_scale)...)
+    sitp = scale(itp, sf_idx(q_scales..., ω_scale)...)
 
     # Pull each partial slice (each leg of the cut) from interpolant
     slices = []

--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -851,6 +851,7 @@ function sf_slice(sf::StructureFactor, points::Vector;
         indexer
     end
 
+    # Periodically wrap value within interval specified by bounds
     function wrap(val::Float64, bounds::Tuple{Float64, Float64})
         offset = bounds[1]
         bound′ = bounds[2] - offset 
@@ -861,6 +862,7 @@ function sf_slice(sf::StructureFactor, points::Vector;
         return  remainder < 1e-12 ? bounds[2] : remainder + offset
     end
 
+    # Sample a series of points on a line between p1 and p2
     function path_points(p1::Vec3, p2::Vec3, densities, bounds; interp_scale=1)
         v = p2 - p1
         steps_coords = v .* densities # Convert continuous distances into number of discrete steps
@@ -879,7 +881,6 @@ function sf_slice(sf::StructureFactor, points::Vector;
         end
     end
 
-    # @assert length(size(sf.sfactor)) == 4 "Currently can only take slices from structures factors with reduced basis and dipole_factors"
     sfdata = parent(sf.sfactor)
     points = Vec3.(points) # Convert to uniform type
 

--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -813,8 +813,6 @@ function sf_slice(sf::StructureFactor, points::Vector;
     interp_method = BSpline(Linear(Periodic())),
     interp_scale = 1, return_idcs=false,
 )
-    # Returns a function that takes ps and ωs, returns the correct Indexing
-    # based on type of structure factor.
     function slice_indexer_func(sf::StructureFactor)
         if sf.reduce_basis
             if sf.dipole_factor
@@ -890,6 +888,7 @@ function sf_slice(sf::StructureFactor, points::Vector;
     ωs = omega_labels(sf)
     dims = size(sfdata)[q_idcs(sf)]
 
+    # Scaling information for interpolation
     q_bounds = [(first(qs), last(qs)) for qs in q_vals] # Upper and lower bounds in momentum space (depends on number of BZs)
     q_dens = [dims[i]/(2bounds[2]) for (i, bounds) in enumerate(q_bounds)] # Discrete steps per unit distance in momentum space
     q_scales = [range(bounds..., length=dims[i]) for (i, bounds) in enumerate(q_bounds)] # Values for scaled interpolation

--- a/src/Systems.jl
+++ b/src/Systems.jl
@@ -170,7 +170,7 @@ function _propagate_site_info(crystal::Crystal, site_infos::Vector{SiteInfo})
 
     specified_atoms = Int[]
     for siteinfo in site_infos
-        (; site, N, g, spin_rescaling) = siteinfo
+        (; site, N, g, spin_rescaling, ff_params) = siteinfo
         if N != maxN
             @warn "Up-converting N=$N -> N=$maxN on site $(site)!"
         end
@@ -185,7 +185,15 @@ function _propagate_site_info(crystal::Crystal, site_infos::Vector{SiteInfo})
                 push!(specified_atoms, sym_atom)
             end
 
-            all_site_infos[sym_atom] = SiteInfo(sym_atom; N = maxN, g = sym_g, spin_rescaling)
+            # all_site_infos[sym_atom] = SiteInfo(sym_atom; N = maxN, g = sym_g, spin_rescaling, ff_params)
+            all_site_infos[sym_atom] = SiteInfo(sym_atom, maxN, sym_g, spin_rescaling, ff_params)
+        end
+    end
+
+    with_ff = filter(si -> !isnothing(si.ff_params), all_site_infos)
+    if length(with_ff) > 0
+        if length(with_ff) != length(all_site_infos)
+            @error "Form factor calculations require that the magnetic ion be specified for all unique lattice sites. Please provide a SiteInfo with an explicit ff_elem for all unique sites or for none at all"
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,4 +74,5 @@ end
     addtests("test_dynamics.jl")
     addtests("test_langevin.jl")
     addtests("test_spin_scaling.jl")
+    addtests("test_structure_factors.jl")
 end

--- a/test/test_structure_factors.jl
+++ b/test/test_structure_factors.jl
@@ -58,7 +58,7 @@ end
 
 ## Running these tests takes about 30 seconds. Not tested by default.
 ## Uncomment to run the test.
-test_structure_factors_are_operational()
+# test_structure_factors_are_operational()
 
 # TODO: Add test for correctness of calculation
 

--- a/test/test_structure_factors.jl
+++ b/test/test_structure_factors.jl
@@ -1,0 +1,65 @@
+@testset "Structure Factors" begin
+
+function diamond_heisenberg_model(; 
+    ff_elem=nothing, ff_lande=nothing, spin_rescaling, J
+)
+    crystal = Sunny.diamond_crystal()
+    interactions = [
+        heisenberg(J, Bond(1, 3, [0,0,0])),
+    ]
+    dims = (8, 8, 8)
+    site_infos = [SiteInfo(1; spin_rescaling, ff_elem, ff_lande)]
+    sys = SpinSystem(crystal, interactions, dims, site_infos) 
+    rand!(sys)
+
+    return sys
+end
+
+#= There are many different paths through the structure factor code.
+This test simply tries them all out to make sure nothing is obviously
+broken. It does not text for the correctness of the results, just for the
+absence of errors. =#
+function test_structure_factors_are_operational()
+    dipole_factor = [true, false]
+    reduce_basis = [true, false]
+    ff_elem = [nothing, "Fe2"]
+    ff_lande = [nothing, 3/2]
+
+    for (dipole_factor, reduce_basis, ff_elem, ff_lande) in Base.Iterators.product(
+         dipole_factor, reduce_basis, ff_elem, ff_lande
+    )
+        (!isnothing(ff_lande) && isnothing(ff_elem)) && continue
+
+        J = Sunny.meV_per_K * 7.5413       
+        spin_rescaling = 3/2
+        sys = diamond_heisenberg_model(; ff_elem, ff_lande, spin_rescaling, J)
+
+        Δt = 0.02 / (spin_rescaling^2 * J) 
+        kT = Sunny.meV_per_K * 2. 
+        α  = 0.1
+        nsteps = 1  
+        sampler = LangevinSampler(sys, kT, α, Δt, nsteps)
+
+        dynΔt = Δt * 10
+        omega_max = 5.5 
+        num_omegas = 2
+
+        dynamic_structure_factor(
+            sys, sampler; nsamples=2, dt = dynΔt, omega_max, num_omegas,
+            bz_size=(1,1,2), thermalize=1, verbose=false,
+            reduce_basis, dipole_factor,
+        )
+
+        # Did we make it?
+        @test true
+    end
+
+end
+
+## Running these tests takes about 30 seconds. Not tested by default.
+## Uncomment to run the test.
+# test_structure_factors_are_operational()
+
+# TODO: Add test for correctness of calculation
+
+end

--- a/test/test_structure_factors.jl
+++ b/test/test_structure_factors.jl
@@ -58,7 +58,7 @@ end
 
 ## Running these tests takes about 30 seconds. Not tested by default.
 ## Uncomment to run the test.
-# test_structure_factors_are_operational()
+test_structure_factors_are_operational()
 
 # TODO: Add test for correctness of calculation
 


### PR DESCRIPTION
Main changes:
1. Structure factor interface changed slightly. For `dynamic_structure_factor`, user no longer sets `meas_rate`. Instead, they may set a `omega_max`, which will determine the down sampling. Number of frequencies resolved is specified with `num_omegas` (not `dyn_meas`). `dynΔt` is now just `dt`.
2. Form factor calculations have been revised. FF information is specified with `SiteInfo`. The corrections are precomputed prior to structure factor calculations and applied after calculating magnetization.
3. Some simple tests have been added for the structure factor material, but they are very preliminary: they don't test for correctness of results, just for errors. I have them commented out for now, but I run them before pushing. They would have caught the errors I introduced after doing the indexing refactor.
4. `sf_slice`, a function for cutting paths through a dynamical structure factor, now works on structure factors for which `reuduce_basis` and `dipole_factor` are false.

In general, this portion of the code is a little bit difficult to modify and expand because the structure factor data has a different number of indices depending on the stage of the calculation and the value of various optional parameters. At some point it would good to find some set of abstractions to make this a bit easier. Have various thoughts. To be continued.