### PR TITLE
Fix wrapping tests

### DIFF
--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -28,7 +28,7 @@ function validate_and_clean_interactions(ints::Vector{<:AbstractInteraction}, cr
             for b′ in bs
                 coeffs = crystal.lat_vecs \ displacement(crystal, b′)
                 for i = 1:3
-                    if coeffs[i] >= latsize[i]/2 - 1e-10
+                    if abs(coeffs[i]) >= latsize[i]/2 - 1e-10
                         println("Interaction $int_str is too long; consider extending system along dimension $i.")
                         error("Interaction wraps system.")
                     end

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -1,2 +1,43 @@
-@testitem "Lattice Type" begin
+@testitem "Lattice construction" begin
+
+    @testset "Wrapping" begin
+        latvecs = lattice_vectors(1, 1, 2, 90, 90, 90)
+        basis_vectors = [[0, 0, 0]]
+        cryst = Crystal(latvecs, basis_vectors)
+        ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
+        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (3, 2, 4))
+        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 3, 4))
+        @test SpinSystem(cryst, ints, (3, 3, 4)) isa SpinSystem
+
+        latvecs = lattice_vectors(0.5, 1.0, 2, 90, 90, 90)
+        basis_vectors = [[0, 0, 0]]
+        cryst = Crystal(latvecs, basis_vectors)
+        ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
+        @test SpinSystem(cryst, ints, (3, 1, 4)) isa SpinSystem
+        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 3, 4))
+
+        # Xiaojian's original test case
+        latvecs = lattice_vectors(1, 1, 2, 90, 90, 90)
+        basis_vectors = [[0, 0, 0], [0.5, 0.9, 0]]
+        cryst = Crystal(latvecs, basis_vectors)
+        ints = [heisenberg(1.0, Bond(1, 2, [0, -1, 0]))]
+        @test SpinSystem(cryst, ints, (2, 1, 4)) isa SpinSystem
+        ints = [heisenberg(1.0, Bond(1, 2, [0, 0, 0]))]
+        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 1, 4))
+
+        latvecs = lattice_vectors(1, 1, 2, 90, 90, 120)
+        basis_vectors = [[0, 0, 0]]
+        cryst = Crystal(latvecs, basis_vectors)
+        ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
+        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (3, 2, 4))
+        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 3, 4))
+        @test SpinSystem(cryst, ints, (3, 3, 4)) isa SpinSystem
+
+        latvecs = lattice_vectors(0.5, 1.0, 2, 90, 90, 120)
+        basis_vectors = [[0, 0, 0]]
+        cryst = Crystal(latvecs, basis_vectors)
+        ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
+        @test SpinSystem(cryst, ints, (3, 1, 4)) isa SpinSystem
+        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 3, 4))
+    end
 end

--- a/test/test_shared.jl
+++ b/test/test_shared.jl
@@ -1,3 +1,9 @@
+# Currently each @testitem must run in isolation. To share common setup code for
+# tests, the recommended pattern is to `include()` a file such as this one. See:
+# https://discourse.julialang.org/t/prerelease-of-new-testing-framework-and-test-run-ui-in-vs-code/86355/37
+# In the future, TestItemRunner may support a better pattern:
+# https://github.com/julia-vscode/TestItemRunner.jl/issues/11
+
 using Random
 using LinearAlgebra
 

--- a/test/test_spin_scaling.jl
+++ b/test/test_spin_scaling.jl
@@ -28,7 +28,7 @@ function make_test_system_lld(; spin_rescaling=1.0)
     quartic_interactions = [quartic_anisotropy(Jquar, i, "quartic") for i ∈ 1:4]
 
     interactions_all = vcat(exchange_interactions..., quartic_interactions...) 
-    dims = (2,2,2)
+    dims = (3,3,3)
 
     return SpinSystem(cryst,
                       interactions_all,
@@ -48,7 +48,7 @@ function make_test_system_gsd(; spin_rescaling=1.0, N=2)
     S = Sunny.gen_spin_ops(N)
     quartic_sun = SUN_anisotropy(-S[3]^4, 1, "quartic") 
 
-    dims = (2,2,2)
+    dims = (3,3,3)
     interactions_all = vcat(exchange_interactions..., quartic_sun) 
 
     return SpinSystem(cryst,
@@ -232,7 +232,7 @@ so results with different spin magnitudes can be compared directly.
 function generate_scaled_quadratic_trajectory(spin_rescaling, Δt; N=0, dur=10.0)
     rng = Random.MersenneTwister(111)
     cryst = Sunny.cubic_crystal()
-    dims = (4,4,2)
+    dims = (4,4,3)
     interactions = [
         heisenberg(1.0, Bond(1,1,[1,0,0])),
         dipole_dipole()


### PR DESCRIPTION
Be more careful about how we test whether a bond wraps the system. This fixes a bug Xiaojian found, and also suggested some updates to the tests on spin scaling.