### PR TITLE
Fix issue with ambiguous crystal setting

### DIFF
--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -321,7 +321,7 @@ function crystal_from_symbol(lat_vecs::Mat3, positions::Vector{Vec3}, types::Vec
             println("   $i_str. \"$hm_symbol\", setting=\"$choice\", with $natoms_str atoms")
         end
         println()
-        println("Note: To disambiguate, pass a named parameter, setting=\"...\".")
+        println("Note: To disambiguate, you may pass a named parameter, setting=\"...\".")
         println()
         return crysts
     end

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -1,120 +1,130 @@
 @testitem "Crystal Construction" begin
-include("test_shared.jl")
+    include("test_shared.jl")
 
 
-### Test construction of diamond lattice
+    ### Test construction of diamond lattice
 
-# Spglib inferred symmetry
-lat_vecs = [1 1 0; 1 0 1; 0 1 1]' / 2
-positions = [[1, 1, 1], [-1, -1, -1]] / 8
-cryst = Crystal(lat_vecs, positions)
-ref_bonds = reference_bonds(cryst, 2.)
-dist1 = [distance(cryst, b) for b in ref_bonds]
+    # Spglib inferred symmetry
+    lat_vecs = [1 1 0; 1 0 1; 0 1 1]' / 2
+    positions = [[1, 1, 1], [-1, -1, -1]] / 8
+    cryst = Crystal(lat_vecs, positions)
+    ref_bonds = reference_bonds(cryst, 2.)
+    dist1 = [distance(cryst, b) for b in ref_bonds]
 
-# Using explicit symops
-lat_vecs = Sunny.Mat3(lat_vecs)
-positions = [Sunny.Vec3(1, 1, 1) / 8]
-types = [""]
-cryst = Sunny.crystal_from_symops(lat_vecs, positions, types, cryst.symops, cryst.spacegroup)
-ref_bonds = reference_bonds(cryst, 2.)
-dist2 = [distance(cryst, b) for b in ref_bonds]
+    # Using explicit symops
+    lat_vecs = Sunny.Mat3(lat_vecs)
+    positions = [Sunny.Vec3(1, 1, 1) / 8]
+    types = [""]
+    cryst = Sunny.crystal_from_symops(lat_vecs, positions, types, cryst.symops, cryst.spacegroup)
+    ref_bonds = reference_bonds(cryst, 2.)
+    dist2 = [distance(cryst, b) for b in ref_bonds]
 
-# Using Hall number
-lat_vecs = lattice_vectors(1, 1, 1, 90, 90, 90) # must switch to standard cubic unit cell
-positions = [Sunny.Vec3(1, 1, 1) / 4]
-cryst = Sunny.crystal_from_hall_number(lat_vecs, positions, types, 525)
-ref_bonds = reference_bonds(cryst, 2.)
-dist3 = [distance(cryst, b) for b in ref_bonds]
+    # Using Hall number
+    lat_vecs = lattice_vectors(1, 1, 1, 90, 90, 90) # must switch to standard cubic unit cell
+    positions = [Sunny.Vec3(1, 1, 1) / 4]
+    cryst = Sunny.crystal_from_hall_number(lat_vecs, positions, types, 525)
+    ref_bonds = reference_bonds(cryst, 2.)
+    dist3 = [distance(cryst, b) for b in ref_bonds]
 
-# Using international symbol
-positions = [[1, 1, 1] / 4]
-# cryst = Crystal(lat_vecs, positions, "F d -3 m") # Ambiguous!
-cryst = Crystal(lat_vecs, positions, "F d -3 m"; setting="1")
-ref_bonds = reference_bonds(cryst, 2.)
-dist4 = [distance(cryst, b) for b in ref_bonds]
+    # Using international symbol
+    positions = [[1, 1, 1] / 4]
+    # cryst = Crystal(lat_vecs, positions, "F d -3 m") # Ambiguous!
+    cryst = Crystal(lat_vecs, positions, "F d -3 m"; setting="1")
+    ref_bonds = reference_bonds(cryst, 2.)
+    dist4 = [distance(cryst, b) for b in ref_bonds]
 
-@test dist1 ≈ dist2 ≈ dist3 ≈ dist4
-
-
-
-### FCC lattice, primitive vs. standard unit cell
-
-lat_vecs = [1 1 0; 1 0 1; 0 1 1]' / 2
-positions = [[0, 0, 0]]
-cryst = Crystal(lat_vecs, positions)
-
-lat_vecs = [1 0 0; 0 1 0; 0 0 1]'
-positions = [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]]
-cryst′ = Crystal(lat_vecs, positions)
-
-@test cryst.sitesyms[1] == cryst′.sitesyms[1]
-
-# Calculate interaction table
-ref_bonds = reference_bonds(cryst, 2.)
-b = ref_bonds[2]
-basis = basis_for_symmetry_allowed_couplings(cryst, b)
-J = basis' * randn(length(basis))
-(bs, Js) = all_symmetry_related_couplings_for_atom(cryst, b.i, b, J)
-@test length(Js) == coordination_number(cryst, b.i, b)
+    @test dist1 ≈ dist2 ≈ dist3 ≈ dist4
 
 
-### Triangular lattice, primitive unit cell
 
-c = 10
-lat_vecs = [1 0 0;  -1/2 √3/2 0;  0 0 c]'
-positions = [[0, 0, 0]]
-cryst = Crystal(lat_vecs, positions)
-@test cell_type(cryst) == Sunny.hexagonal
-@test nbasis(cryst) == 1
-@test cell_volume(cryst) ≈ c * √3 / 2 
-@test all(lattice_params(cryst) .≈ (1., 1., c, 90., 90., 120.))
+    ### FCC lattice, primitive vs. standard unit cell
 
-### Kagome lattice
+    lat_vecs = [1 1 0; 1 0 1; 0 1 1]' / 2
+    positions = [[0, 0, 0]]
+    cryst = Crystal(lat_vecs, positions)
 
-lat_vecs = [1 0 0;  -1/2 √3/2 0;  0 0 c]'
-positions = [[0, 0, 0], [0.5, 0, 0], [0, 0.5, 0]]
-cryst = Crystal(lat_vecs, positions)
-@test cell_type(cryst) == Sunny.hexagonal
-@test nbasis(cryst) == 3
-@test cell_volume(cryst) ≈ c * √3 / 2 
-@test all(lattice_params(cryst) .≈ (1., 1., c, 90., 90., 120.))
+    lat_vecs = [1 0 0; 0 1 0; 0 0 1]'
+    positions = [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]]
+    cryst′ = Crystal(lat_vecs, positions)
 
+    @test cryst.sitesyms[1] == cryst′.sitesyms[1]
 
-### Arbitrary monoclinic
-
-mono_lat_params = (6, 7, 8, 90, 90, 40)
-lat_vecs = lattice_vectors(mono_lat_params...)
-positions = [[0,0,0]]
-# cryst = Crystal(lat_vecs, positions, "C 2/c")
-cryst = Crystal(lat_vecs, positions, "C 2/c", setting="c1")
-@test cell_type(cryst) == Sunny.monoclinic
-@test nbasis(cryst) == 4
-@test all(lattice_params(cryst) .≈ mono_lat_params)
+    # Calculate interaction table
+    ref_bonds = reference_bonds(cryst, 2.)
+    b = ref_bonds[2]
+    basis = basis_for_symmetry_allowed_couplings(cryst, b)
+    J = basis' * randn(length(basis))
+    (bs, Js) = all_symmetry_related_couplings_for_atom(cryst, b.i, b, J)
+    @test length(Js) == coordination_number(cryst, b.i, b)
 
 
-### Arbitrary trigonal
+    ### Triangular lattice, primitive unit cell
 
-lat_vecs = lattice_vectors(5, 5, 6, 90, 90, 120)
-positions = [[0,0,0]]
-cryst1 = Crystal(lat_vecs, positions, "P -3")
-@test nbasis(cryst1) == 1
-@test cell_type(cryst1) == Sunny.hexagonal
-cryst2 = Crystal(lat_vecs, positions, "R -3")
-@test nbasis(cryst2) == 3
-cryst3 = Crystal(lat_vecs, positions, 147) # spacegroup number
-@test cell_type(cryst1) == cell_type(cryst2) == cell_type(cryst3) == Sunny.hexagonal
+    c = 10
+    lat_vecs = [1 0 0;  -1/2 √3/2 0;  0 0 c]'
+    positions = [[0, 0, 0]]
+    cryst = Crystal(lat_vecs, positions)
+    @test cell_type(cryst) == Sunny.hexagonal
+    @test nbasis(cryst) == 1
+    @test cell_volume(cryst) ≈ c * √3 / 2 
+    @test all(lattice_params(cryst) .≈ (1., 1., c, 90., 90., 120.))
+
+    ### Kagome lattice
+
+    lat_vecs = [1 0 0;  -1/2 √3/2 0;  0 0 c]'
+    positions = [[0, 0, 0], [0.5, 0, 0], [0, 0.5, 0]]
+    cryst = Crystal(lat_vecs, positions)
+    @test cell_type(cryst) == Sunny.hexagonal
+    @test nbasis(cryst) == 3
+    @test cell_volume(cryst) ≈ c * √3 / 2 
+    @test all(lattice_params(cryst) .≈ (1., 1., c, 90., 90., 120.))
 
 
-### Arbitrary triclinic
+    ### Arbitrary monoclinic
 
-lat_vecs = lattice_vectors(6, 7, 8, 70, 80, 90)
-positions = [[0,0,0]]
-cryst1 = Crystal(lat_vecs, positions, "P 1")
-@test nbasis(cryst1) == 1
-cryst2 = Crystal(lat_vecs, positions) # Infers 'P -1'
-@test nbasis(cryst1) == nbasis(cryst2) == 1
-@test cell_type(cryst1) == cell_type(cryst2) == Sunny.triclinic
+    mono_lat_params = (6, 7, 8, 90, 90, 40)
+    lat_vecs = lattice_vectors(mono_lat_params...)
+    positions = [[0,0,0]]
+    # cryst = Crystal(lat_vecs, positions, "C 2/c")
+    cryst = Crystal(lat_vecs, positions, "C 2/c", setting="c1")
+    @test cell_type(cryst) == Sunny.monoclinic
+    @test nbasis(cryst) == 4
+    @test all(lattice_params(cryst) .≈ mono_lat_params)
 
+
+    ### Arbitrary trigonal
+
+    lat_vecs = lattice_vectors(5, 5, 6, 90, 90, 120)
+    positions = [[0,0,0]]
+    cryst1 = Crystal(lat_vecs, positions, "P -3")
+    @test nbasis(cryst1) == 1
+    @test cell_type(cryst1) == Sunny.hexagonal
+    cryst2 = Crystal(lat_vecs, positions, "R -3")
+    @test nbasis(cryst2) == 3
+    cryst3 = Crystal(lat_vecs, positions, 147) # spacegroup number
+    @test cell_type(cryst1) == cell_type(cryst2) == cell_type(cryst3) == Sunny.hexagonal
+
+
+    ### Arbitrary triclinic
+
+    lat_vecs = lattice_vectors(6, 7, 8, 70, 80, 90)
+    positions = [[0,0,0]]
+    cryst1 = Crystal(lat_vecs, positions, "P 1")
+    @test nbasis(cryst1) == 1
+    cryst2 = Crystal(lat_vecs, positions) # Infers 'P -1'
+    @test nbasis(cryst1) == nbasis(cryst2) == 1
+    @test cell_type(cryst1) == cell_type(cryst2) == Sunny.triclinic
+
+    ### Orthorhombic test, found by Ovi Garlea
+
+    lat_vecs = lattice_vectors(13.261, 7.718, 6.278, 90.0, 90.0, 90.0);
+    types = ["Yb1","Yb2"];
+    basis_vecs = [[0,0,0], [0.266,0.25,0.02]]; # Locations of atoms as multiples of lattice vectors
+    crysts = Crystal(lat_vecs, basis_vecs, 62; types, symprec=1e-4)
+    @test length(crysts) == 6
+    cryst = Crystal(lat_vecs, basis_vecs,62; types, symprec=1e-4, setting="-cba")
+    @test count(==(1), cryst.classes) == 4
+    @test count(==(2), cryst.classes) == 4    
 end
 
 
@@ -263,9 +273,3 @@ end
     @test norm(n) ≈ 1
     @test R*n ≈ n
 end
-
-
-#=
-using Pkg
-Pkg.test("Sunny", test_args=["test_symmetry"])
-=#


### PR DESCRIPTION
Ovi Garlea reported that he was not getting the expected crystal with this code:

```julia
using Sunny
lat_vecs = lattice_vectors(13.261, 7.718, 6.278, 90.0, 90.0, 90.0);
types = ["Yb1","Yb2"];
basis_vecs = [[0,0,0], [0.266,0.25,0.997]]; # Locations of atoms as multiples of lattice vectors
Crystal(lat_vecs, basis_vecs,62;types,symprec=0.001)
```

The problem is that space group 62 could have multiple interpretations. For example, it could be any of 6 possible Hall numbers, 292...297 ( ["Setos page" has the full list](https://yseto.net/?page_id=29%3E)). These can be disambiguated with an approprate "setting" parameter. To add to the confusion, each of these settings has a different HM symbol, and Sunny was not prepared to handle it.

This PR fixes the bug, and the above code now outputs:
```
The spacegroup '62' allows for multiple settings!
Returning a list of the possible crystals:
    1. "P n m a", setting="", with  8 atoms
    2. "P m n b", setting="ba-c", with 12 atoms
    3. "P b n m", setting="cab", with 12 atoms
    4. "P c m n", setting="-cba", with  8 atoms
    5. "P m c n", setting="bca", with 12 atoms
    6. "P n a m", setting="a-cb", with 12 atoms

Note: To disambiguate, you may pass a named parameter, setting="...".
```

This should make it easier to understand what's going on, and to select the desired crystal.