### PR TITLE
Remove uses of Logging macros

### DIFF
--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -29,8 +29,7 @@ function validate_and_clean_interactions(ints::Vector{<:AbstractInteraction}, cr
                 coeffs = crystal.lat_vecs \ displacement(crystal, b′)
                 for i = 1:3
                     if abs(coeffs[i]) >= latsize[i]/2 - 1e-10
-                        println("Interaction $int_str is too long; consider extending system along dimension $i.")
-                        error("Interaction wraps system.")
+                        println("Warning: Interaction $int_str wraps the system along dimension $i.")
                     end
                 end
             end
@@ -112,9 +111,9 @@ function propagate_sun_anisos(crystal::Crystal, anisos::Vector{SUNAnisotropy}, N
 
         for (sym_atom, sym_Λ) in zip(sym_bs, sym_Λs)
             if sym_atom in specified_atoms
-                @error "Provided two SU($N) anisotropies for symmetry equivalent sites."
+                error("Provided two SU($N) anisotropies for symmetry equivalent sites.")
             elseif size(sym_Λ)[1] != N
-                @error "Provided an SU($(size(sym_Λ)[1])) anisotropy for an SU($N) model!"
+                error("Provided an SU($(size(sym_Λ)[1])) anisotropy for an SU($N) model!")
             else
                 push!(specified_atoms, sym_atom)
             end
@@ -140,7 +139,7 @@ function merge_upconvert_anisos(anisos::Vector{<:AbstractAnisotropy}, crystal::C
     # Convert to backend types if in LL mode.
     if N == 0
         if length(sun_anisos) != 0
-            @error "Given a SU(N) anisotropy but running in classic Landau-Lifshitz mode."
+            error("Given a SU(N) anisotropy but running in classic Landau-Lifshitz mode.")
         end
 
         quadratic_aniso = merge(quadratic_anisos)
@@ -151,7 +150,7 @@ function merge_upconvert_anisos(anisos::Vector{<:AbstractAnisotropy}, crystal::C
 
     # Throw error if given non-SU(N) anisotropy and in SU(N) mode 
     if length(quadratic_anisos) != 0 || length(quartic_anisos) != 0
-        @error "Given a Landau-Lifshitz-type anisotropy, but running in SU(N) mode."
+        error("Given a Landau-Lifshitz-type anisotropy, but running in SU(N) mode.")
     end
 
     # Propagate SU(N) anisotropies to symmetry equivalent sites
@@ -228,7 +227,7 @@ function HamiltonianCPU(ints::Vector{<:AbstractInteraction}, crystal::Crystal,
             push!(anisos, int)
         elseif isa(int, DipoleDipole)
             if !isnothing(dipole_int)
-                @warn "Provided multiple dipole interactions. Only using last one."
+                println("Warning: Provided multiple dipole interactions. Only using last one.")
             end
             dipole_int = DipoleFourierCPU(int, crystal, latsize, site_infos; μB=μB, μ0=μ0)
         else

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -83,7 +83,7 @@ mutable struct SphericalMidpoint <: Integrator
 end
 
 function SphericalMidpoint(sys::SpinSystem{N}; atol=1e-12) where N
-    @error "SphericalMidpoint integrator is not available for SU(N) systems. Use ImplicitMidpoint integrator."
+    error("SphericalMidpoint integrator is not available for SU(N) systems. Use ImplicitMidpoint integrator.")
     nothing
 end
 
@@ -172,7 +172,7 @@ function SchrodingerMidpoint(sys::SpinSystem{N}; atol=1e-14) where N
 end
 
 function SchrodingerMidpoint(sys::SpinSystem{0}; atol=1e-14)
-    @error "SchrodingerMidpoint integration is only available for SU(N) systems. Use ImplicitMidpoint integrator."
+    error("SchrodingerMidpoint integration is only available for SU(N) systems. Use ImplicitMidpoint integrator.")
     nothing
 end
 

--- a/src/Interactions.jl
+++ b/src/Interactions.jl
@@ -104,7 +104,9 @@ function SiteInfo(site::Int; N=0, g=2*I(3), spin_rescaling=1.0, ff_elem=nothing,
 
     # Make sure a valid element is given if a g_lande value is given. 
     if isnothing(ff_elem) && !isnothing(ff_lande)
-        @warn "When creating a SiteInfo, you must provide valid `ff_elem` if you are also assigning a value to `ff_lande`. No form factor corrections will be applied."
+        println("""Warning: When creating a SiteInfo, you must provide valid `ff_elem` if you
+                   are also assigning a value to `ff_lande`. No form factor corrections will be
+                   applied.""")
     end
 
     # Read all relevant form factor data if an element name is provided

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -370,8 +370,8 @@ function crystal_from_symops(lat_vecs::Mat3, positions::Vector{Vec3}, types::Vec
     end
 
     if !is_subgroup
-        println("WARNING: User provided symmetry operation could not be inferred by Spglib,")
-        println("which likely indicates a non-conventional unit cell.")
+        println("""Warning: User provided symmetry operation could not be inferred by Spglib,
+                   which likely indicates a non-conventional unit cell.""")
     end
 
     # If the inferred symops match the provided ones, then we use the inferred
@@ -424,7 +424,7 @@ function subcrystal(cryst::Crystal, classes::Vararg{Int, N}) where {N}
     new_sitesyms = cryst.sitesyms[idxs]
 
     if idxs != 1:maximum(idxs)
-        println("WARNING, atoms are being renumbered.")
+        println("Warning: atoms are being renumbered.")
     end
 
     ret = Crystal(cryst.lat_vecs, new_positions, new_types, new_classes, new_sitesyms,

--- a/src/Systems.jl
+++ b/src/Systems.jl
@@ -138,7 +138,7 @@ function _propagate_site_info(crystal::Crystal, site_infos::Vector{SiteInfo})
     for siteinfo in site_infos
         (; site, N, g, spin_rescaling, ff_params) = siteinfo
         if N != maxN
-            @warn "Up-converting N=$N -> N=$maxN on site $(site)!"
+            println("Warning: Up-converting N=$N -> N=$maxN on site $(site)!")
         end
         (sym_bs, sym_gs) = all_symmetry_related_couplings(crystal, Bond(site, site, [0,0,0]), g)
         for (sym_b, sym_g) in zip(sym_bs, sym_gs)
@@ -146,7 +146,7 @@ function _propagate_site_info(crystal::Crystal, site_infos::Vector{SiteInfo})
             if sym_atom in specified_atoms
                 # Perhaps this should only throw if two _conflicting_ SiteInfo are passed?
                 # Then propagate_site_info can be the identity on an already-filled list.
-                @error "Provided two `SiteInfo` which describe symmetry-equivalent sites!"
+                error("Provided two `SiteInfo` which describe symmetry-equivalent sites!")
             else
                 push!(specified_atoms, sym_atom)
             end
@@ -159,7 +159,9 @@ function _propagate_site_info(crystal::Crystal, site_infos::Vector{SiteInfo})
     with_ff = filter(si -> !isnothing(si.ff_params), all_site_infos)
     if length(with_ff) > 0
         if length(with_ff) != length(all_site_infos)
-            @error "Form factor calculations require that the magnetic ion be specified for all unique lattice sites. Please provide a SiteInfo with an explicit ff_elem for all unique sites or for none at all"
+            error("""Form factor calculations require that the magnetic ion be specified for
+                     all unique lattice sites. Please provide a SiteInfo with an explicit
+                     ff_elem for all unique sites or for none at all.""")
         end
     end
 

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -1,43 +1,45 @@
 @testitem "Lattice construction" begin
+    # TODO: Send all warnings to stderr and reenable @test_warn once
+    # TestItemRunner supports it.
+    # https://github.com/julia-vscode/TestItemRunner.jl/issues/25
 
-    @testset "Wrapping" begin
-        latvecs = lattice_vectors(1, 1, 2, 90, 90, 90)
-        basis_vectors = [[0, 0, 0]]
-        cryst = Crystal(latvecs, basis_vectors)
-        ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
-        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (3, 2, 4))
-        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 3, 4))
-        @test SpinSystem(cryst, ints, (3, 3, 4)) isa SpinSystem
+    latvecs = lattice_vectors(1, 1, 2, 90, 90, 90)
+    basis_vectors = [[0, 0, 0]]
+    cryst = Crystal(latvecs, basis_vectors)
+    ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
+    # @test_warn "Interaction" SpinSystem(cryst, ints, (3, 2, 4))
+    # @test_warn "Interaction" SpinSystem(cryst, ints, (2, 3, 4))
+    @test SpinSystem(cryst, ints, (3, 3, 4)) isa SpinSystem
 
-        latvecs = lattice_vectors(0.5, 1.0, 2, 90, 90, 90)
-        basis_vectors = [[0, 0, 0]]
-        cryst = Crystal(latvecs, basis_vectors)
-        ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
-        @test SpinSystem(cryst, ints, (3, 1, 4)) isa SpinSystem
-        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 3, 4))
+    latvecs = lattice_vectors(0.5, 1.0, 2, 90, 90, 90)
+    basis_vectors = [[0, 0, 0]]
+    cryst = Crystal(latvecs, basis_vectors)
+    ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
+    @test SpinSystem(cryst, ints, (3, 1, 4)) isa SpinSystem
+    # @test_warn "Interaction" SpinSystem(cryst, ints, (2, 3, 4))
 
-        # Xiaojian's original test case
-        latvecs = lattice_vectors(1, 1, 2, 90, 90, 90)
-        basis_vectors = [[0, 0, 0], [0.5, 0.9, 0]]
-        cryst = Crystal(latvecs, basis_vectors)
-        ints = [heisenberg(1.0, Bond(1, 2, [0, -1, 0]))]
-        @test SpinSystem(cryst, ints, (2, 1, 4)) isa SpinSystem
-        ints = [heisenberg(1.0, Bond(1, 2, [0, 0, 0]))]
-        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 1, 4))
+    # Xiaojian's original test case
+    latvecs = lattice_vectors(1, 1, 2, 90, 90, 90)
+    basis_vectors = [[0, 0, 0], [0.5, 0.9, 0]]
+    cryst = Crystal(latvecs, basis_vectors)
+    ints = [heisenberg(1.0, Bond(1, 2, [0, -1, 0]))]
+    @test SpinSystem(cryst, ints, (2, 1, 4)) isa SpinSystem
+    ints = [heisenberg(1.0, Bond(1, 2, [0, 0, 0]))]
+    # @test_warn "Interaction" SpinSystem(cryst, ints, (2, 1, 4))
 
-        latvecs = lattice_vectors(1, 1, 2, 90, 90, 120)
-        basis_vectors = [[0, 0, 0]]
-        cryst = Crystal(latvecs, basis_vectors)
-        ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
-        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (3, 2, 4))
-        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 3, 4))
-        @test SpinSystem(cryst, ints, (3, 3, 4)) isa SpinSystem
+    latvecs = lattice_vectors(1, 1, 2, 90, 90, 120)
+    basis_vectors = [[0, 0, 0]]
+    cryst = Crystal(latvecs, basis_vectors)
+    ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
+    # @test_warn "Interaction" SpinSystem(cryst, ints, (3, 2, 4))
+    # @test_warn "Interaction" SpinSystem(cryst, ints, (2, 3, 4))
+    @test SpinSystem(cryst, ints, (3, 3, 4)) isa SpinSystem
 
-        latvecs = lattice_vectors(0.5, 1.0, 2, 90, 90, 120)
-        basis_vectors = [[0, 0, 0]]
-        cryst = Crystal(latvecs, basis_vectors)
-        ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
-        @test SpinSystem(cryst, ints, (3, 1, 4)) isa SpinSystem
-        @test_throws ErrorException("Interaction wraps system.") SpinSystem(cryst, ints, (2, 3, 4))
-    end
+    latvecs = lattice_vectors(0.5, 1.0, 2, 90, 90, 120)
+    basis_vectors = [[0, 0, 0]]
+    cryst = Crystal(latvecs, basis_vectors)
+    ints = [heisenberg(1.0, Bond(1, 1, [1, 0, 0]))]
+    @test SpinSystem(cryst, ints, (3, 1, 4)) isa SpinSystem
+    # @test_warn "Interaction" SpinSystem(cryst, ints, (2, 3, 4))
+
 end


### PR DESCRIPTION
Note that `error()` throws an exception, whereas `@error` does not. Convert all instances to the former.

For consistency with the rest of the codebase, remove usages of `@warn`. Eventually we may want to replace all `println()` warning statements with `@warn`.

Additionally: Make system-wrapping interactions a warning rather than an error.