### PR TITLE
SF intensity and sum rule revisions

### DIFF
--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -812,11 +812,13 @@ along a linear path successively connecting each point in `points`.
 
 The three q indices of the structure factor `sf` will be reduced to a
 single index. So, for example, if you pass a structure factor with
-indices [α, β, qa, qb, qc, ω], you will be returned array with
-indices [α, β, q, ω].
+indices [α, β, qa, qb, qc, ω], you will be returned an array with
+indices [α, β, q, ω], where the q index corresponds to linearly spaced
+points along your specified path.
 
 If `return_idcs` is set to `true`, the function will also return the indices
-of the slice that correspond to each point of `points`.
+of the slice that correspond to each point of `points`. This is useful for
+plotting labels.
 
 If `interp_scale=1` and the paths are parallel to one of the reciprocal
 lattice vectors (e.g., (0,0,0) -> (π,0,0)), or strictly diagonal

--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -647,7 +647,6 @@ accumulates the structure factor from `S` with the dipole factor applied into `r
 """
 function accum_dipole_factor_wbasis!(res, S, lattice::Lattice, nsamples::Int)
     recip = gen_reciprocal(lattice)
-    nb = nbasis(lattice)
     Sα = reshape(S, _outersizeα(axes(S), 5))  # Size [3,..., 1, B, T] 
     Sβ = reshape(S, _outersizeβ(axes(S), 5))  # Size [3,..., B, 1, T] 
 

--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -423,6 +423,7 @@ of `spin_traj`.
 function fft_spin_traj!(res::Array{ComplexF64}, spin_traj::Array{Vec3};
                         plan::Union{Nothing, FFTW.cFFTWPlan}=nothing)
     @assert size(res) == tuplejoin(3, size(spin_traj)) "fft_spins size not compatible with spin_traj size"
+    println("here")
 
     # Reinterpret array to add the spin dimension explicitly
     # Now of shape [3, D1, ..., Dd, B, T]
@@ -443,9 +444,8 @@ function fft_spin_traj!(spin_traj::Array{ComplexF64};
                         plan::Union{Nothing, FFTW.cFFTWPlan}=nothing)
     if isnothing(plan)
         FFTW.fft!(spin_traj, (2,3,4,6))
-        spin_traj /= N
     else
-        spin_traj = (plan * spin_traj) ./ 1e11
+        spin_traj = plan * spin_traj
     end
 end
 

--- a/src/StructureFactors.jl
+++ b/src/StructureFactors.jl
@@ -840,6 +840,12 @@ function sf_slice(sf::StructureFactor, points::Vector;
     interp_method = BSpline(Linear(Periodic())),
     interp_scale = 1, return_idcs=false,
 )
+    # The following two functions return functions that take q and ω information
+    # and insert it into the correct indices. What the correct indices are will
+    # depend on the configuration of the StructureFactor (i.e., whether coordinate
+    # indices are present, and whether basis indices are present). There should be
+    # a way to combine these functions into a single function, but I ran into so
+    # some issues with splatting. This will all go in the refactor.
     function slice_indexer_func(sf::StructureFactor)
         if sf.reduce_basis
             if sf.dipole_factor
@@ -918,7 +924,7 @@ function sf_slice(sf::StructureFactor, points::Vector;
     # as Interpolations.jl requires at least two points along each dimension. In particular, this
     # allows the user to cut paths from 2D systems.
     #
-    # This is an ugly quick fix to avoid redoing the approach to indexing and interpolation.
+    # This is a quick fix to avoid redoing the approach to indexing and interpolation.
     # Not investing time in a better solution because the need for this entire function will be 
     # eliminated in the refactor. Note the user will never see this.
     function expand_singleton_dims(sfdata)
@@ -967,7 +973,7 @@ function sf_slice(sf::StructureFactor, points::Vector;
         push!(idcs, idcs[i] + dim)
     end
 
-    # Set up offsets
+    # Set up offsets (only on ω axis). 
     numones = 5
     (sf.reduce_basis) && (numones -= 2)
     (sf.dipole_factor) && (numones -= 2)

--- a/test/test_structure_factors.jl
+++ b/test/test_structure_factors.jl
@@ -58,7 +58,7 @@ end
 
 ## Running these tests takes about 30 seconds. Not tested by default.
 ## Uncomment to run the test.
-test_structure_factors_are_operational()
+# test_structure_factors_are_operational()
 
 # TODO: Add test for correctness of calculation
 

--- a/test/test_structure_factors.jl
+++ b/test/test_structure_factors.jl
@@ -58,7 +58,7 @@ end
 
 ## Running these tests takes about 30 seconds. Not tested by default.
 ## Uncomment to run the test.
-# test_structure_factors_are_operational()
+test_structure_factors_are_operational()
 
 # TODO: Add test for correctness of calculation
 


### PR DESCRIPTION
This is a collection of minor revisions and bug fixes to make it easier to check sum rules. The intensities are also rescaled to match physical conventions. This makes it easier to compare results from Sunny directly with spin wave calculations.

Changes in behavior and features:

1. Accumulation of SF samples is now done with averaging, $\overline{x}_{n}= \overline{x}_{n-1}+\frac{x_{n} - \overline{x}_{n-1}}{n}$, so the intensity doesn't grow with the number of samples.
2. The Fourier transforms of the trajectories are now scaled by a factor of $\frac{1}{\sqrt{N_1N_2N_3}T}$, where $N_i$ is the dimension of the lattice along lattice vector $i$, and $T$ is the number of time steps. The resulting intensities are now comparable to what would be given by spin wave calculations. In particular, if you sum out out the $q$ and $\omega$ indices of $\textrm{Tr} \left( \mathcal{S} \left(\mathbf{q}, \omega \right) \right)$, the result will now be $N_1N_2N_3\vert S\vert^2$.
3. There is now an option to turn off application of the g-factor. (This is helpful to check the sum rule when the g-factor is anisotropic.)

Bug fixes:
1. I had introduced an indexing arithmetic error in one of the accumulation functions when I added offsets to the omega axis. Essentially all the negative omegas were off by a single index when `reduce_basis` was set to false. I never noticed because it is usually a subtle effect ($\Delta\omega$ is usually small) and negative energies are generally ignored. This manifested in small errors in the sum rule. This has been corrected. In the refactor, I'll add sum rule tests. We also won't be going back and forth between offset arrays and regular arrays, so I shouldn't be able to make the same mistake again.
2. I think there was an existing bug in `accum_dipole_factor_wbasis!`. Previously there `real(Sα[α, q_idx, :, :, :] * Sβ[β, q_idx, :, :, :])`, but I believe it should be `real(Sα[α, q_idx, :, :, :] * conj(Sβ[β, q_idx, :, :, :]))`. The `conj` has been added, and results are much more reasonable when `reduce_basis=false` and `dipole_factor=true`.
3. I added a hack to the `sf_slice` function so it doesn't throw an error when one of the spatial dimensions has size 1. This way users can use the function to get slices from effectively 2D systems. The fix is kind of ugly, but this function will not survive the upcoming refactor.

Testing:
I ran the code on two different models: one had eight sites per cell and was three dimensional, the other had one site per cell and was effectively 2D. I checked that the results were as expected for all permutations of `reduce_basis` and `dipole_factor` being true and false. I just the sum rule when `reduce_basis` was both true and false (but `dipole_factor` was always false, since it changes the intensities). I checked the slicing function on the 2D system.
