### PR TITLE
Large N integrator fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Cole Miles <cmm572@cornell.edu>", "Kipton Barros <kbarros@lanl.gov>"
 version = "0.3.0"
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 CrystalInfoFramework = "6007d9b0-c6b2-11e8-0510-1d10e825f3f1"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Cole Miles <cmm572@cornell.edu>", "Kipton Barros <kbarros@lanl.gov>"
 version = "0.3.0"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 CrystalInfoFramework = "6007d9b0-c6b2-11e8-0510-1d10e825f3f1"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -350,18 +350,15 @@ end
 
     return quote
         (; sys, _ℌ) = integrator
-        # (; hamiltonian, site_infos, lattice, S) = sys
         (; hamiltonian, site_infos, lattice) = sys
         nb = nbasis(lattice)
         Λs = hamiltonian.sun_aniso
         rhs′ = reinterpret(reshape, ComplexF64, rhs) 
-        # Sˣ, Sʸ, Sᶻ = S[:,:,1], S[:,:,2], S[:,:,3] # Cheaper to take the allocations than use views.
 
         @inbounds for s in 1:nb
             κ = $scale_expr 
             Λ = @view(Λs[:,:,s])
             for c in eachcellindex(lattice)
-                # @. _ℌ = κ * (Λ - (B[c,s][1]*Sˣ + B[c,s][2]*Sʸ + B[c,s][3]*Sᶻ))
                 @. _ℌ = κ * Λ 
                 add_dipolar_field!(_ℌ, -κ*B[c,s]) 
                 mul!(@view(rhs′[:, c, s]), _ℌ, Z[c, s])

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -334,7 +334,7 @@ end
             Λ = @view(Λs[:,:,s])
             for c in eachcellindex(lattice)
                 @. _ℌ = κ * Λ 
-                add_dipolar_field!(_ℌ, -κ*B[c,s]) 
+                accum_spin_matrices!(_ℌ, -κ*B[c,s]) 
                 mul!(@view(rhs′[:, c, s]), _ℌ, Z[c, s])
             end
         end

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -292,32 +292,6 @@ end
     (a - ((Z' * a) * Z))  
 end
 
-
-function add_dipolar_field!(op::Array{ComplexF64, 2}, B::Sunny.Vec3)
-    N = size(op, 1)
-    S = (N-1)/2
-
-    # Note indexing by column (hence using conjugate of standard formula)
-    @inbounds for j in 1:N
-        # Subdiagonal
-        if j > 1
-            val = 0.5*√(S*(S + 1) - (S - j + 1)*(S - j + 2))
-            op[j-1,j] += val*(B[1] - im*B[2])
-        end
-
-        # Diagonal
-        op[j,j] += B[3]*(S - j + 1)
-
-        # Superdiagonal
-        if j < N
-            val = 0.5*√(S*(S + 1) - (S - j + 1)*(S - j))
-            op[j+1,j] += val*(B[1] + im*B[2])
-        end
-    end
-
-    nothing
-end
-
 @generated function _apply_ℌ!(rhs::Array{CVec{N}, 4}, B::Array{Vec3, 4}, Z::Array{CVec{N}, 4}, integrator)  where {N}
 
     if integrator <: LangevinIntegrator

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -298,10 +298,10 @@ function add_dipolar_field!(op::Array{ComplexF64, 2}, B::Sunny.Vec3)
     S = (N-1)/2
 
     # Note indexing by column (hence using conjugate of standard formula)
-    for j in 1:N
+    @inbounds for j in 1:N
         # Subdiagonal
-        if j-1 > 0
-            val = 0.5*√(S*(S+1) - (S - j + 1)*(S - j + 2))
+        if j > 1
+            val = 0.5*√(S*(S + 1) - (S - j + 1)*(S - j + 2))
             op[j-1,j] += val*(B[1] - im*B[2])
         end
 
@@ -309,8 +309,8 @@ function add_dipolar_field!(op::Array{ComplexF64, 2}, B::Sunny.Vec3)
         op[j,j] += B[3]*(S - j + 1)
 
         # Superdiagonal
-        if j + 1 < N+1
-            val = 0.5*√(S*(S+1) - (S - j + 1)*(S - j))
+        if j < N
+            val = 0.5*√(S*(S + 1) - (S - j + 1)*(S - j))
             op[j+1,j] += val*(B[1] + im*B[2])
         end
     end

--- a/src/Symmetry/LocalOperators.jl
+++ b/src/Symmetry/LocalOperators.jl
@@ -155,10 +155,10 @@ function accum_spin_matrices!(acc, B::Sunny.Vec3)
     for j in 1:N-1
         off = sqrt(2(S+1)*j - j*(j+1)) / 2
         acc[j,j+1] += off*(B[1] - im*B[2]) # superdiagonal
-        acc[j,j]   += B[3]*(S - (j-1))     # diagonal
+        acc[j,j]   += (S - (j-1))*B[3]     # diagonal
         acc[j+1,j] += off*(B[1] + im*B[2]) # subdiagonal
     end
-    acc[N, N] += B[3]*(S - (N-1))
+    acc[N, N] += (S - (N-1))*B[3]
 
     return nothing
 end

--- a/src/Symmetry/LocalOperators.jl
+++ b/src/Symmetry/LocalOperators.jl
@@ -148,7 +148,7 @@ function spin_matrices(N::Int)
 end
 
 # Accumulates BᵅSᵅ into N×N matrix `acc`.
-function add_dipolar_field!(acc, B::Sunny.Vec3)
+function accum_spin_matrices!(acc, B::Sunny.Vec3)
     N = size(acc, 1)
     S = (N-1)/2
 

--- a/src/Symmetry/LocalOperators.jl
+++ b/src/Symmetry/LocalOperators.jl
@@ -147,6 +147,33 @@ function spin_matrices(N::Int)
     return SVector{3}(Sx, Sy, Sz)
 end
 
+# Adds B ⋅ 𝐒 to `op`.
+function add_dipolar_field!(op::Array{ComplexF64, 2}, B::Sunny.Vec3)
+    N = size(op, 1)
+    S = (N-1)/2
+
+    # Note indexing by column (hence using conjugate of standard formula)
+    @inbounds for j in 1:N
+        # Subdiagonal
+        if j > 1
+            val = 0.5*√(S*(S + 1) - (S - j + 1)*(S - j + 2))
+            op[j-1,j] += val*(B[1] - im*B[2])
+        end
+
+        # Diagonal
+        op[j,j] += B[3]*(S - j + 1)
+
+        # Superdiagonal
+        if j < N
+            val = 0.5*√(S*(S + 1) - (S - j + 1)*(S - j))
+            op[j+1,j] += val*(B[1] + im*B[2])
+        end
+    end
+
+    nothing
+end
+
+
 # Construct Stevens operators as polynomials in the spin operators.
 function stevens_matrices(k::Int; N::Int)
     if k >= N

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -149,14 +149,3 @@ function time_real_fourier_dipole()
     return real_times, ft_times
 end
 
-
-@testitem "Sparse B⋅𝐒" begin
-    
-    # Test that action `add_dipolar_field!(op, B)` is identical to adding B⋅𝐒 to `op`
-    for N = 4:6
-        op = zeros(ComplexF64, N, N)
-        B = randn(Sunny.Vec3)
-        Sunny.add_dipolar_field!(op, B)
-        @test op ≈ sum(Sunny.spin_matrices(N) .* B)
-    end
-end

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -1,6 +1,7 @@
 @testitem "Dynamics" begin
 include("test_shared.jl")
 
+
 "Tests that SphericalMidpoint conserves energy for simple forces to a certain tolerance."
 function test_spherical_midpoint()
     crystal = Sunny.diamond_crystal()
@@ -147,4 +148,16 @@ function time_real_fourier_dipole()
         push!(ft_times, t)
     end
     return real_times, ft_times
+end
+
+
+@testitem "Sparse B⋅𝐒" begin
+    
+    # Test that action `add_dipolar_field!(op, B)` is identical to adding B⋅𝐒 to `op`
+    for N = 4:6
+        op = zeros(ComplexF64, N, N)
+        B = randn(Sunny.Vec3)
+        Sunny.add_dipolar_field!(op, B)
+        @test op ≈ sum(Sunny.spin_matrices(N) .* B)
+    end
 end

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -1,7 +1,6 @@
 @testitem "Dynamics" begin
 include("test_shared.jl")
 
-
 "Tests that SphericalMidpoint conserves energy for simple forces to a certain tolerance."
 function test_spherical_midpoint()
     crystal = Sunny.diamond_crystal()

--- a/test/test_spin_scaling.jl
+++ b/test/test_spin_scaling.jl
@@ -140,7 +140,7 @@ function test_energy_scaling_gsd()
     for N in Ns
         for (interaction, power) in zip(interactions_gsd, powers_gsd)
             spin_rescalings = 5.0 * rand(num_rescalings)
-            for spin_rescaling ∈ spin_rescalings
+            for spin_rescaling in spin_rescalings
                 sys = SpinSystem(cryst, [interaction], dims, [SiteInfo(1; N)])
                 rand!(sys)
                 E₀ = energy(sys)

--- a/test/test_spin_scaling.jl
+++ b/test/test_spin_scaling.jl
@@ -125,7 +125,7 @@ test_energy_scaling_lld()
 
 
 function test_energy_scaling_gsd()
-    N = 5
+    Ns = [5, 6]
     num_rescalings = 2    # number of rescalings to try
 
     cryst = Sunny.fcc_crystal()
@@ -137,20 +137,22 @@ function test_energy_scaling_gsd()
                         anisotropy(Λ, 1)]
     powers_gsd = [2, 1]
 
-    for (interaction, power) in zip(interactions_gsd, powers_gsd)
-        spin_rescalings = 5.0 * rand(num_rescalings)
-        for spin_rescaling ∈ spin_rescalings
-            sys = SpinSystem(cryst, [interaction], dims, [SiteInfo(1; N)])
-            rand!(sys)
-            E₀ = energy(sys)
+    for N in Ns
+        for (interaction, power) in zip(interactions_gsd, powers_gsd)
+            spin_rescalings = 5.0 * rand(num_rescalings)
+            for spin_rescaling ∈ spin_rescalings
+                sys = SpinSystem(cryst, [interaction], dims, [SiteInfo(1; N)])
+                rand!(sys)
+                E₀ = energy(sys)
 
-            Z₀ = copy(sys._coherents)
-            sys = SpinSystem(cryst, [interaction], dims, [SiteInfo(1; N, spin_rescaling)])
-            sys._coherents .= Z₀
-            Sunny.set_expected_spins!(sys)
-            E₁ = energy(sys)
+                Z₀ = copy(sys._coherents)
+                sys = SpinSystem(cryst, [interaction], dims, [SiteInfo(1; N, spin_rescaling)])
+                sys._coherents .= Z₀
+                Sunny.set_expected_spins!(sys)
+                E₁ = energy(sys)
 
-            @test (E₁/E₀) ≈ spin_rescaling^power
+                @test (E₁/E₀) ≈ spin_rescaling^power
+            end
         end
     end
 end

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -160,6 +160,15 @@ end
     end    
 end
 
+@testitem "Sparse B⋅𝐒" begin
+    # Test that action `add_dipolar_field!(op, B)` is identical to adding B⋅𝐒 to `op`
+    for N = 4:6
+        op = zeros(ComplexF64, N, N)
+        B = randn(Sunny.Vec3)
+        Sunny.add_dipolar_field!(op, B)
+        @test op ≈ sum(Sunny.spin_matrices(N) .* B)
+    end
+end
 
 @testitem "Spherical tensors" begin
     include("test_shared.jl")

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -161,12 +161,12 @@ end
 end
 
 @testitem "Sparse B⋅𝐒" begin
-    # Test that action `add_dipolar_field!(op, B)` is identical to adding B⋅𝐒 to `op`
+    # Test that action `accum_spin_matrices!(acc, B)` is identical to adding B⋅𝐒 to `acc`
     for N = 4:6
-        op = zeros(ComplexF64, N, N)
+        acc = zeros(ComplexF64, N, N)
         B = randn(Sunny.Vec3)
-        Sunny.add_dipolar_field!(op, B)
-        @test op ≈ sum(Sunny.spin_matrices(N) .* B)
+        Sunny.accum_spin_matrices!(acc, B)
+        @test acc ≈ sum(Sunny.spin_matrices(N) .* B)
     end
 end
 


### PR DESCRIPTION
Removes the need to keep the spin matrices in memory for N > 5. Instead adds a function called `add_dipolar_field!(op::Array{ComplexF64, 2}, B::Vec3` which adds `B ⋅ S` to `op` by constructing the relevant matrix elements of the spin matrices on the fly. For N=6 this is marginally faster than keeping the matrices stored (3-5%). I also tried N=10, where it was about 10% faster than storing the matrices. So it seems like this is a reasonable approach to dealing with the N > 5 case, at least for now.

I added a test that ensures this function does what it should. I also added an `N=6` case to the spin rescaling tests, so that the `N > 5` case is at least run during routine testing.

