### PR TITLE
Avoid all use of `deepcopy`

### DIFF
--- a/src/ReplicaExchangeMC.jl
+++ b/src/ReplicaExchangeMC.jl
@@ -92,7 +92,7 @@ function replica_exchange!(replica::Replica)
     S_curr = running_energy(replica.sampler) / get_temp(replica.sampler)
 
     # Backup current configuration
-    backup_spins = deepcopy(replica.sampler.sys.dipoles)
+    backup_spins = copy(replica.sampler.sys.dipoles)
 
     # Swap trial configuration with partner
     MPI.Sendrecv!(

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -27,6 +27,12 @@ function Ewald(sys::System{N}) where N
     return Ewald(A, ϕ, FA, Fs, Fϕ, plan, ift_plan)
 end
 
+# Clone all mutable state within Ewald. Note that `A`, `FA`, and plans should be
+# immutable data.
+function clone_ewald(ewald::Ewald)
+    (; A, ϕ, FA, Fs, Fϕ, plan, ift_plan) = ewald
+    return Ewald(A, copy(ϕ), FA, copy(Fs), copy(Fϕ), plan, ift_plan)
+end
 
 # Tensor product of 3-vectors
 (⊗)(a::Vec3,b::Vec3) = reshape(kron(a,b), 3, 3)

--- a/test/mc_tests/REMC_H_Ising2D.jl
+++ b/test/mc_tests/REMC_H_Ising2D.jl
@@ -46,7 +46,7 @@ replica = Replica(IsingSampler(system, kT, 1), α)
 #  the sampling distribution or the system
 function set_α!(replica::Replica, α::Float64)
     replica.α = α
-    copy_sites = deepcopy(replica.sampler.system.sites)
+    copy_sites = copy(replica.sampler.system.sites)
     replica.sampler.system = create_system(α)
     replica.sampler.system.sites .= copy_sites
     reset_running_energy!(replica.sampler)

--- a/test/test_energy_consistency.jl
+++ b/test/test_energy_consistency.jl
@@ -8,7 +8,7 @@
         add_linear_interactions!(sys, mode)
         add_quadratic_interactions!(sys, mode)
         add_quartic_interactions!(sys, mode)
-        # enable_dipole_dipole!(sys) # workaround segfault
+        enable_dipole_dipole!(sys)
 
         # Random field
         for idx in Sunny.all_sites(sys)
@@ -18,16 +18,19 @@
         rand!(sys.rng, sys.κs)
         # Random spins
         randomize_spins!(sys)
-        # Make inhomogeneous
-        if inhomog
-            sys = to_inhomogeneous(sys)
-            set_vacancy_at!(sys, (1,1,1,1))
-            set_exchange_at!(sys, 0.5, Bond(1, 2, [1,0,0]), (1,1,1,1))
-            set_biquadratic_at!(sys, 0.7, Bond(2, 3, [0,-1,0]), (3,1,1,2))
-            set_anisotropy_at!(sys, 0.4*(𝒮[1]^4+𝒮[2]^4+𝒮[3]^4), (2,2,2,4))
-        end
 
-        return sys
+        if !inhomog
+            return sys
+        else
+            # Add some inhomogeneous interactions
+            sys2 = to_inhomogeneous(sys)
+            @test energy(sys2) ≈ energy(sys)
+            set_vacancy_at!(sys2, (1,1,1,1))
+            set_exchange_at!(sys2, 0.5, Bond(1, 2, [1,0,0]), (1,1,1,1))
+            set_biquadratic_at!(sys2, 0.7, Bond(2, 3, [0,-1,0]), (3,1,1,2))
+            set_anisotropy_at!(sys2, 0.4*(𝒮[1]^4+𝒮[2]^4+𝒮[3]^4), (2,2,2,4))
+            return sys2
+        end
     end
 
 


### PR DESCRIPTION
Julia developers Gabriel Baraldi and Jameson Nash pointed out that the use of `deepcopy` can be memory unsafe, especially when used in combination with C datastructures. It appears this was the source of intermittent segfault behavior observed when calling FFTW. (Perhaps the problem was deep-copying an FFTW plan, or perhaps it was some other memory corruption.)

This PR replaces all calls to `deepcopy` with custom clone functions that  perform ordinary `copy` operations on mutable arrays. Hopefully resolves https://github.com/SunnySuite/Sunny.jl/issues/65, originally reported in https://github.com/JuliaLang/julia/issues/48722 .