### PR TITLE
Add SU(N) LSWT to Sunny

### DIFF
--- a/src/SpinWave/SWUtil.jl
+++ b/src/SpinWave/SWUtil.jl
@@ -176,35 +176,35 @@ function construct_magnetic_supercell(sys :: System, A :: Matrix{Int})
     return reshape_geometry_aux(newsys, mag_latsize, mag_cell_size)
 end
 
-"""
-    set_dipoles!
+# """
+#     set_dipoles!
 
-Manually set the ground state configurations by inputing the `dipoles` for all sites along with their `positions` in the magnetic supercell. `dipoles` and `positions` are `3×Nₘ` matrices. Each column of the two objects should match each other. \n
-*Warning*: 1. Must run `construct_magnetic_supercell` before calling this function. 2. You should always use the Langevin sampler provided by Sunny to find the ground state other than calling this function, unless the ground state configuration is known for sure. 3. This function works for `:dipole` and `large_S` mode. For `:SUN` mode, only the fundamental representation of `SU(2)`, i.e. S=1/2 works.
-"""
-function set_dipoles!(sys :: System, dipoles :: Matrix{Float64}, positions :: Matrix{Float64})
-    Ns, Nₘ = sys.Ns[1], length(sys.dipoles)
-    spin = (Ns-1) / 2
-    (sys.mode == :SUN && !isapprox(spin, 0.5, atol=1e-6)) && (throw("SU(N)N>2 not supported, use set_coherents! instead."))
-    @assert sys.latsize == (1, 1, 1) "`sys` is not a valid magnetic supercell, run `construct_magnetic_supercell` first!"
-    @assert size(dipoles, 1) == 3 "dipole should be a 3-vector"
-    @assert size(positions, 1) == 3 "dipole should be a 3-vector"
-    @assert size(dipoles, 2) == Nₘ "number of dipoles does not match `sys`"
-    @assert size(positions, 2) == Nₘ "number of dipoles does not match `sys`"
+# Manually set the ground state configurations by inputing the `dipoles` for all sites along with their `positions` in the magnetic supercell. `dipoles` and `positions` are `3×Nₘ` matrices. Each column of the two objects should match each other. \n
+# *Warning*: 1. Must run `construct_magnetic_supercell` before calling this function. 2. You should always use the Langevin sampler provided by Sunny to find the ground state other than calling this function, unless the ground state configuration is known for sure. 3. This function works for `:dipole` and `large_S` mode. For `:SUN` mode, only the fundamental representation of `SU(2)`, i.e. S=1/2 works.
+# """
+# function set_dipoles!(sys :: System, dipoles :: Matrix{Float64}, positions :: Matrix{Float64})
+#     Ns, Nₘ = sys.Ns[1], length(sys.dipoles)
+#     spin = (Ns-1) / 2
+#     (sys.mode == :SUN && !isapprox(spin, 0.5, atol=1e-6)) && (throw("SU(N)N>2 not supported, use set_coherents! instead."))
+#     @assert sys.latsize == (1, 1, 1) "`sys` is not a valid magnetic supercell, run `construct_magnetic_supercell` first!"
+#     @assert size(dipoles, 1) == 3 "dipole should be a 3-vector"
+#     @assert size(positions, 1) == 3 "dipole should be a 3-vector"
+#     @assert size(dipoles, 2) == Nₘ "number of dipoles does not match `sys`"
+#     @assert size(positions, 2) == Nₘ "number of dipoles does not match `sys`"
     
-    indices = Vector{Int}()
+#     indices = Vector{Int}()
 
-    for i in 1:Nₘ
-        idx = findfirst(isapprox(positions[:, i], atol=1e-8, rtol=1e-10), sys.crystal.positions)
-        @assert !isnothing(idx) "wrong positions for magnetic sites"
-        push!(indices, idx)
-    end
+#     for i in 1:Nₘ
+#         idx = findfirst(isapprox(positions[:, i], atol=1e-8, rtol=1e-10), sys.crystal.positions)
+#         @assert !isnothing(idx) "wrong positions for magnetic sites"
+#         push!(indices, idx)
+#     end
 
-    for i in 1:Nₘ
-        sys.dipoles[1, 1, 1, i] = dipoles[:, indices[i]]
-    end
+#     for i in 1:Nₘ
+#         sys.dipoles[1, 1, 1, i] = dipoles[:, indices[i]]
+#     end
 
-end
+# end
 
 # """
 #     set_coherents!

--- a/src/SpinWave/SWUtil.jl
+++ b/src/SpinWave/SWUtil.jl
@@ -61,7 +61,7 @@ function generate_local_sun_gens(sys :: System)
         end
 
     elseif sys.mode == :dipole
-        s_mat_2 = spin * spin_matrices(2)
+        s_mat_2 = spin_matrices(2)
         s_mat_N = spin_matrices(N)
         
         s̃_mat = Array{ComplexF64, 4}(undef, 2, 2, 3, Nₘ)
@@ -113,7 +113,7 @@ External constructor for `SpinWaveFields`
 function SpinWaveFields(sys :: System, energy_ϵ :: Float64=1e-8, energy_tol :: Float64=1e-6)
     s̃_mat, T̃_mat = generate_local_sun_gens(sys)
     Q̃_mat = zeros(ComplexF64, 0, 0, 0, 0)
-    maglat_basis = sys.origin.crystal.lat_vecs \ sys.crystal.lat_vecs
+    maglat_basis = isnothing(sys.origin) ? diagm(ones(3)) : sys.origin.crystal.latvecs \ sys.crystal.latvecs
 
     Nₘ = length(sys.dipoles)
     chemical_positions = Vector{Vec3}(undef, Nₘ)
@@ -131,12 +131,12 @@ function SpinWaveFields(sys :: System, energy_ϵ :: Float64=1e-8, energy_tol :: 
     maglat_reciprocal_basis = Mat3(maglat_reciprocal_basis)
 
     # computes the reciprocal basis vectors of the chemical lattice (units Å⁻¹)
-    lat_vecs = sys.origin.crystal.lat_vecs
-    det_A = det(lat_vecs')
+    latvecs = isnothing(sys.origin) ? diagm(ones(3)) : sys.origin.crystal.latvecs
+    det_A = det(latvecs')
     chemic_reciprocal_basis = zeros(Float64, 3, 3)
-    chemic_reciprocal_basis[:, 1] = cross(lat_vecs[:, 2], lat_vecs[:, 3]) / det_A
-    chemic_reciprocal_basis[:, 2] = cross(lat_vecs[:, 3], lat_vecs[:, 1]) / det_A
-    chemic_reciprocal_basis[:, 3] = cross(lat_vecs[:, 1], lat_vecs[:, 2]) / det_A
+    chemic_reciprocal_basis[:, 1] = cross(latvecs[:, 2], latvecs[:, 3]) / det_A
+    chemic_reciprocal_basis[:, 2] = cross(latvecs[:, 3], latvecs[:, 1]) / det_A
+    chemic_reciprocal_basis[:, 3] = cross(latvecs[:, 1], latvecs[:, 2]) / det_A
     chemic_reciprocal_basis = Mat3(chemic_reciprocal_basis)
 
     return SpinWaveFields(sys, s̃_mat, T̃_mat, Q̃_mat, chemical_positions, chemic_reciprocal_basis, maglat_reciprocal_basis, energy_ϵ, energy_tol)

--- a/src/SpinWave/SWUtil.jl
+++ b/src/SpinWave/SWUtil.jl
@@ -1,0 +1,238 @@
+###########################################################################
+# Below takes Sunny to construct `SpinWaveFields` for LSWT calculations.  #
+###########################################################################
+
+"""
+Additional fields for linear spin-wave calculations.
+"""
+struct SpinWaveFields
+    sys   :: Sunny.System
+    s̃_mat :: Array{ComplexF64, 4}  # dipole operators
+    T̃_mat :: Array{ComplexF64, 3}  # single-ion anisos
+    Q̃_mat :: Array{ComplexF64, 4}  # quarupolar operators (for biquad only)
+    chemical_positions :: Vector{Sunny.Vec3} # positions of magnetic atoms in units of (a₁, a₂, a₃) of the chemical lattice. (useful when computing the dynamical spin structure factor)
+    chemic_reciprocal_basis :: Sunny.Mat3 # maybe not useful if we have David's interface for S(q, ω)
+    maglat_reciprocal_basis :: Sunny.Mat3 # reciprocal lattice basis vectors for the magnetic supercell
+    energy_ϵ   :: Float64 # energy epsilon in the diagonalization. Set to add to diagonal elements of the spin-wave Hamiltonian for cholesky decompostion
+    energy_tol :: Float64 # energy tolerance for maximal imaginary part of spin-wave energies
+end
+
+
+"""
+    dipole_to_angles
+
+convert the dipole expectation values from the Cartesian frame to the spherical frame
+"""
+function dipole_to_angles(dipoles :: AbstractVector{Float64})
+    r = norm(dipoles)
+    @assert r > 1e-7
+    θ = acos(dipoles[3] / r)
+    @assert isfinite(θ)
+    ϕ = atan(dipoles[2], dipoles[1])
+    @assert isfinite(ϕ)
+    (ϕ < 0.0) && (ϕ += 2.0 * π)
+    return θ, ϕ
+end
+
+"""
+    generate_local_sun_gens
+
+Compute SU(N) generators in the local reference frame.
+"""
+function generate_local_sun_gens(sys :: Sunny.System)
+    Nₘ, N = length(sys.dipoles), sys.Ns[1] # number of magnetic atoms and dimension of Hilbert space
+    spin  = (N-1)/2
+    if sys.mode == :SUN
+        s_mat = Sunny.spin_matrices(N)
+
+        s̃_mat = Array{ComplexF64, 4}(undef, N, N, 3, Nₘ)
+        T̃_mat = Array{ComplexF64, 3}(undef, N, N, Nₘ)
+
+        U_mat = Matrix{ComplexF64}(undef, N, N)
+
+        for site = 1:Nₘ
+            U_mat[:, 1] = sys.coherents[1, 1, 1, site]
+            U_mat[:, 2:N] = nullspace(U_mat[:, 1]')
+            @assert isapprox(U_mat * U_mat', I) "rotation matrix from (global frame to local frame) not unitary"
+            for μ = 1:3
+                s̃_mat[:, :, μ, site] = Hermitian(U_mat' * s_mat[μ] * U_mat)
+            end
+            T̃_mat[:, :, site] = Hermitian(U_mat' * sys.interactions.anisos[site].matrep * U_mat)
+        end
+
+    elseif sys.mode == :dipole
+        s_mat_2 = spin * Sunny.spin_matrices(2)
+        s_mat_N = Sunny.spin_matrices(N)
+        
+        s̃_mat = Array{ComplexF64, 4}(undef, 2, 2, 3, Nₘ)
+        T̃_mat = Array{ComplexF64, 3}(undef, 2, 2, Nₘ)
+
+        U_mat_2 = Matrix{ComplexF64}(undef, 2, 2)
+        U_mat_N = Matrix{ComplexF64}(undef, N, N)
+
+        for site = 1:Nₘ
+            θ, ϕ = dipole_to_angles(sys.dipoles[1, 1, 1, site])
+            U_mat_N[:] = exp(-1im * ϕ * s_mat_N[3]) * exp(-1im * θ * s_mat_N[2])
+            U_mat_2[:] = exp(-1im * ϕ * s_mat_2[3]) * exp(-1im * θ * s_mat_2[2])
+            @assert isapprox(U_mat_N * U_mat_N', I) "rotation matrix from (global frame to local frame) not unitary"
+            @assert isapprox(U_mat_2 * U_mat_2', I) "rotation matrix from (global frame to local frame) not unitary"
+            for μ = 1:3
+                s̃_mat[:, :, μ, site] = Hermitian(U_mat_2' * s_mat_2[μ] * U_mat_2)
+            end
+            T̃_mat[:, :, site] = Hermitian(U_mat_N' * sys.interactions.anisos[site].matrep * U_mat_N)[1:2, 1:2]
+        end
+    
+    # here I need help from Kipton and David to map back the solution, because in general this is difficult to implement.
+    elseif sys.mode == :large_S
+        error("unsupported")
+        # spin  = (N-1) / 2
+        # s_mat_2 = spin * Sunny.spin_matrices(2)
+
+        # s̃_mat = Array{ComplexF64, 4}(undef, 2, 2, 3, Nₘ)
+        # T̃_mat = Array{ComplexF64, 3}(undef, 2, 2, Nₘ)
+
+        # U_mat_2 = Matrix{ComplexF64}(undef, 2, 2)
+
+        # for site = 1:Nₘ
+        #     θ, ϕ = dipole_to_angles(sys.dipoles[1, 1, 1, site])
+        #     U_mat_2[:] = exp(-1im * ϕ * s_mat_2[3]) * exp(-1im * θ * s_mat_2[2])
+        #     @assert isapprox(U_mat_2 * U_mat_2', I) "rotation matrix from (global frame to local frame) not unitary"
+        #     for μ = 1:3
+        #         s̃_mat[:, :, μ, site] = Hermitian(U_mat_2' * s_mat_2[μ] * U_mat_2)
+        #     end
+        #     # T̃_mat[:, :, site] = Hermitian(U_mat_N' * sys.interactions.anisos[site].matrep * U_mat_N)[1:2, 1:2]
+        # end
+    end
+
+    return s̃_mat, T̃_mat
+end
+
+"""
+External constructor for `SpinWaveFields`
+"""
+function SpinWaveFields(sys :: Sunny.System, energy_ϵ :: Float64=1e-8, energy_tol :: Float64=1e-6)
+    s̃_mat, T̃_mat = generate_local_sun_gens(sys)
+    Q̃_mat = zeros(ComplexF64, 0, 0, 0, 0)
+    maglat_basis = sys.origin.crystal.lat_vecs \ sys.crystal.lat_vecs
+
+    Nₘ = length(sys.dipoles)
+    chemical_positions = Vector{Sunny.Vec3}(undef, Nₘ)
+    for site = 1:Nₘ
+        tmp_pos = maglat_basis * sys.crystal.positions[site]
+        chemical_positions[site] = Sunny.Vec3(tmp_pos)
+    end
+
+    # computes the reciprocal basis vectors of the magnetic lattice (units 2π/|a|)
+    det_A = det(maglat_basis')
+    maglat_reciprocal_basis = zeros(Float64, 3, 3)
+    maglat_reciprocal_basis[:, 1] = cross(maglat_basis[:, 2], maglat_basis[:, 3]) / det_A
+    maglat_reciprocal_basis[:, 2] = cross(maglat_basis[:, 3], maglat_basis[:, 1]) / det_A
+    maglat_reciprocal_basis[:, 3] = cross(maglat_basis[:, 1], maglat_basis[:, 2]) / det_A
+    maglat_reciprocal_basis = Sunny.Mat3(maglat_reciprocal_basis)
+
+    # computes the reciprocal basis vectors of the chemical lattice (units Å⁻¹)
+    lat_vecs = sys.origin.crystal.lat_vecs
+    det_A = det(lat_vecs')
+    chemic_reciprocal_basis = zeros(Float64, 3, 3)
+    chemic_reciprocal_basis[:, 1] = cross(lat_vecs[:, 2], lat_vecs[:, 3]) / det_A
+    chemic_reciprocal_basis[:, 2] = cross(lat_vecs[:, 3], lat_vecs[:, 1]) / det_A
+    chemic_reciprocal_basis[:, 3] = cross(lat_vecs[:, 1], lat_vecs[:, 2]) / det_A
+    chemic_reciprocal_basis = Sunny.Mat3(chemic_reciprocal_basis)
+
+    return SpinWaveFields(sys, s̃_mat, T̃_mat, Q̃_mat, chemical_positions, chemic_reciprocal_basis, maglat_reciprocal_basis, energy_ϵ, energy_tol)
+end
+
+"""
+    k_chemical_to_k_magnetic
+
+Convert the components of a wavevector from the original Brillouin zone (of the chemical lattice) to the reduced Brillouin zone (BZ)
+(of the magnetic lattice). \
+This is necessary because components in the reduced BZ are good quantum numbers.
+`K` is the reciprocal lattice vector, and `k̃` is the components of wavevector in the reduced BZ. Note `k = K + k̃`
+"""
+function k_chemical_to_k_magnetic(sw_fields :: SpinWaveFields, k :: Vector{Float64})
+    k_copy = deepcopy(k)
+    α = sw_fields.maglat_reciprocal_basis \ k_copy
+    k̃ = Vector{Float64}(undef, 3)
+    K = Vector{Int}(undef, 3)
+    for i = 1:3
+        if abs(α[i]) < eps()
+            K[i] = 0.0
+            k̃[i] = 0.0
+        else
+            K[i] = Int(round(floor(α[i])))
+            k̃[i] = α[i] - K[i]
+        end
+        @assert k̃[i] ≥ 0.0 && k̃[i] < 1.0
+    end
+    k_check = sw_fields.maglat_reciprocal_basis * (K + k̃)
+    @assert norm(k - k_check) < 1e-12
+
+    return K, k̃
+end
+
+function construct_magnetic_supercell(sys :: Sunny.System, A :: Matrix{Int})
+    newsys = reshape_geometry(sys, A)
+    mag_latsize = (1, 1, 1)
+    mag_cell_size = Sunny.cell_dimensions(newsys) * diagm(collect(newsys.latsize))
+    return Sunny.reshape_geometry_aux(newsys, mag_latsize, mag_cell_size)
+end
+
+"""
+    set_dipoles!
+
+Manually set the ground state configurations by inputing the `dipoles` for all sites along with their `positions` in the magnetic supercell. `dipoles` and `positions` are `3×Nₘ` matrices. Each column of the two objects should match each other. \n
+*Warning*: 1. Must run `construct_magnetic_supercell` before calling this function. 2. You should always use the Langevin sampler provided by Sunny to find the ground state other than calling this function, unless the ground state configuration is known for sure. 3. This function works for `:dipole` and `large_S` mode. For `:SUN` mode, only the fundamental representation of `SU(2)`, i.e. S=1/2 works.
+"""
+function set_dipoles!(sys :: Sunny.System, dipoles :: Matrix{Float64}, positions :: Matrix{Float64})
+    Ns, Nₘ = sys.Ns[1], length(sys.dipoles)
+    spin = (Ns-1) / 2
+    (sys.mode == :SUN && !isapprox(spin, 0.5, atol=1e-6)) && (throw("SU(N)N>2 not supported, use set_coherents! instead."))
+    @assert sys.latsize == (1, 1, 1) "`sys` is not a valid magnetic supercell, run `construct_magnetic_supercell` first!"
+    @assert size(dipoles, 1) == 3 "dipole should be a 3-vector"
+    @assert size(positions, 1) == 3 "dipole should be a 3-vector"
+    @assert size(dipoles, 2) == Nₘ "number of dipoles does not match `sys`"
+    @assert size(positions, 2) == Nₘ "number of dipoles does not match `sys`"
+    
+    indices = Vector{Int}()
+
+    for i in 1:Nₘ
+        idx = findfirst(isapprox(positions[:, i], atol=1e-8, rtol=1e-10), sys.crystal.positions)
+        @assert !isnothing(idx) "wrong positions for magnetic sites"
+        push!(indices, idx)
+    end
+
+    for i in 1:Nₘ
+        sys.dipoles[1, 1, 1, i] = dipoles[:, indices[i]]
+    end
+
+end
+
+# """
+#     set_coherents!
+
+# Manually set the ground state configurations by inputing the `dipoles` for all sites along with their `positions` in the magnetic supercell. `dipoles` and `positions` are `3×Nₘ` matrices. Each column of the two objects should match each other. \n
+# *Warning*: 1. Must run `construct_magnetic_supercell` before calling this function. 2. You should always use the Langevin sampler provided by Sunny to find the ground state other than calling this function, unless the ground state configuration is known for sure. 3. This function works for `:dipole` and `large_S` mode. For `:SUN` mode, only the fundamental representation of `SU(2)`, i.e. S=1/2 works.
+# """
+# function set_dipoles!(sys :: Sunny.System, dipoles :: Matrix{Float64}, positions :: Matrix{Float64})
+#     Ns, Nₘ = sys.Ns[1], length(sys.dipoles)
+#     spin = (Ns-1) / 2
+#     (sys.mode == :SUN && !isapprox(spin, 0.5, atol=1e-6)) && (throw("SU(N)N>2 not supported, use set_coherents! instead."))
+#     @assert sys.latsize == (1, 1, 1) "`sys` is not a valid magnetic supercell, run `construct_magnetic_supercell` first!"
+#     @assert size(dipoles, 1) == 3 "dipole should be a 3-vector"
+#     @assert size(positions, 1) == 3 "dipole should be a 3-vector"
+#     @assert size(dipoles, 2) == Nₘ "number of dipoles does not match `sys`"
+#     @assert size(positions, 2) == Nₘ "number of dipoles does not match `sys`"
+    
+
+#     indices = Vector{Int}(undef, Nₘ)
+
+#     for i in 1:Nₘ
+#         idx = findfirst(isapprox(positions[i], atol=1e-8, rtol=1e-10), sys.crystal.positions)
+#         @assert !isnothing(idx) "wrong positions for magnetic sites"
+#         push!(indices, idx)
+#     end
+
+#     sys.dipoles = dipoles[indices]
+
+# end

--- a/src/SpinWave/SWUtil.jl
+++ b/src/SpinWave/SWUtil.jl
@@ -1,11 +1,11 @@
 ###########################################################################
-# Below takes Sunny to construct `SpinWaveFields` for LSWT calculations.  #
+# Below takes Sunny to construct `SpinWave` for LSWT calculations.  #
 ###########################################################################
 
 """
 Additional fields for linear spin-wave calculations.
 """
-struct SpinWaveFields
+struct SpinWave
     sys   :: System
     s̃_mat :: Array{ComplexF64, 4}  # dipole operators
     T̃_mat :: Array{ComplexF64, 3}  # single-ion anisos
@@ -106,9 +106,9 @@ function generate_local_sun_gens(sys :: System)
 end
 
 """
-External constructor for `SpinWaveFields`
+External constructor for `SpinWave`
 """
-function SpinWaveFields(sys :: System, energy_ϵ :: Float64=1e-8, energy_tol :: Float64=1e-6)
+function SpinWave(sys :: System, energy_ϵ :: Float64=1e-8, energy_tol :: Float64=1e-6)
     s̃_mat, T̃_mat, Q̃_mat = generate_local_sun_gens(sys)
     maglat_basis = isnothing(sys.origin) ? diagm(ones(3)) : sys.origin.crystal.latvecs \ sys.crystal.latvecs
 
@@ -136,7 +136,7 @@ function SpinWaveFields(sys :: System, energy_ϵ :: Float64=1e-8, energy_tol :: 
     chemic_reciprocal_basis[:, 3] = cross(latvecs[:, 1], latvecs[:, 2]) / det_A
     chemic_reciprocal_basis = Mat3(chemic_reciprocal_basis)
 
-    return SpinWaveFields(sys, s̃_mat, T̃_mat, Q̃_mat, chemical_positions, chemic_reciprocal_basis, maglat_reciprocal_basis, energy_ϵ, energy_tol)
+    return SpinWave(sys, s̃_mat, T̃_mat, Q̃_mat, chemical_positions, chemic_reciprocal_basis, maglat_reciprocal_basis, energy_ϵ, energy_tol)
 end
 
 """
@@ -147,7 +147,7 @@ Convert the components of a wavevector from the original Brillouin zone (of the 
 This is necessary because components in the reduced BZ are good quantum numbers.
 `K` is the reciprocal lattice vector, and `k̃` is the components of wavevector in the reduced BZ. Note `k = K + k̃`
 """
-function k_chemical_to_k_magnetic(sw_fields :: SpinWaveFields, k :: Vector{Float64})
+function k_chemical_to_k_magnetic(sw_fields :: SpinWave, k :: Vector{Float64})
     α = sw_fields.maglat_reciprocal_basis \ k
     k̃ = Vector{Float64}(undef, 3)
     K = Vector{Int}(undef, 3)

--- a/src/SpinWave/SWUtil.jl
+++ b/src/SpinWave/SWUtil.jl
@@ -41,7 +41,6 @@ Compute SU(N) generators in the local reference frame.
 """
 function generate_local_sun_gens(sys :: System)
     Nₘ, N = length(sys.dipoles), sys.Ns[1] # number of magnetic atoms and dimension of Hilbert space
-    spin  = (N-1)/2
     if sys.mode == :SUN
         s_mat = spin_matrices(N)
 
@@ -151,8 +150,7 @@ This is necessary because components in the reduced BZ are good quantum numbers.
 `K` is the reciprocal lattice vector, and `k̃` is the components of wavevector in the reduced BZ. Note `k = K + k̃`
 """
 function k_chemical_to_k_magnetic(sw_fields :: SpinWaveFields, k :: Vector{Float64})
-    k_copy = deepcopy(k)
-    α = sw_fields.maglat_reciprocal_basis \ k_copy
+    α = sw_fields.maglat_reciprocal_basis \ k
     k̃ = Vector{Float64}(undef, 3)
     K = Vector{Int}(undef, 3)
     for i = 1:3

--- a/src/SpinWave/SpinWave.jl
+++ b/src/SpinWave/SpinWave.jl
@@ -29,8 +29,7 @@ function generate_ham_lswt!(sw_fields :: SpinWaveFields, k̃ :: Vector{Float64},
     Hmat12 = zeros(ComplexF64, L, L)
     Hmat21 = zeros(ComplexF64, L, L)
 
-    (; extfield, anisos, pairexch) = sys.interactions
-
+    (; extfield) = sys
     # external field
     for matom = 1:Nm
         @views effB = extfield[1, 1, 1, matom]
@@ -59,10 +58,11 @@ function generate_ham_lswt!(sw_fields :: SpinWaveFields, k̃ :: Vector{Float64},
 
 
     # pairexchange interactions
-    for (; heisen, quadmat, biquad) in pairexch
+    for matom = 1:Nm
+        ints = sys.interactions_union[matom]
         # Heisenberg exchange
-        for (culled, bond, J) in heisen
-            culled && break
+        for (; isculled, bond, J) in ints.heisen
+            isculled && break
             sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
 
             tTi_μ = s̃_mat[:, :, :, sub_i]
@@ -112,8 +112,8 @@ function generate_ham_lswt!(sw_fields :: SpinWaveFields, k̃ :: Vector{Float64},
         end
 
         # Quadratic exchange
-        for (culled, bond, J) in quadmat
-            culled && break
+        for (; isculled, bond, J) in ints.exchange
+            isculled && break
             sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
 
             tTi_μ = s̃_mat[:, :, :, sub_i]

--- a/src/SpinWave/SpinWave.jl
+++ b/src/SpinWave/SpinWave.jl
@@ -1,0 +1,401 @@
+###########################################################################
+# Below are the implementations of the SU(N) linear spin-wave calculations #
+###########################################################################
+
+@inline δ(x, y) = ==(x, y) # my delta function
+
+
+"""
+    generate_ham_lswt!
+
+Update the linear spin-wave Hamiltonian from the exchange interactions.
+Note that `k̃` is a 3-vector, the units of k̃ᵢ is 2π/|ãᵢ|, where |ãᵢ| is the lattice constant of the **magnetic** lattice.
+"""
+function generate_ham_lswt!(sw_fields :: SpinWaveFields, k̃ :: Vector{Float64}, Hmat :: Matrix{ComplexF64})
+    (; sys, s̃_mat, T̃_mat, Q̃_mat) = sw_fields
+    Nm, Ns = length(sys.dipoles), sys.Ns[1] # number of magnetic atoms and dimension of Hilbert space
+    Nf = sys.mode == :SUN ? Ns-1 : 1
+    N  = Nf + 1
+    L  = Nf * Nm
+    @assert size(Hmat) == (2*L, 2*L)
+
+    for k̃ᵢ in k̃
+        (k̃ᵢ < 0.0 || k̃ᵢ ≥ 1.0) && throw("k̃ outside [0, 1) range")
+    end
+
+    # block matrices of `Hmat`
+    Hmat11 = zeros(ComplexF64, L, L)
+    Hmat22 = zeros(ComplexF64, L, L)
+    Hmat12 = zeros(ComplexF64, L, L)
+    Hmat21 = zeros(ComplexF64, L, L)
+
+    (; extfield, anisos, pairexch) = sys.interactions
+
+    # external field
+    for matom = 1:Nm
+        @views effB = extfield[1, 1, 1, matom]
+        @views site_tS = s̃_mat[:, :, :, matom]
+        site_B_dot_tS  = - effB[1] * site_tS[:, :, 1] - effB[2] * site_tS[:, :, 2] - effB[3] * site_tS[:, :, 3]
+        for m = 2:N
+            for n = 2:N
+                δmn = δ(m, n)
+                Hmat[(matom-1)*Nf+m-1,   (matom-1)*Nf+n-1]   += 0.5 * (site_B_dot_tS[m, n] - δmn * site_B_dot_tS[1, 1])
+                Hmat[(matom-1)*Nf+n-1+L, (matom-1)*Nf+m-1+L] += 0.5 * (site_B_dot_tS[m, n] - δmn * site_B_dot_tS[1, 1])
+            end
+        end
+    end
+
+    # single-ion anisotropy
+    for matom = 1:Nm
+        @views site_aniso = T̃_mat[:, :, matom]
+        for m = 2:N
+            for n = 2:N
+                δmn = δ(m, n)
+                Hmat[(matom-1)*Nf+m-1,   (matom-1)*Nf+n-1]   += 0.5 * (site_aniso[m, n] - δmn * site_aniso[1, 1])
+                Hmat[(matom-1)*Nf+n-1+L, (matom-1)*Nf+m-1+L] += 0.5 * (site_aniso[m, n] - δmn * site_aniso[1, 1])
+            end
+        end
+    end
+
+
+    # pairexchange interactions
+    for (; heisen, quadmat, biquad) in pairexch
+        # Heisenberg exchange
+        for (culled, bond, J) in heisen
+            culled && break
+            sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
+
+            tTi_μ = s̃_mat[:, :, :, sub_i]
+            tTj_ν = s̃_mat[:, :, :, sub_j]
+            phase  = exp(2im * π * dot(k̃, ΔRδ))
+            cphase = conj(phase)
+            sub_i_M1, sub_j_M1 = sub_i - 1, sub_j - 1
+
+            for m = 2:N
+                mM1 = m - 1
+                T_μ_11 = conj(tTi_μ[1, 1, :])
+                T_μ_m1 = conj(tTi_μ[m, 1, :])
+                T_μ_1m = conj(tTi_μ[1, m, :])
+                T_ν_11 = tTj_ν[1, 1, :]
+
+                for n = 2:N
+                    nM1 = n - 1
+                    δmn = δ(m, n)
+                    T_μ_mn, T_ν_mn = conj(tTi_μ[m, n, :]), tTj_ν[m, n, :]
+                    T_ν_n1 = tTj_ν[n, 1, :]
+                    T_ν_1n = tTj_ν[1, n, :]
+
+                    c1 = J * dot(T_μ_mn - δmn * T_μ_11, T_ν_11)
+                    c2 = J * dot(T_μ_11, T_ν_mn - δmn * T_ν_11)
+                    c3 = J * dot(T_μ_m1, T_ν_1n)
+                    c4 = J * dot(T_μ_1m, T_ν_n1)
+                    c5 = J * dot(T_μ_m1, T_ν_n1)
+                    c6 = J * dot(T_μ_1m, T_ν_1n)
+
+                    Hmat11[sub_i_M1*Nf+mM1, sub_i_M1*Nf+nM1] += 0.5 * c1
+                    Hmat11[sub_j_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c2
+                    Hmat22[sub_i_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c1
+                    Hmat22[sub_j_M1*Nf+nM1, sub_j_M1*Nf+mM1] += 0.5 * c2
+
+                    Hmat11[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c3 * phase
+                    Hmat22[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c3 * cphase
+                    
+                    Hmat22[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c4 * phase
+                    Hmat11[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c4 * cphase
+
+                    Hmat12[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c5 * phase
+                    Hmat12[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c5 * cphase
+                    Hmat21[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c6 * phase
+                    Hmat21[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c6 * cphase
+                end
+            end
+        end
+
+        # Quadratic exchange
+        for (culled, bond, J) in quadmat
+            culled && break
+            sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
+
+            tTi_μ = s̃_mat[:, :, :, sub_i]
+            tTj_ν = s̃_mat[:, :, :, sub_j]
+            phase  = exp(2im * π * dot(k̃, ΔRδ))
+            cphase = conj(phase)
+            sub_i_M1, sub_j_M1 = sub_i - 1, sub_j - 1
+
+            for m = 2:N
+                mM1 = m - 1
+                T_μ_11 = conj(tTi_μ[1, 1, :])
+                T_μ_m1 = conj(tTi_μ[m, 1, :])
+                T_μ_1m = conj(tTi_μ[1, m, :])
+                T_ν_11 = tTj_ν[1, 1, :]
+
+                for n = 2:N
+                    nM1 = n - 1
+                    δmn = δ(m, n)
+                    T_μ_mn, T_ν_mn = conj(tTi_μ[m, n, :]), tTj_ν[m, n, :]
+                    T_ν_n1 = tTj_ν[n, 1, :]
+                    T_ν_1n = tTj_ν[1, n, :]
+
+                    c1 = dot(T_μ_mn - δmn * T_μ_11, J, T_ν_11)
+                    c2 = dot(T_μ_11, J, T_ν_mn - δmn * T_ν_11)
+                    c3 = dot(T_μ_m1, J, T_ν_1n)
+                    c4 = dot(T_μ_1m, J, T_ν_n1)
+                    c5 = dot(T_μ_m1, J, T_ν_n1)
+                    c6 = dot(T_μ_1m, J, T_ν_1n)
+
+                    Hmat11[sub_i_M1*Nf+mM1, sub_i_M1*Nf+nM1] += 0.5 * c1
+                    Hmat11[sub_j_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c2
+                    Hmat22[sub_i_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c1
+                    Hmat22[sub_j_M1*Nf+nM1, sub_j_M1*Nf+mM1] += 0.5 * c2
+
+                    Hmat11[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c3 * phase
+                    Hmat22[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c3 * cphase
+                    
+                    Hmat22[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c4 * phase
+                    Hmat11[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c4 * cphase
+
+                    Hmat12[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c5 * phase
+                    Hmat12[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c5 * cphase
+                    Hmat21[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c6 * phase
+                    Hmat21[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c6 * cphase
+                end
+            end
+        end
+    end
+
+    Hmat[1:L, 1:L] += Hmat11
+    Hmat[L+1:2*L, L+1:2*L] += Hmat22
+    Hmat[1:L, L+1:2*L] += Hmat12
+    Hmat[L+1:2*L, 1:L] += Hmat21
+
+    # Hmat must be hermitian up to round-off errors
+    if norm(Hmat-Hmat') > 1.0e-12
+        println("norm(Hmat-Hmat')= ", norm(Hmat-Hmat'))
+        throw("Hmat is not hermitian!")
+    end
+    
+    # make Hmat exactly hermitian for cholesky decomposition.
+    Hmat[:, :] = (0.5 + 0.0im) * (Hmat + Hmat')
+
+    # add tiny part to the diagonal elements for cholesky decomposition.
+    for ii = 1:2*L
+        Hmat[ii, ii] += sw_fields.energy_ϵ
+    end
+end
+
+"""
+    bogoliubov!
+
+Bogoliubov transformation that diagonalizes a bosonic Hamiltonian. 
+See Colpa JH. *Diagonalization of the quadratic boson hamiltonian* 
+Physica A: Statistical Mechanics and its Applications, 1978 Sep 1;93(3-4):327-53.
+"""
+function bogoliubov!(disp :: Vector{Float64}, V :: Matrix{ComplexF64}, Hmat :: Matrix{ComplexF64}, energy_tol :: Float64, mode_fast :: Bool = false)
+    @assert size(Hmat, 1) == size(Hmat, 2) "Hmat is not a square matrix"
+    @assert size(Hmat, 1) % 2 == 0 "dimension of Hmat is not even"
+
+    L = size(Hmat, 1) ÷ 2
+    (length(disp) != L) && (resize!(disp, L))
+
+    Σ = diagm([ones(ComplexF64, L); -ones(ComplexF64, L)])
+
+    if (!mode_fast)
+        eigval_check = eigen(Σ * Hmat).values
+        @assert all(<(energy_tol), abs.(imag(eigval_check))) "Matrix contains complex eigenvalues with imaginary part larger than `energy_tol`= "*string(energy_tol)*"(`sw_fields.coherent_states` not a classical ground state of the Hamiltonian)"
+
+        eigval_check = eigen(Hmat).values
+        @assert all(>(1e-12), real(eigval_check)) "Matrix not positive definite (`sw_fields.coherent_states` not a classical ground state of the Hamiltonian)"
+    end
+
+    K = cholesky(Hmat).U
+    @assert mode_fast || norm(K' * K - Hmat) < 1e-12 "Cholesky fails"
+
+    T = K * Σ * K'
+    eigval, U = eigen(Hermitian(T + T') / 2)
+
+    @assert mode_fast || norm(U * U' - I) < 1e-10 "Orthonormality fails"
+
+    # sort eigenvalues and eigenvectors
+    eigval = real(eigval)
+    # sort eigenvalues in descending order
+    index  = sortperm(eigval, rev=true)
+    eigval = eigval[index]
+    U = U[:, index]
+    for i = 1:2*L
+        if (i ≤ L && eigval[i] < 0.0) || (i > L && eigval[i] > 0.0)
+            error("Matrix not positive definite (`sw_fields.coherent_states` not a classical ground state of the Hamiltonian)")
+        end
+        pref = i ≤ L ? √(eigval[i]) : √(-eigval[i])
+        U[:, i] .*= pref
+    end
+
+    for col = 1:2*L
+        normalize!(U[:, col])
+    end
+
+    V[:] = K \ U
+
+    if (!mode_fast)
+        E_check = V' * Hmat * V
+        [E_check[i, i] -= eigval[i] for i = 1:L]
+        [E_check[i, i] += eigval[i] for i = L+1:2*L]
+        @assert all(<(1e-8), abs.(E_check)) "Eigenvectors check fails (Bogoliubov matrix `V` are not normalized!)"
+        @assert all(<(1e-6), abs.(V' * Σ * V - Σ)) "Para-renormalization check fails (Boson commutatition relations not preserved after the Bogoliubov transformation!)"
+    end
+
+    # The linear spin-wave dispersion also in descending order.
+    return [disp[i] = 2.0 * eigval[i] for i = 1:L]
+
+end
+
+"""
+    lswt_dispersion_relation
+
+Computes the spin excitation energy dispersion relations given a `SpinWaveField` and `k`. Note that `k` is a 3-vector, the units of kᵢ is 2π/|aᵢ|, where |aᵢ| is the lattice constant of the **chemical** lattice.
+"""
+function lswt_dispersion_relation(sw_fields :: SpinWaveFields, k :: Vector{Float64})
+    K, k̃ = k_chemical_to_k_magnetic(sw_fields, k)
+    (; sys) = sw_fields
+    Nm, Ns = length(sys.dipoles), sys.Ns[1] # number of magnetic atoms and dimension of Hilbert space
+    Nf = sys.mode == :SUN ? Ns-1 : 1
+    N  = Nf + 1
+    L  = Nf * Nm
+
+    Hmat = zeros(ComplexF64, 2*L, 2*L)
+    generate_ham_lswt!(sw_fields, k̃, Hmat)
+
+    disp = zeros(Float64, L)
+    V    = zeros(ComplexF64, 2*L, 2*L)
+    bogoliubov!(disp, V, Hmat, sw_fields.energy_tol)
+
+    return disp
+end
+
+"""
+    lswt_dynamical_spin_structure_factor
+
+Computes the dynamical spin structure factor: \n
+    𝒮ᵅᵝ(k, ω) = 1/(2πN)∫dω ∑ₖ exp[i(ωt - k⋅r)] ⟨Sᵅ(r, t)Sᵝ(0, 0)⟩ \n
+For spin-wave theory at the linear level
+    𝒮ᵅᵝ(k, ω) = ∑ₙ |Aₙᵅᵝ(k)|²δ[ω-ωₙ(k)]. \n
+
+The output is a `n×9` dimensional matrix that hold |Aₙᵅᵝ(k)|², where `n` is the band index. \n
+Sαβ_matrix[:, 1:3] → xx, yy, zz. \n 
+Sαβ_matrix[:, 4:6] → 2*real(xy+yx), 2*real(yz+zy), 2*real(zx+xz). \n 
+Sαβ_matrix[:, 7:9] → 2*imag(xy-yx), 2*imag(yz-zy), 2*imag(zx-xz). \n 
+Note that `k` is a 3-vector, the units of kᵢ is 2π/|aᵢ|, where |aᵢ| is the lattice constant of the **chemical** lattice.
+"""
+function lswt_dynamical_spin_structure_factor!(sw_fields :: SpinWaveFields, k :: Vector{Float64}, disp :: Vector{Float64}, Sαβ_matrix :: Matrix{Float64})
+
+    K, k̃ = k_chemical_to_k_magnetic(sw_fields, k)
+    (; sys, chemical_positions) = sw_fields
+    Nm, Ns = length(sys.dipoles), sys.Ns[1] # number of magnetic atoms and dimension of Hilbert space
+    Nf = sys.mode == :SUN ? Ns-1 : 1
+    N  = Nf + 1
+    L  = Nf * Nm
+    (; s̃_mat) = sw_fields
+
+    Hmat = zeros(ComplexF64, 2*L, 2*L)
+    generate_ham_lswt!(sw_fields, k̃, Hmat)
+
+    Vmat = zeros(ComplexF64, 2*L, 2*L)
+    bogoliubov!(disp, Vmat, Hmat, sw_fields.energy_tol)
+
+    if size(Sαβ_matrix, 1) != L || size(Sαβ_matrix, 2) != 9
+        reshape(Sαβ_matrix, (L, 9))
+    end
+    fill!(Sαβ_matrix, 0.0)
+
+    Avec_pref = zeros(ComplexF64, Nm)
+    sqrt_Nm_inv = 1.0 / √Nm
+
+    for site = 1:Nm
+        # note that d is the chemical coordinates
+        chemical_coor = chemical_positions[site]
+        phase = exp(-2im * π  * dot(k, chemical_coor))
+        Avec_pref[site] = sqrt_Nm_inv * phase
+    end
+
+    for band = 1:L
+        v = Vmat[:, band]
+        Avec = zeros(ComplexF64, 3)
+        for site = 1:Nm
+            @views tS_μ = s̃_mat[:, :, :, site]
+            for μ = 1:3
+                for α = 2:N
+                    Avec[μ] += Avec_pref[site] * (tS_μ[α, 1, μ] * v[(site-1)*(N-1)+α-1+L] + tS_μ[1, α, μ] * v[(site-1)*(N-1)+α-1])
+                end
+            end
+        end
+
+        Sαβ_matrix[band, 1] = real(Avec[1] * conj(Avec[1]))
+        Sαβ_matrix[band, 2] = real(Avec[2] * conj(Avec[2]))
+        Sαβ_matrix[band, 3] = real(Avec[3] * conj(Avec[3]))
+        # xy + yx
+        Sαβ_matrix[band, 4] = 2.0 * real(Avec[1] * conj(Avec[2]))
+        # yz + zy
+        Sαβ_matrix[band, 5] = 2.0 * real(Avec[2] * conj(Avec[3]))
+        # zx + xz
+        Sαβ_matrix[band, 6] = 2.0 * real(Avec[3] * conj(Avec[1]))
+        # xy - yx
+        Sαβ_matrix[band, 7] = 2.0 * imag(Avec[1] * conj(Avec[2]))
+        # yz - zy
+        Sαβ_matrix[band, 8] = 2.0 * imag(Avec[2] * conj(Avec[3]))
+        # zx - xz
+        Sαβ_matrix[band, 9] = 2.0 * imag(Avec[3] * conj(Avec[1]))
+    end
+
+end 
+
+function polarization_matrix(sw_fields :: SpinWaveFields, k :: Vector{Float64})
+    k_cart = sw_fields.chemic_reciprocal_basis * k
+    l = norm(k_cart)
+    mat = Matrix{Float64}(I, 3, 3)
+    if l > 1.0e-12
+        [mat[μ, ν] = μ == ν ? 1.0 - k_cart[μ] * k_cart[μ] / l^2 : -k_cart[μ] * k_cart[ν] / l^2 for μ = 1:3, ν = 1:3]
+        return mat
+    else
+        return mat
+    end
+end
+
+
+@inline lorentzian(x :: Float64, η :: Float64) = η / (π * (x^2 + η^2))
+
+
+"""
+    lswt_unpolarized_INS_spec
+
+Computes the unpolarized inelastic neutron scattering intensities given a `SpinWaveField`, `k`, and `ω_list`. Note that `k` is a 3-vector, the units of kᵢ is 2π/|aᵢ|, where |aᵢ| is the lattice constant of the **chemical** lattice.
+"""
+function lswt_unpolarized_INS_spec(sw_fields :: SpinWaveFields, k :: Vector{Float64}, ω_list :: Vector{Float64}, η :: Float64)
+    polar_mat = polarization_matrix(sw_fields, k)
+    (; sys) = sw_fields
+    Nm, Ns = length(sys.dipoles), sys.Ns[1] # number of magnetic atoms and dimension of Hilbert space
+    Nf = sys.mode == :SUN ? Ns-1 : 1
+    N  = Nf + 1
+    L  = Nf * Nm
+
+    disp = zeros(Float64, L)
+    Sαβ_matrix = zeros(Float64, L, 9)
+    lswt_dynamical_spin_structure_factor!(sw_fields, k, disp, Sαβ_matrix)
+
+    num_ω = length(ω_list)
+    unpolarized_intensity = zeros(Float64, num_ω)
+
+    for band = 1:L
+        int_band = polar_mat[1, 1] * Sαβ_matrix[band, 1] + polar_mat[2, 2] * Sαβ_matrix[band, 2] + polar_mat[3, 3] * Sαβ_matrix[band, 3] +
+        polar_mat[1, 2] * Sαβ_matrix[band, 4] + polar_mat[2, 3] * Sαβ_matrix[band, 5] + polar_mat[3, 1] * Sαβ_matrix[band, 6]
+        # At a Goldstone mode, where the intensity is divergent, use a delta-function for the intensity.
+        if (disp[band] < 1.0e-3) && (int_band > 1.0e3)
+            unpolarized_intensity[1] += int_band
+        else
+            for index_ω = 1:num_ω
+                lll = lorentzian(ω_list[index_ω]-disp[band], η)
+                unpolarized_intensity[index_ω] += int_band * lll
+            end
+        end
+    end
+
+    return unpolarized_intensity
+end

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -89,6 +89,16 @@ export DynamicStructureFactor, InstantStructureFactor, StructureFactor, FormFact
     add_sample!, intensities, instant_intensities, broaden_energy, lorentzian,
     connected_path, all_exact_wave_vectors, ωs, spherical_shell
 
+include("SpinWave/SWUtil.jl")
+include("SpinWave/SpinWave.jl")
+export SpinWaveFields, construct_magnetic_supercell,
+    set_dipoles!, lswt_dispersion_relation, lswt_dynamical_spin_structure_factor!, lswt_unpolarized_INS_spec
+
+# include("WangLandau/BinnedArray.jl")
+# include("WangLandau/WangLandau.jl")
+# export BinnedArray, filter_visited, reset!,
+#     WangLandau, spherical_cap_update, init_bounded!, run!
+
 include("SunnyGfx/SunnyGfx.jl")
 include("SunnyGfx/CrystalViewer.jl")
 export view_crystal, offline_viewers, browser

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -94,11 +94,6 @@ include("SpinWave/SpinWave.jl")
 export SpinWaveFields, construct_magnetic_supercell,
     set_dipoles!, lswt_dispersion_relation, lswt_dynamical_spin_structure_factor!, lswt_unpolarized_INS_spec
 
-# include("WangLandau/BinnedArray.jl")
-# include("WangLandau/WangLandau.jl")
-# export BinnedArray, filter_visited, reset!,
-#     WangLandau, spherical_cap_update, init_bounded!, run!
-
 include("SunnyGfx/SunnyGfx.jl")
 include("SunnyGfx/CrystalViewer.jl")
 export view_crystal, offline_viewers, browser

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -91,8 +91,8 @@ export DynamicStructureFactor, InstantStructureFactor, StructureFactor, FormFact
 
 include("SpinWave/SWUtil.jl")
 include("SpinWave/SpinWave.jl")
-export SpinWaveFields, construct_magnetic_supercell,
-    set_dipoles!, lswt_dispersion_relation, lswt_dynamical_spin_structure_factor!, lswt_unpolarized_INS_spec
+export SpinWave, construct_magnetic_supercell,
+    set_dipoles!, dispersion, dssf, intensities
 
 include("SunnyGfx/SunnyGfx.jl")
 include("SunnyGfx/CrystalViewer.jl")

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -1,0 +1,109 @@
+@testitem "Single Ion" begin
+    J, J′, D = 1.0, 0.1, 5.0
+
+    a = b = 1.0
+    c = 1.5
+    lat_vecs = lattice_vectors(a, b, c, 90, 90, 90)
+    types = ["A"]
+    basis_vecs = [[0, 0, 0]]
+
+    cryst = Crystal(lat_vecs, basis_vecs; types)
+
+    # Spin System
+    dims = (2, 2, 2)
+    infos = [SpinInfo(1, S=1)]
+    sys = System(cryst, dims, infos, :SUN)
+
+    set_exchange!(sys, J,  Bond(1, 1, [1, 0, 0]))
+    set_exchange!(sys, J′, Bond(1, 1, [0, 0, 1]))
+    set_anisotropy!(sys, D * 𝒮[3]^2, 1)
+
+    Δt  = abs(0.05 / D)
+    λ = 0.1
+    langevin = Langevin(Δt; kT=0, λ)
+
+    randomize_spins!(sys)
+    A = [1 1 1; -1 1 0; 0 0 1]
+    sys_lswt = construct_magnetic_supercell(sys, [1 1 1; -1 1 0; 0 0 1])
+
+    langevin.kT = 0
+    for i in 1:50_000
+        step!(sys_lswt, langevin)
+    end
+
+    sw_fields = SpinWaveFields(sys_lswt)
+
+    function sion_analytical_disp(k :: Vector{Float64})
+        # analytical solutions
+        γkxy = cos(2*π*k[1]) + cos(2*π*k[2])
+        γkz  = cos(2*π*k[3])
+        x = 1/2 - D/(8*(2*J+J′))
+        Ak₊ = -8 * (x-1) * x * (2*J+J′) - (x-1) * D + 2 * (2*x-1) * (J *γkxy + J′*γkz)
+        Bk₊ = -2 * (J * γkxy + J′ * γkz)
+        Ak₋ = -16 * (x-1) * x * (2*J+J′) - (2*x-1) * D - 2 * (1-2*x)^2*(J*γkxy + J′*γkz)
+        Bk₋ = 2 * (1-2*x)^2 * (J*γkxy + J′*γkz)
+        ωk₊ = √(Ak₊^2-Bk₊^2)
+        ωk₋ = √(Ak₋^2-Bk₋^2)
+        return ωk₊, ωk₋
+    end
+
+    k = rand(Float64, 3)
+    ωk1, ωk2 = sion_analytical_disp(k)
+    ωk3, ωk4 = sion_analytical_disp(k .+= 0.5)
+    ωk_ana = [ωk1, ωk2, ωk3, ωk4]
+    index  = sortperm(ωk_ana, rev=true)
+    ωk_ana = ωk_ana[index]
+    ωk_num = lswt_dispersion_relation(sw_fields, k)
+
+    @test isapprox(ωk_ana, ωk_num)
+end
+
+@testitem "Intensities" begin
+    using LinearAlgebra
+
+    a = 8.289
+    lat_vecs = lattice_vectors(a, a, a, 90, 90, 90)
+    types = ["MzR1"]
+    basis_vecs = [[0, 0, 0]]
+    fcc = Crystal(lat_vecs, basis_vecs, 225; types)
+    S = 5/2
+
+    # According to a renormalized classical theory for spins (the details will be presented in a manuscript in preparation), the large-S expansion and the :dipole mode should produce the same results when
+    cov_factor = (1 - 3/S + 11/(4*S^2)- 3/(4*S^3))
+
+    dims = (1, 1, 1)
+    infos = [SpinInfo(1, S=S)]
+    sys = System(fcc, dims, infos, :dipole)
+
+    J = 22.06 * Sunny.meV_per_K
+    K = 0.15  * Sunny.meV_per_K
+    C = J + K
+    J₁ = diagm([J, J, C])
+    D_ST = 0.2
+    D = D_ST / cov_factor
+
+    set_exchange!(sys, J₁, Bond(1, 2, [0, 0, 0]))
+    Λ = D * (𝒮[1]^4 + 𝒮[2]^4 + 𝒮[3]^4)
+    set_anisotropy!(sys, Λ, 1)
+
+    Δt = abs(0.05 / D)
+    λ  = 0.1
+    langevin = Langevin(Δt; kT=0, λ)
+
+    dipoles = S * [1.0 1.0 -1.0 -1.0; 1.0 -1.0 -1.0 1.0; 1.0 -1.0 1.0 -1.0] / √3
+    positions = [0.0 0.5 0.5 0.0; 0.0 0.5 0.0 0.5; 0.0 0.0 0.5 0.5]
+    set_dipoles!(sys, dipoles, positions)
+    sw_fields = SpinWaveFields(sys)
+
+    disp = zeros(Float64, 4)
+    Sαβ_matrix = zeros(Float64, 4, 9)
+
+    k = [0.8, 0.6, 0.1]
+    lswt_dynamical_spin_structure_factor!(sw_fields, k, disp, Sαβ_matrix)
+    tmp = Sαβ_matrix[:, 1:3]
+    sunny_trace = sum(tmp, dims=2)
+
+    spintools_trace = [0.0, 1.1743243223274487, 1.229979802236658, 1.048056653379038]
+
+    @test isapprox(sunny_trace, spintools_trace)
+end

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -31,7 +31,7 @@
         step!(sys_lswt, langevin)
     end
 
-    sw_fields = SpinWaveFields(sys_lswt)
+    sw_fields = SpinWave(sys_lswt)
 
     function sion_analytical_disp(k :: Vector{Float64})
         # analytical solutions
@@ -53,7 +53,7 @@
     ωk_ana = [ωk1, ωk2, ωk3, ωk4]
     index  = sortperm(ωk_ana, rev=true)
     ωk_ana = ωk_ana[index]
-    ωk_num = lswt_dispersion_relation(sw_fields, k)
+    ωk_num = dispersion(sw_fields, k)
 
     @test isapprox(ωk_ana, ωk_num)
 end
@@ -94,13 +94,13 @@ end
     polarize_spin!(sys, (1, -1, -1), position_to_site(sys, (1/2, 1/2, 0)))
     polarize_spin!(sys, (-1, -1, 1), position_to_site(sys, (1/2, 0, 1/2)))
     polarize_spin!(sys, (-1, 1, -1), position_to_site(sys, (0, 1/2, 1/2)))
-    sw_fields = SpinWaveFields(sys)
+    sw_fields = SpinWave(sys)
 
     disp = zeros(Float64, 4)
     Sαβ_matrix = zeros(Float64, 4, 9)
 
     k = [0.8, 0.6, 0.1]
-    lswt_dynamical_spin_structure_factor!(sw_fields, k, disp, Sαβ_matrix)
+    Sαβ_matrix =  dssf(sw_fields, k)
     tmp = Sαβ_matrix[:, 1:3]
     sunny_trace = sum(tmp, dims=2)
 
@@ -148,12 +148,12 @@ end
             step!(sys_lswt, langevin)
         end
 
-        sw_fields = SpinWaveFields(sys_lswt)
+        sw_fields = SpinWave(sys_lswt)
 
         @inline γk(k :: Vector{Float64}) = 2 * (cos(2π*k[1]) + cos(2π*k[2]) + cos(2π*k[3]))
         @inline ϵk₁(k :: Vector{Float64}) = J * (S*cos(α) - (2*S-2+1/S) * sin(α)) * √(36 - γk(k)^2) 
 
-        ϵk_num = lswt_dispersion_relation(sw_fields, k)
+        ϵk_num = dispersion(sw_fields, k)
         ϵk_ana = ϵk₁(k)
 
         isapprox(ϵk_num[1], ϵk_ana)

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -68,7 +68,7 @@ end
     fcc = Crystal(lat_vecs, basis_vecs, 225; types)
     S = 5/2
 
-    # According to a renormalized classical theory for spins (the details will be presented in a manuscript in preparation), the large-S expansion and the :dipole mode should produce the same results when
+    # According to a renormalized classical theory for spins (the details will be presented in a manuscript in preparation), the large-S expansion and the :dipole mode should produce the same results when apply the proper renormalization factor for the single-ion interaction strength.
     cov_factor = (1 - 3/S + 11/(4*S^2)- 3/(4*S^3))
 
     dims = (1, 1, 1)
@@ -90,9 +90,10 @@ end
     λ  = 0.1
     langevin = Langevin(Δt; kT=0, λ)
 
-    dipoles = S * [1.0 1.0 -1.0 -1.0; 1.0 -1.0 -1.0 1.0; 1.0 -1.0 1.0 -1.0] / √3
-    positions = [0.0 0.5 0.5 0.0; 0.0 0.5 0.0 0.5; 0.0 0.0 0.5 0.5]
-    set_dipoles!(sys, dipoles, positions)
+    polarize_spin!(sys, (1, 1, 1), position_to_site(sys, (0, 0, 0)))
+    polarize_spin!(sys, (1, -1, -1), position_to_site(sys, (1/2, 1/2, 0)))
+    polarize_spin!(sys, (-1, -1, 1), position_to_site(sys, (1/2, 0, 1/2)))
+    polarize_spin!(sys, (-1, 1, -1), position_to_site(sys, (0, 1/2, 1/2)))
     sw_fields = SpinWaveFields(sys)
 
     disp = zeros(Float64, 4)


### PR DESCRIPTION
This PR adds the SU(N) linear spin-wave theory features to Sunny. The `:SUN` and `: dipole` modes are supported. But the `:large_S` mode is not supported yet. Moreover, the `biquad` interactions are not supported.