### PR TITLE
Performance enhancements for inverse problem

### DIFF
--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -120,7 +120,7 @@ function step!(sys::System{0}, integrator::ImplicitMidpoint)
     error("Spherical midpoint method failed to converge to tolerance $atol after $max_iters iterations.")
 end
 
-function fast_isapprox(x, y; atol=0)
+function fast_isapprox(x, y; atol)
     sqTol = atol^2
     acc = 0.
     for i in eachindex(x)

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -107,7 +107,7 @@ function step!(sys::System{0}, integrator::ImplicitMidpoint)
         @. s̄′ = s + 0.5 * Δt * rhs_dipole(ŝ, B)
 
         # If converged, then we can return
-        if fast_isapprox(s̄, s̄′, atol* √length(s̄))
+        if fast_isapprox(s̄, s̄′,atol=atol* √length(s̄))
             # Normalization here should not be necessary in principle, but it
             # could be useful in practice for finite `atol`.
             @. s = normalize_dipole(2*s̄′ - s, sys.κs)
@@ -120,12 +120,12 @@ function step!(sys::System{0}, integrator::ImplicitMidpoint)
     error("Spherical midpoint method failed to converge to tolerance $atol after $max_iters iterations.")
 end
 
-function fast_isapprox(s̄, s̄′, atol)
+function fast_isapprox(x, y; atol=0)
     sqTol = atol^2
     acc = 0.
-    for i in eachindex(s̄)
-        diff = s̄[i] - s̄′[i]
-        acc += dot(diff,diff)
+    for i in eachindex(x)
+        diff = x[i] - y[i]
+        acc += real(dot(diff,diff))
         if acc > sqTol
             return false
         end
@@ -257,7 +257,7 @@ function step!(sys::System{N}, integrator::ImplicitMidpoint; max_iters=100) wher
 
         @. Z″ = Z + ΔZ
 
-        if isapprox(Z′, Z″, atol=atol*√length(Z′))
+        if fast_isapprox(Z′, Z″, atol=atol*√length(Z′))
             @. Z = normalize_ket(Z″, sys.κs)
             @. sys.dipoles = expected_spin(Z)
             return

--- a/src/StructureFactors/BasisReduction.jl
+++ b/src/StructureFactors/BasisReduction.jl
@@ -6,7 +6,7 @@ function phase_averaged_elements(data, k::Vec3, sf::StructureFactor{N}, ffdata::
 
     for j in 1:NAtoms, i in 1:NAtoms
         phase = exp(im*(k ⋅ (rs[j] - rs[i])))
-        @. elems += phase * ffs[i] * ffs[j] * (@views data[:, i, j])
+        elems .+= phase .* ffs[i] .* ffs[j] .* view(data,:, i, j)
     end
 
     return SVector(elems)

--- a/src/StructureFactors/BasisReduction.jl
+++ b/src/StructureFactors/BasisReduction.jl
@@ -1,13 +1,13 @@
 function phase_averaged_elements(data, k::Vec3, sf::StructureFactor{N}, ffdata::Vector{FormFactor{FFType}}, ::Val{NCorr}, ::Val{NAtoms}) where {FFType, N, NCorr, NAtoms} 
-    elems = zero(SVector{NCorr, ComplexF64})
+    elems = zero(MVector{NCorr,ComplexF64})
     knorm = norm(k)
     ffs = ntuple(i -> compute_form(knorm, ffdata[i]), NAtoms)
     rs = ntuple(i -> sf.crystal.latvecs * sf.crystal.positions[i], NAtoms)
 
     for j in 1:NAtoms, i in 1:NAtoms
         phase = exp(im*(k ⋅ (rs[j] - rs[i])))
-        elems += phase * ffs[i] * ffs[j] * view(data, :, i, j)  # This view allocates
+        @. elems += phase * ffs[i] * ffs[j] * (@views data[:, i, j])
     end
 
-    return elems
+    return SVector(elems)
 end

--- a/src/StructureFactors/SampleGeneration.jl
+++ b/src/StructureFactors/SampleGeneration.jl
@@ -111,15 +111,10 @@ function accum_sample!(sf::StructureFactor)
     nsamples[1] += 1
 
     # Transfer to final memory layout while accumulating new samplebuf
-    for j in 1:natoms
-      for i in 1:natoms
-        for (ci, c) in idxinfo 
-          α, β = ci.I
-          @. copybuf = @views samplebuf[α,:,:,:,i,:] * conj(samplebuf[β,:,:,:,j,:]) - data[c,i,j,:,:,:,:] 
-          oneOverN = 1/nsamples[1]
-          @views data[c,i,j,:,:,:,:] .+= copybuf .* oneOverN
-        end
-      end
+    for j in 1:natoms, i in 1:natoms, (ci, c) in idxinfo 
+        α, β = ci.I
+        @. copybuf = @views samplebuf[α,:,:,:,i,:] * conj(samplebuf[β,:,:,:,j,:]) - data[c,i,j,:,:,:,:] 
+        @views data[c,i,j,:,:,:,:] .+= copybuf .* (1/nsamples[1])
     end
 
     return nothing


### PR DESCRIPTION
@kbarros , in anticipation of working on inverse problem (= approx 10^6 x forwards problem), I've made a few performance tweaks, mainly focused on making the memory allocations scale better (no GC anymore during long integrations 🎉).

These are mainly for my use but if they look useful enough for Sunny proper then I'm happy to make any style changes + squash the commits if needed.

Before:

![benchPre](https://github.com/SunnySuite/Sunny.jl/assets/2996388/5f2d57d0-9d5d-48ca-ade1-c84959164e02)

After:

![benchPost](https://github.com/SunnySuite/Sunny.jl/assets/2996388/bc4c5309-686c-4b21-870b-8b9d389eabb0)