### PR TITLE
Accelerate force calculation

### DIFF
--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -44,6 +44,7 @@ include("Symmetry/AllowedCouplings.jl")
 include("Symmetry/AllowedAnisotropy.jl")
 include("Symmetry/Parsing.jl")
 include("Symmetry/Printing.jl")
+include("Symmetry/CartesianIndicesShifted.jl")
 export Crystal, subcrystal, lattice_vectors, lattice_params, Bond, 
     reference_bonds, print_site, print_bond, print_symmetry_table,
     print_suggested_frame

--- a/src/Symmetry/CartesianIndicesShifted.jl
+++ b/src/Symmetry/CartesianIndicesShifted.jl
@@ -1,0 +1,66 @@
+struct CartesianIndicesShifted{N} # <: AbstractArray{CartesianIndex{N},N}
+    limit::NTuple{N,Int}
+    shift::NTuple{N,Int}
+
+    function CartesianIndicesShifted(limit, shift)
+        any(iszero, limit) && error("Empty iterator.")
+        N = length(limit)
+        return new{N}(limit, mod.(shift, limit))
+    end
+end
+
+CartesianIndicesShifted(a::AbstractArray, shift) = CartesianIndicesShifted(size(a), shift)
+
+
+function Base.first(iter::CartesianIndicesShifted)
+    (; limit, shift) = iter
+    return CartesianIndex(mod1.(shift .+ 1, limit))
+end
+
+function Base.last(iter::CartesianIndicesShifted)
+    (; limit, shift) = iter
+    return CartesianIndex(mod1.(shift, limit))
+end
+
+@inline function Base.iterate(iter::CartesianIndicesShifted)
+    iterfirst = first(iter)
+    iterfirst, iterfirst
+end
+
+@inline function Base.iterate(iter::CartesianIndicesShifted, state)
+    valid, I = inc_shifted(state.I, iter.limit, iter.shift)
+    valid || return nothing
+    return CartesianIndex(I), CartesianIndex(I)
+end
+
+
+# << Adapted from multidimensional.jl in Julia Base stdlib >>
+# CartesianIndicesShifted continues the iteration in the next column when the
+# current column is consumed. The implementation is written recursively to
+# achieve this. `iterate` returns `Union{Nothing, Tuple}`, we explicitly pass a
+# `valid` flag to eliminate the type instability inside the core `inc_shifted`
+# logic, and this gives better runtime performance.
+@inline inc_shifted(::Tuple{}, ::Tuple{}, ::Tuple{}) = false, ()
+
+@inline function inc_shifted(state::Tuple{Int}, limit::Tuple{Int}, shift::Tuple{Int})
+    i = state[1]
+    ip = i < limit[1] ? i+1 : 1
+    if ip != shift[1]+1
+        return true, (ip,)
+    else
+        # wrapped to starting index so we're finished
+        return false, (0,)
+    end
+end
+
+@inline function inc_shifted(state::Tuple{Int,Int,Vararg{Int}}, limit::Tuple{Int,Int,Vararg{Int}}, shift::Tuple{Int,Int,Vararg{Int}})
+    i = state[1]
+    ip = i < limit[1] ? i+1 : 1
+    if ip != shift[1]+1
+        return true, (ip, Base.tail(state)...)
+    else
+        valid, I = inc_shifted(Base.tail(state), Base.tail(limit), Base.tail(shift))
+        return valid, (shift[1]+1, I...)
+    end
+end
+

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -418,22 +418,22 @@ function polarize_spins!(sys::System{N}, dir) where N
 end
 
 
-function get_dipole_buffers(sys::System{N}, numrequested) where N
+@inline function get_dipole_buffers(sys::System{N}, numrequested) where N
     numexisting = length(sys.dipole_buffers)
     if numexisting < numrequested
         for _ in 1:(numrequested-numexisting)
             push!(sys.dipole_buffers, zero(sys.dipoles))
         end
     end
-    return sys.dipole_buffers[1:numrequested]
+    return view(sys.dipole_buffers,1:numrequested)
 end
 
-function get_coherent_buffers(sys::System{N}, numrequested) where N
+@inline function get_coherent_buffers(sys::System{N}, numrequested) where N
     numexisting = length(sys.coherent_buffers)
     if numexisting < numrequested
         for _ in 1:(numrequested-numexisting)
             push!(sys.coherent_buffers, zero(sys.coherents))
         end
     end
-    return sys.coherent_buffers[1:numrequested]
+    return view(sys.coherent_buffers,1:numrequested)
 end


### PR DESCRIPTION
Uses Kip's CartesianIndicesShifted to efficiently implement periodic boundary conditions. Also accelerates `energy_aux` and allows the interactions to use site indices instead of cell+sublattice (if someone were to add an interaction in the future, this is the nicer way for them to write their code in the first place)