### PR TITLE
PairCoupling refactors

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -18,6 +18,9 @@ a polynomial of [`spin_operators`](@ref). To understand the mapping between
 these two, the new function [`print_stevens_expansion`](@ref) acts on an
 arbitrary local operator.
 
+Replace `set_biquadratic!` with an optional keyword argument `biquad` to
+[`set_exchange!`](@ref).
+
 Symbolic representations of operators are now hidden unless the package
 `DynamicPolynomials` is explicitly loaded by the user. The functionality of
 `print_anisotropy_as_stevens` has been replaced with
@@ -68,7 +71,7 @@ The function [`to_inhomogeneous`](@ref) creates a system that supports
 inhomogeneous interactions, which can be set using [`set_exchange_at!`](@ref),
 etc.
 
-[`set_biquadratic!`](@ref) replaces `set_exchange_with_biquadratic!`.
+`set_biquadratic!` replaces `set_exchange_with_biquadratic!`.
 
 
 # Version 0.4.0

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -174,7 +174,7 @@ function rhs_langevin!(ΔZ::Array{CVec{N}, 4}, Z::Array{CVec{N}, 4}, ξ::Array{C
     if is_homogeneous(sys)
         ints = interactions_homog(sys)
         for site in all_sites(sys)
-            Λ = ints[to_atom(site)].aniso.matrep
+            Λ = ints[to_atom(site)].onsite.matrep
             HZ = mul_spin_matrices(Λ, -B[site], Z[site]) # HZ = (Λ - B⋅s) Z
             ΔZ′ = -im*√(2*Δt*kT*λ)*ξ[site] - Δt*(im+λ)*HZ
             ΔZ[site] = proj(ΔZ′, Z[site])
@@ -182,7 +182,7 @@ function rhs_langevin!(ΔZ::Array{CVec{N}, 4}, Z::Array{CVec{N}, 4}, ξ::Array{C
     else
         ints = interactions_inhomog(sys)
         for site in all_sites(sys)
-            Λ = ints[site].aniso.matrep
+            Λ = ints[site].onsite.matrep
             HZ = mul_spin_matrices(Λ, -B[site], Z[site]) # HZ = (Λ - B⋅s) Z
             ΔZ′ = -im*√(2*Δt*kT*λ)*ξ[site] - Δt*(im+λ)*HZ
             ΔZ[site] = proj(ΔZ′, Z[site])
@@ -221,14 +221,14 @@ function rhs_ll!(ΔZ, Z, B, integrator, sys)
     if is_homogeneous(sys)
         ints = interactions_homog(sys)
         for site in all_sites(sys)
-            Λ = ints[to_atom(site)].aniso.matrep
+            Λ = ints[to_atom(site)].onsite.matrep
             HZ = mul_spin_matrices(Λ, -B[site], Z[site]) # HZ = (Λ - B⋅s) Z
             ΔZ[site] = - Δt*im*HZ
         end 
     else
         ints = interactions_inhomog(sys)
         for site in all_sites(sys)
-            Λ = ints[site].aniso.matrep
+            Λ = ints[site].onsite.matrep
             HZ = mul_spin_matrices(Λ, -B[site], Z[site]) # HZ = (Λ - B⋅s) Z
             ΔZ[site] = - Δt*im*HZ
         end 

--- a/src/SpinWaveTheory/SWTCalculations.jl
+++ b/src/SpinWaveTheory/SWTCalculations.jl
@@ -26,6 +26,16 @@ function swt_hamiltonian!(swt::SpinWaveTheory, k̃ :: Vector{Float64}, Hmat::Mat
     N  = Nf + 1
     L  = Nf * Nm
     @assert size(Hmat) == (2*L, 2*L)
+    # scaling factor (=1) if in the fundamental representation
+    M = sys.mode == :SUN ? 1 : (Ns-1)
+    no_single_ion = isempty(swt.sys.interactions_union[1].onsite.matrep)
+
+    # the "metric" of scalar biquad interaction. Here we are using the following identity:
+    # (𝐒ᵢ⋅𝐒ⱼ)² = -(𝐒ᵢ⋅𝐒ⱼ)/2 + ∑ₐ (OᵢᵃOⱼᵃ)/2, a=4,…,8
+    # where the definition of Oᵢᵃ is given in Appendix B of *Phys. Rev. B 104, 104409*
+    # Note: this is only valid for the `:dipole` mode, for `:SUN` mode, we consider 
+    # different implementations
+    biquad_metric = 1/2 * diagm([-1, -1, -1, 1/M, 1/M, 1/M, 1/M, 1/M])
 
     for k̃ᵢ in k̃
         (k̃ᵢ < 0.0 || k̃ᵢ ≥ 1.0) && throw("k̃ outside [0, 1) range")
@@ -55,60 +65,13 @@ function swt_hamiltonian!(swt::SpinWaveTheory, k̃ :: Vector{Float64}, Hmat::Mat
     # pairexchange interactions
     for matom = 1:Nm
         ints = sys.interactions_union[matom]
-        # Heisenberg exchange
-        for (; isculled, bond, J) in ints.heisen
+
+        for (; isculled, bond, bilin, biquad) in ints.pair
             isculled && break
-            sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
 
-            tTi_μ = s̃_mat[:, :, :, sub_i]
-            tTj_ν = s̃_mat[:, :, :, sub_j]
-            phase  = exp(2im * π * dot(k̃, ΔRδ))
-            cphase = conj(phase)
-            sub_i_M1, sub_j_M1 = sub_i - 1, sub_j - 1
+            ### Quadratic exchange
+            J = bilin
 
-            for m = 2:N
-                mM1 = m - 1
-                T_μ_11 = conj(tTi_μ[1, 1, :])
-                T_μ_m1 = conj(tTi_μ[m, 1, :])
-                T_μ_1m = conj(tTi_μ[1, m, :])
-                T_ν_11 = tTj_ν[1, 1, :]
-
-                for n = 2:N
-                    nM1 = n - 1
-                    δmn = δ(m, n)
-                    T_μ_mn, T_ν_mn = conj(tTi_μ[m, n, :]), tTj_ν[m, n, :]
-                    T_ν_n1 = tTj_ν[n, 1, :]
-                    T_ν_1n = tTj_ν[1, n, :]
-
-                    c1 = J * dot(T_μ_mn - δmn * T_μ_11, T_ν_11)
-                    c2 = J * dot(T_μ_11, T_ν_mn - δmn * T_ν_11)
-                    c3 = J * dot(T_μ_m1, T_ν_1n)
-                    c4 = J * dot(T_μ_1m, T_ν_n1)
-                    c5 = J * dot(T_μ_m1, T_ν_n1)
-                    c6 = J * dot(T_μ_1m, T_ν_1n)
-
-                    Hmat11[sub_i_M1*Nf+mM1, sub_i_M1*Nf+nM1] += 0.5 * c1
-                    Hmat11[sub_j_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c2
-                    Hmat22[sub_i_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c1
-                    Hmat22[sub_j_M1*Nf+nM1, sub_j_M1*Nf+mM1] += 0.5 * c2
-
-                    Hmat11[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c3 * phase
-                    Hmat22[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c3 * cphase
-                    
-                    Hmat22[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c4 * phase
-                    Hmat11[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c4 * cphase
-
-                    Hmat12[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c5 * phase
-                    Hmat12[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c5 * cphase
-                    Hmat21[sub_i_M1*Nf+mM1, sub_j_M1*Nf+nM1] += 0.5 * c6 * phase
-                    Hmat21[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c6 * cphase
-                end
-            end
-        end
-
-        # Quadratic exchange
-        for (; isculled, bond, J) in ints.exchange
-            isculled && break
             sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
 
             tTi_μ = s̃_mat[:, :, :, sub_i]
@@ -155,10 +118,10 @@ function swt_hamiltonian!(swt::SpinWaveTheory, k̃ :: Vector{Float64}, Hmat::Mat
                     Hmat21[sub_j_M1*Nf+nM1, sub_i_M1*Nf+mM1] += 0.5 * c6 * cphase
                 end
             end
-        end
 
-        for (; isculled, bond, J) in ints.biquad
-            isculled && break
+            ### Biquadratic
+
+            J = biquad
             sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
             phase  = exp(2im * π * dot(k̃, ΔRδ))
             cphase = conj(phase)

--- a/src/SpinWaveTheory/SWTCalculations.jl
+++ b/src/SpinWaveTheory/SWTCalculations.jl
@@ -66,11 +66,16 @@ function swt_hamiltonian!(swt::SpinWaveTheory, k̃ :: Vector{Float64}, Hmat::Mat
     for matom = 1:Nm
         ints = sys.interactions_union[matom]
 
-        for (; isculled, bond, bilin, biquad) in ints.pair
+        for coupling in ints.pair
+            (; isculled, bond) = coupling
             isculled && break
 
-            ### Quadratic exchange
-            J = bilin
+            ### Bilinear exchange
+            if coupling.bilin isa Number
+                J = Mat3(coupling.bilin*I)
+            else
+                J = coupling.bilin
+            end
 
             sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
 
@@ -119,9 +124,9 @@ function swt_hamiltonian!(swt::SpinWaveTheory, k̃ :: Vector{Float64}, Hmat::Mat
                 end
             end
 
-            ### Biquadratic
+            ### Biquadratic exchange
 
-            J = biquad
+            J = coupling.biquad
             sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
             phase  = exp(2im * π * dot(k̃, ΔRδ))
             cphase = conj(phase)

--- a/src/SpinWaveTheory/SWTCalculations.jl
+++ b/src/SpinWaveTheory/SWTCalculations.jl
@@ -71,12 +71,8 @@ function swt_hamiltonian!(swt::SpinWaveTheory, k̃ :: Vector{Float64}, Hmat::Mat
             isculled && break
 
             ### Bilinear exchange
-            if coupling.bilin isa Number
-                J = Mat3(coupling.bilin*I)
-            else
-                J = coupling.bilin
-            end
-
+            
+            J = Mat3(coupling.bilin*I)
             sub_i, sub_j, ΔRδ = bond.i, bond.j, bond.n
 
             tTi_μ = s̃_mat[:, :, :, sub_i]

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -135,7 +135,7 @@ function generate_local_sun_gens(sys :: System)
                 T̃_mat[:, :, atom] = Hermitian(U_mat_N' * sys.interactions_union[atom].onsite.matrep * U_mat_N)[1:2, 1:2]
             end
         end
-        T̃_mat[:, :, atom] = Hermitian(U_mat' * sys.interactions_union[atom].aniso.matrep * U_mat)
+        T̃_mat[:, :, atom] = Hermitian(U_mat' * sys.interactions_union[atom].onsite.matrep * U_mat)
     end
 
     return s̃_mat, T̃_mat, Q̃_mat
@@ -164,7 +164,7 @@ function generate_local_stevens_coefs(sys :: System)
         R[:] = [-sin(ϕ) -cos(ϕ)*cos(θ) cos(ϕ)*sin(θ);
                     cos(ϕ) -sin(ϕ)*cos(θ) sin(ϕ)*sin(θ);
                     0.0     sin(θ)        cos(θ)]
-        (; c2, c4, c6) = sys.interactions_union[atom].aniso.stvexp
+        (; c2, c4, c6) = sys.interactions_union[atom].onsite.stvexp
         SR  = Mat3(R)
         # In Cristian's note, S̃ = R S, so here we should pass SR'
         push!(R_mat, SR')

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -84,20 +84,56 @@ function generate_local_sun_gens(sys :: System)
     Q_mat_N[4] = s_mat_N[1] * s_mat_N[2] + s_mat_N[2] * s_mat_N[1]
     Q_mat_N[5] = √3 * s_mat_N[3] * s_mat_N[3] - 1/√3 * S * (S+1) * I
 
-    U_mat = Matrix{ComplexF64}(undef, N, N)
+    if sys.mode == :SUN
+        s_mat_N = spin_matrices(; N)
 
-    s̃_mat = Array{ComplexF64, 4}(undef, N, N, 3, Nₘ)
-    T̃_mat = Array{ComplexF64, 3}(undef, N, N, Nₘ)
-    Q̃_mat = zeros(ComplexF64, N, N, 5, Nₘ)
+        s̃_mat = Array{ComplexF64, 4}(undef, N, N, 3, Nₘ)
+        T̃_mat = Array{ComplexF64, 3}(undef, N, N, Nₘ)
+        Q̃_mat = zeros(ComplexF64, N, N, 5, Nₘ)
 
-    for atom = 1:Nₘ
-        U_mat[:, 1] = sys.coherents[1, 1, 1, atom]
-        U_mat[:, 2:N] = nullspace(U_mat[:, 1]')
-        for μ = 1:3
-            s̃_mat[:, :, μ, atom] = Hermitian(U_mat' * s_mat_N[μ] * U_mat)
+        U_mat = Matrix{ComplexF64}(undef, N, N)
+
+        for atom = 1:Nₘ
+            U_mat[:, 1] = sys.coherents[1, 1, 1, atom]
+            U_mat[:, 2:N] = nullspace(U_mat[:, 1]')
+            @assert isapprox(U_mat * U_mat', I) "rotation matrix from (global frame to local frame) not unitary"
+            for μ = 1:3
+                s̃_mat[:, :, μ, atom] = Hermitian(U_mat' * s_mat_N[μ] * U_mat)
+            end
+            for ν = 1:5
+                Q̃_mat[:, :, ν, atom] = Hermitian(U_mat' * Q_mat_N[ν] * U_mat)
+            end
+            T̃_mat[:, :, atom] = Hermitian(U_mat' * sys.interactions_union[atom].onsite.matrep * U_mat)
         end
-        for ν = 1:5
-            Q̃_mat[:, :, ν, atom] = Hermitian(U_mat' * Q_mat_N[ν] * U_mat)
+
+    elseif sys.mode == :dipole
+        s_mat_2 = spin_matrices(N=2)
+        
+        s̃_mat = Array{ComplexF64, 4}(undef, 2, 2, 3, Nₘ)
+
+        no_single_ion = isempty(sys.interactions_union[1].onsite.matrep)
+        T̃_mat = no_single_ion ? zeros(ComplexF64, 0, 0, 0) : Array{ComplexF64, 3}(undef, 2, 2, Nₘ)
+        Q̃_mat = Array{ComplexF64, 4}(undef, 2, 2, 5, Nₘ)
+
+        U_mat_2 = Matrix{ComplexF64}(undef, 2, 2)
+        U_mat_N = Matrix{ComplexF64}(undef, N, N)
+
+        for atom = 1:Nₘ
+            θ, ϕ = dipole_to_angles(sys.dipoles[1, 1, 1, atom])
+            U_mat_N[:] = exp(-1im * ϕ * s_mat_N[3]) * exp(-1im * θ * s_mat_N[2])
+            U_mat_2[:] = exp(-1im * ϕ * s_mat_2[3]) * exp(-1im * θ * s_mat_2[2])
+            @assert isapprox(U_mat_N * U_mat_N', I) "rotation matrix from (global frame to local frame) not unitary"
+            @assert isapprox(U_mat_2 * U_mat_2', I) "rotation matrix from (global frame to local frame) not unitary"
+            for μ = 1:3
+                s̃_mat[:, :, μ, atom] = Hermitian(U_mat_2' * s_mat_2[μ] * U_mat_2)
+            end
+            for ν = 1:5
+                Q̃_mat[:, :, ν, atom] = Hermitian(U_mat_N' * Q_mat_N[ν] * U_mat_N)[1:2, 1:2]
+            end
+
+            if !no_single_ion
+                T̃_mat[:, :, atom] = Hermitian(U_mat_N' * sys.interactions_union[atom].onsite.matrep * U_mat_N)[1:2, 1:2]
+            end
         end
         T̃_mat[:, :, atom] = Hermitian(U_mat' * sys.interactions_union[atom].aniso.matrep * U_mat)
     end

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -60,7 +60,7 @@ include("System/SpinInfo.jl")
 include("System/Types.jl")
 include("System/System.jl")
 include("System/PairExchange.jl")
-include("System/SingleIonAnisotropy.jl")
+include("System/OnsiteCoupling.jl")
 include("System/Ewald.jl")
 include("System/Interactions.jl")
 export SpinInfo, System, Site, all_sites, position_to_site,

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -65,9 +65,9 @@ include("System/Ewald.jl")
 include("System/Interactions.jl")
 export SpinInfo, System, Site, all_sites, position_to_site,
     global_position, magnetic_moment, polarize_spin!, polarize_spins!, randomize_spins!, energy, forces,
-    spin_operators, stevens_operators, set_external_field!, set_onsite_coupling!, set_exchange!, set_biquadratic!,
+    spin_operators, stevens_operators, set_external_field!, set_onsite_coupling!, set_exchange!,
     dmvec, enable_dipole_dipole!, to_inhomogeneous, set_external_field_at!, set_vacancy_at!, set_onsite_coupling_at!,
-    symmetry_equivalent_bonds, set_exchange_at!, set_biquadratic_at!, remove_periodicity!
+    symmetry_equivalent_bonds, set_exchange_at!, remove_periodicity!
 
 include("Reshaping.jl")
 export reshape_geometry, resize_periodically, repeat_periodically, 

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -1,17 +1,14 @@
 function empty_interactions(na, N)
     return map(1:na) do _
-        Interactions(empty_anisotropy(N),
-                     Coupling{Float64}[],
-                     Coupling{Mat3}[],
-                     Coupling{Float64}[])
+        Interactions(empty_anisotropy(N), PairCoupling[])
     end
 end
 
 # Creates a clone of the lists of exchange interactions, which can be mutably
 # updated.
 function clone_interactions(ints::Interactions)
-    (; aniso, heisen, exchange, biquad) = ints
-    return Interactions(aniso, copy(heisen), copy(exchange), copy(biquad))
+    (; onsite, pair) = ints
+    return Interactions(onsite, copy(pair))
 end
 
 function interactions_homog(sys::System{N}) where N
@@ -31,7 +28,7 @@ end
 
 Returns a copy of the system that allows for inhomogeneous interactions, which
 can be set using [`set_onsite_coupling_at!`](@ref), [`set_exchange_at!`](@ref),
-[`set_biquadratic_at!`](@ref), and [`set_vacancy_at!`](@ref).
+and [`set_vacancy_at!`](@ref).
 
 Inhomogeneous systems do not support symmetry-propagation of interactions or
 system reshaping.
@@ -116,9 +113,9 @@ function local_energy_change(sys::System{N}, site, state::SpinState) where N
     (; latsize, extfield, dipoles, coherents, ewald) = sys
 
     if is_homogeneous(sys)
-        (; aniso, heisen, exchange, biquad) = interactions_homog(sys)[to_atom(site)]
+        (; onsite, pair) = interactions_homog(sys)[to_atom(site)]
     else
-        (; aniso, heisen, exchange, biquad) = interactions_inhomog(sys)[site]
+        (; onsite, pair) = interactions_inhomog(sys)[site]
     end
 
     s₀ = dipoles[site]
@@ -126,48 +123,47 @@ function local_energy_change(sys::System{N}, site, state::SpinState) where N
     Δs = s - s₀
     ΔE = 0.0
 
-    cell = to_cell(site)
-
     # Zeeman coupling to external field
-    ΔE -= sys.units.μB * extfield[site] ⋅ (sys.gs[site] * Δs)
+    ΔE -= sys.units.μB * dot(extfield[site], sys.gs[site], Δs)
 
     # Single-ion anisotropy, dipole or SUN mode
     if N == 0
-        E_new, _ = energy_and_gradient_for_classical_anisotropy(s, aniso.stvexp)
-        E_old, _ = energy_and_gradient_for_classical_anisotropy(s₀, aniso.stvexp)
+        E_new, _ = energy_and_gradient_for_classical_anisotropy(s, onsite.stvexp)
+        E_old, _ = energy_and_gradient_for_classical_anisotropy(s₀, onsite.stvexp)
         ΔE += E_new - E_old
     else
-        Λ = aniso.matrep
+        Λ = onsite.matrep
         ΔE += real(dot(Z, Λ, Z) - dot(Z₀, Λ, Z₀))
     end
 
-    # Heisenberg exchange
-    for (; bond, J) in heisen
-        sⱼ = dipoles[offsetc(cell, bond.n, latsize), bond.j]
-        ΔE += J * (Δs ⋅ sⱼ)    
-    end
-
     # Quadratic exchange matrix
-    for (; bond, J) in exchange
-        sⱼ = dipoles[offsetc(cell, bond.n, latsize), bond.j]
-        ΔE += dot(Δs, J, sⱼ)
-    end
-
-    # Scalar biquadratic exchange
-    for (; bond, J) in biquad
-        cellⱼ = offsetc(cell, bond.n, latsize)
+    for coupling in pair
+        (; bond) = coupling
+        cellⱼ = offsetc(to_cell(site), bond.n, latsize)
         sⱼ = dipoles[cellⱼ, bond.j]
-        if sys.mode == :dipole
-            # Renormalization introduces a factor r and a Heisenberg term
-            Sᵢ = (sys.Ns[site]-1)/2
-            Sⱼ = (sys.Ns[cellⱼ, bond.j]-1)/2
-            S = √(Sᵢ*Sⱼ)
-            r = (1 - 1/S + 1/4S^2)
-            ΔE += J * (r*((s⋅sⱼ)^2 - (s₀⋅sⱼ)^2) - (Δs⋅sⱼ)/2)
-        elseif sys.mode == :large_S
-            ΔE += J * ((s⋅sⱼ)^2 - (s₀⋅sⱼ)^2)
-        elseif sys.mode == :SUN
-            error("Biquadratic currently unsupported in SU(N) mode.") 
+
+        if coupling.bilin isa Float64
+            J = coupling.bilin::Float64
+            ΔE += J * dot(Δs, sⱼ)
+        else
+            J = coupling.bilin::Mat3
+            ΔE += dot(Δs, J, sⱼ)
+        end
+
+        if !iszero(coupling.biquad)
+            J = coupling.biquad
+            if sys.mode == :dipole
+                # Renormalization introduces a factor r and a Heisenberg term
+                Sᵢ = (sys.Ns[site]-1)/2
+                Sⱼ = (sys.Ns[cellⱼ, bond.j]-1)/2
+                S = √(Sᵢ*Sⱼ)
+                r = (1 - 1/S + 1/4S^2)
+                ΔE += J * (r*((s⋅sⱼ)^2 - (s₀⋅sⱼ)^2) - (Δs⋅sⱼ)/2)
+            elseif sys.mode == :large_S
+                ΔE += J * ((s⋅sⱼ)^2 - (s₀⋅sⱼ)^2)
+            elseif sys.mode == :SUN
+                error("Biquadratic currently unsupported in SU(N) mode.") 
+            end
         end
     end
 
@@ -227,45 +223,42 @@ function energy_aux(sys::System{N}, ints::Interactions, i::Int, cells, foreachbo
     if N == 0       # Dipole mode
         for cell in cells
             s = dipoles[cell, i]
-            E += energy_and_gradient_for_classical_anisotropy(s, ints.aniso.stvexp)[1]
+            E += energy_and_gradient_for_classical_anisotropy(s, ints.onsite.stvexp)[1]
         end
     else            # SU(N) mode
         for cell in cells
-            Λ = ints.aniso.matrep
+            Λ = ints.onsite.matrep
             Z = coherents[cell, i]
             E += real(dot(Z, Λ, Z))
         end
     end
 
-    # Heisenberg exchange
-    foreachbond(ints.heisen) do J, site1, site2
+    foreachbond(ints.pair) do coupling, site1, site2
         sᵢ = dipoles[site1]
         sⱼ = dipoles[site2]
-        E += J * dot(sᵢ, sⱼ)
-    end
 
-    # Quadratic exchange matrix
-    foreachbond(ints.exchange) do J, site1, site2
-        sᵢ = dipoles[site1]
-        sⱼ = dipoles[site2]
-        E += dot(sᵢ, J, sⱼ)
-    end
+        if coupling.bilin isa Float64
+            J = coupling.bilin::Float64
+            E += J * dot(sᵢ, sⱼ)
+        else
+            J = coupling.bilin::Mat3
+            E += dot(sᵢ, J, sⱼ)
+        end
 
-    # Scalar biquadratic exchange
-    foreachbond(ints.biquad) do J, site1, site2
-        sᵢ = dipoles[site1]
-        sⱼ = dipoles[site2]
-        if sys.mode == :dipole
-            # Renormalization introduces a factor r and a Heisenberg term
-            Sᵢ = (sys.Ns[site1]-1)/2
-            Sⱼ = (sys.Ns[site2]-1)/2
-            S = √(Sᵢ*Sⱼ)
-            r = (1 - 1/S + 1/4S^2)
-            E += J * (r*(sᵢ⋅sⱼ)^2 - (sᵢ⋅sⱼ)/2 + S^3 + S^2/4)
-        elseif sys.mode == :large_S
-            E += J * (sᵢ⋅sⱼ)^2
-        elseif sys.mode == :SUN
-            error("Biquadratic currently unsupported in SU(N) mode.")
+        if !iszero(coupling.biquad)
+            J = coupling.biquad
+            if sys.mode == :dipole
+                # Renormalization introduces a factor r and a Heisenberg term
+                Sᵢ = (sys.Ns[site1]-1)/2
+                Sⱼ = (sys.Ns[site2]-1)/2
+                S = √(Sᵢ*Sⱼ)
+                r = (1 - 1/S + 1/4S^2)
+                E += J * (r*(sᵢ⋅sⱼ)^2 - (sᵢ⋅sⱼ)/2 + S^3 + S^2/4)
+            elseif sys.mode == :large_S
+                E += J * (sᵢ⋅sⱼ)^2
+            elseif sys.mode == :SUN
+                error("Biquadratic currently unsupported in SU(N) mode.")
+            end
         end
     end
 
@@ -312,58 +305,55 @@ function set_forces_aux!(B, dipoles::Array{Vec3, 4}, ints::Interactions, sys::Sy
     if N == 0
         for cell in cells
             s = dipoles[cell, i]
-            B[cell, i] -= energy_and_gradient_for_classical_anisotropy(s, ints.aniso.stvexp)[2]
+            B[cell, i] -= energy_and_gradient_for_classical_anisotropy(s, ints.onsite.stvexp)[2]
         end
     end
 
-    # Heisenberg exchange
-    foreachbond(ints.heisen) do J, site1, site2
-        sᵢ = dipoles[site1]
-        sⱼ = dipoles[site2]
-        B[site1] -= J  * sⱼ
-        B[site2] -= J' * sᵢ
-    end
-
-    # Quadratic exchange matrix
-    foreachbond(ints.exchange) do J, site1, site2
-        sᵢ = dipoles[site1]
-        sⱼ = dipoles[site2]
-        B[site1] -= J  * sⱼ
-        B[site2] -= J' * sᵢ
-    end
-
-    # Scalar biquadratic exchange
-    foreachbond(ints.biquad) do J, site1, site2
+    foreachbond(ints.pair) do coupling, site1, site2
         sᵢ = dipoles[site1]
         sⱼ = dipoles[site2]
 
-        if sys.mode == :dipole
-            Sᵢ = (sys.Ns[site1]-1)/2
-            Sⱼ = (sys.Ns[site2]-1)/2
-            S = √(Sᵢ*Sⱼ)
-            # Renormalization introduces a factor r and a Heisenberg term
-            r = (1 - 1/S + 1/4S^2)
-            B[site1] -= J * (2r*sⱼ*(sᵢ⋅sⱼ) - sⱼ/2)
-            B[site2] -= J * (2r*sᵢ*(sᵢ⋅sⱼ) - sᵢ/2)
-        elseif sys.mode == :large_S
-            B[site1] -= J * 2sⱼ*(sᵢ⋅sⱼ)
-            B[site2] -= J * 2sᵢ*(sᵢ⋅sⱼ)
-        elseif sys.mode == :SUN
-            error("Biquadratic currently unsupported in SU(N) mode.")
+        if coupling.bilin isa Float64
+            J = coupling.bilin::Float64
+            B[site1] -= J  * sⱼ
+            B[site2] -= J' * sᵢ
+        else
+            J = coupling.bilin::Mat3
+            B[site1] -= J  * sⱼ
+            B[site2] -= J' * sᵢ
+        end
+
+        if !iszero(coupling.biquad)
+            J = coupling.biquad
+            if sys.mode == :dipole
+                Sᵢ = (sys.Ns[site1]-1)/2
+                Sⱼ = (sys.Ns[site2]-1)/2
+                S = √(Sᵢ*Sⱼ)
+                # Renormalization introduces a factor r and a Heisenberg term
+                r = (1 - 1/S + 1/4S^2)
+                B[site1] -= J * (2r*sⱼ*(sᵢ⋅sⱼ) - sⱼ/2)
+                B[site2] -= J * (2r*sᵢ*(sᵢ⋅sⱼ) - sᵢ/2)
+            elseif sys.mode == :large_S
+                B[site1] -= J * 2sⱼ*(sᵢ⋅sⱼ)
+                B[site2] -= J * 2sᵢ*(sᵢ⋅sⱼ)
+            elseif sys.mode == :SUN
+                error("Biquadratic currently unsupported in SU(N) mode.")
+            end
         end
     end
 end
 
+
 # Produces a function that iterates over a list interactions for a given cell
 function inhomog_bond_iterator(latsize, cell)
-    return function foreachbond(f, ints)
-        for (; isculled, bond, J) in ints
+    return function foreachbond(f, pcs)
+        for pc in pcs
             # Early return to avoid double-counting a bond
-            isculled && break
+            pc.isculled && break
 
             # Neighboring cell may wrap the system
-            cell′ = offsetc(cell, bond.n, latsize)
-            f(J, CartesianIndex(cell, bond.i), CartesianIndex(cell′, bond.j))
+            cell′ = offsetc(cell, pc.bond.n, latsize)
+            f(pc, CartesianIndex(cell, pc.bond.i), CartesianIndex(cell′, pc.bond.j))
         end
     end
 end
@@ -371,14 +361,14 @@ end
 # Produces a function that iterates over a list of interactions, involving all
 # pairs of cells in a homogeneous system
 function homog_bond_iterator(latsize)
-    return function foreachbond(f, ints)
-        for (; isculled, bond, J) in ints
+    return function foreachbond(f, pcs)
+        for pc in pcs
             # Early return to avoid double-counting a bond
-            isculled && break
+            pc.isculled && break
 
             # Iterate over all cells and periodically shifted neighbors
-            for (ci, cj) in zip(CartesianIndices(latsize), CartesianIndicesShifted(latsize, Tuple(bond.n)))
-                f(J, CartesianIndex(ci, bond.i), CartesianIndex(cj, bond.j))
+            for (ci, cj) in zip(CartesianIndices(latsize), CartesianIndicesShifted(latsize, Tuple(pc.bond.n)))
+                f(pc, CartesianIndex(ci, pc.bond.i), CartesianIndex(cj, pc.bond.j))
             end
         end
     end

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -150,7 +150,7 @@ function local_energy_change(sys::System{N}, site, state::SpinState) where N
         if !iszero(coupling.biquad)
             J = coupling.biquad
             if sys.mode == :dipole
-                # Renormalization introduces a factor r and a Heisenberg term
+                # Renormalization defined in https://arxiv.org/abs/2304.03874.
                 Sᵢ = (sys.Ns[site]-1)/2
                 Sⱼ = (sys.Ns[cellⱼ, bond.j]-1)/2
                 S = √(Sᵢ*Sⱼ)
@@ -242,7 +242,7 @@ function energy_aux(sys::System{N}, ints::Interactions, i::Int, cells, foreachbo
         if !iszero(coupling.biquad)
             J = coupling.biquad
             if sys.mode == :dipole
-                # Renormalization introduces a factor r and a Heisenberg term
+                # Renormalization defined in https://arxiv.org/abs/2304.03874.
                 Sᵢ = (sys.Ns[site1]-1)/2
                 Sⱼ = (sys.Ns[site2]-1)/2
                 S = √(Sᵢ*Sⱼ)
@@ -316,8 +316,7 @@ function set_forces_aux!(B, dipoles::Array{Vec3, 4}, ints::Interactions, sys::Sy
         if !iszero(coupling.biquad)
             J = coupling.biquad
             if sys.mode == :dipole
-                # Renormalization procedure introduces a factor r and a
-                # Heisenberg term, https://arxiv.org/abs/2304.03874.
+                # Renormalization defined in https://arxiv.org/abs/2304.03874.
                 Sᵢ = (sys.Ns[site1]-1)/2
                 Sⱼ = (sys.Ns[site2]-1)/2
                 S = √(Sᵢ*Sⱼ)

--- a/src/System/OnsiteCoupling.jl
+++ b/src/System/OnsiteCoupling.jl
@@ -1,4 +1,4 @@
-function SingleIonAnisotropy(sys::System, op, N)
+function OnsiteCoupling(sys::System, op, N)
     if sys.mode ∈ (:dipole, :SUN)
         # Convert `op` to a traceless Hermitian matrix
         matrep = operator_to_matrix(op; N)
@@ -25,10 +25,10 @@ function SingleIonAnisotropy(sys::System, op, N)
         stvexp = StevensExpansion(c[2], c[4], c[6])
     end
     
-    return SingleIonAnisotropy(matrep, stvexp)
+    return OnsiteCoupling(matrep, stvexp)
 end
 
-function SingleIonAnisotropy(sys::System, matrep::Matrix{ComplexF64}, N)
+function OnsiteCoupling(sys::System, matrep::Matrix{ComplexF64}, N)
     # Remove trace
     matrep -= (tr(matrep)/N)*I
     if norm(matrep) < 1e-12
@@ -45,7 +45,7 @@ function SingleIonAnisotropy(sys::System, matrep::Matrix{ComplexF64}, N)
         stvexp = StevensExpansion(c[2], c[4], c[6])
     end
     
-    return SingleIonAnisotropy(matrep, stvexp)
+    return OnsiteCoupling(matrep, stvexp)
 end
 
 
@@ -62,10 +62,10 @@ end
 function empty_anisotropy(N)
     matrep = zeros(ComplexF64, N, N)
     stvexp = StevensExpansion(zeros(5), zeros(9), zeros(13))
-    return SingleIonAnisotropy(matrep, stvexp)
+    return OnsiteCoupling(matrep, stvexp)
 end
 
-function Base.iszero(onsite::SingleIonAnisotropy)
+function Base.iszero(onsite::OnsiteCoupling)
     return iszero(onsite.matrep) && iszero(onsite.stvexp.kmax)
 end
 
@@ -153,7 +153,7 @@ function set_onsite_coupling!(sys::System{N}, op::Matrix{ComplexF64}, i::Int) wh
         println("Warning: Overriding anisotropy for atom $i.")
     end
 
-    onsite = SingleIonAnisotropy(sys, op, sys.Ns[1,1,1,i])
+    onsite = OnsiteCoupling(sys, op, sys.Ns[1,1,1,i])
 
     cryst = sys.crystal
     for j in all_symmetry_related_atoms(cryst, i)
@@ -172,7 +172,7 @@ function set_onsite_coupling!(sys::System{N}, op::Matrix{ComplexF64}, i::Int) wh
         # remains invariant when applied to the transformed spins.
         matrep′ = rotate_operator(onsite.matrep, Q')
         stvexp′ = rotate_operator(onsite.stvexp, Q')
-        ints[j].onsite = SingleIonAnisotropy(matrep′, stvexp′)
+        ints[j].onsite = OnsiteCoupling(matrep′, stvexp′)
     end
 end
 
@@ -190,7 +190,7 @@ function set_onsite_coupling_at!(sys::System{N}, op::Matrix{ComplexF64}, site::S
     is_homogeneous(sys) && error("Use `to_inhomogeneous` first.")
     ints = interactions_inhomog(sys)
     site = to_cartesian(site)
-    ints[site].onsite = SingleIonAnisotropy(sys, op, sys.Ns[site])
+    ints[site].onsite = OnsiteCoupling(sys, op, sys.Ns[site])
 end
 
 

--- a/src/System/OnsiteCoupling.jl
+++ b/src/System/OnsiteCoupling.jl
@@ -49,6 +49,8 @@ function OnsiteCoupling(sys::System, matrep::Matrix{ComplexF64}, N)
 end
 
 
+# k-dependent renormalization of Stevens operators O[k,q] as derived in
+# https://arxiv.org/abs/2304.03874.
 function anisotropy_renormalization(N)
     S = (N-1)/2
     return ((1), # k=1

--- a/src/System/PairExchange.jl
+++ b/src/System/PairExchange.jl
@@ -21,7 +21,7 @@ function to_float_or_mat3(J)
     else
         J = Mat3(J)
     end
-    return J
+    return J::Union{Float64, Mat3}
 end
 
 # Internal function only

--- a/src/System/SingleIonAnisotropy.jl
+++ b/src/System/SingleIonAnisotropy.jl
@@ -65,8 +65,8 @@ function empty_anisotropy(N)
     return SingleIonAnisotropy(matrep, stvexp)
 end
 
-function Base.iszero(aniso::SingleIonAnisotropy)
-    return iszero(aniso.matrep) && iszero(aniso.stvexp.kmax)
+function Base.iszero(onsite::SingleIonAnisotropy)
+    return iszero(onsite.matrep) && iszero(onsite.stvexp.kmax)
 end
 
 function rotate_operator(stevens::StevensExpansion, R)
@@ -149,11 +149,11 @@ function set_onsite_coupling!(sys::System{N}, op::Matrix{ComplexF64}, i::Int) wh
 
     (1 <= i <= natoms(sys.crystal)) || error("Atom index $i is out of range.")
 
-    if !iszero(ints[i].aniso)
+    if !iszero(ints[i].onsite)
         println("Warning: Overriding anisotropy for atom $i.")
     end
 
-    aniso = SingleIonAnisotropy(sys, op, sys.Ns[1,1,1,i])
+    onsite = SingleIonAnisotropy(sys, op, sys.Ns[1,1,1,i])
 
     cryst = sys.crystal
     for j in all_symmetry_related_atoms(cryst, i)
@@ -170,9 +170,9 @@ function set_onsite_coupling!(sys::System{N}, op::Matrix{ComplexF64}, i::Int) wh
         # In moving from site i to j, a spin S rotates to Q S. Transform the
         # anisotropy operator using the inverse rotation Q' so that the energy
         # remains invariant when applied to the transformed spins.
-        matrep′ = rotate_operator(aniso.matrep, Q')
-        stvexp′ = rotate_operator(aniso.stvexp, Q')
-        ints[j].aniso = SingleIonAnisotropy(matrep′, stvexp′)
+        matrep′ = rotate_operator(onsite.matrep, Q')
+        stvexp′ = rotate_operator(onsite.stvexp, Q')
+        ints[j].onsite = SingleIonAnisotropy(matrep′, stvexp′)
     end
 end
 
@@ -190,7 +190,7 @@ function set_onsite_coupling_at!(sys::System{N}, op::Matrix{ComplexF64}, site::S
     is_homogeneous(sys) && error("Use `to_inhomogeneous` first.")
     ints = interactions_inhomog(sys)
     site = to_cartesian(site)
-    ints[site].aniso = SingleIonAnisotropy(sys, op, sys.Ns[site])
+    ints[site].onsite = SingleIonAnisotropy(sys, op, sys.Ns[site])
 end
 
 

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -452,15 +452,15 @@ spin_operators(sys::System{N}, site::Site) where N = spin_matrices(N=sys.Ns[to_a
     stevens_operators(sys, site::Int)
 
 Returns a generator of Stevens operators appropriate to an atom or
-[`Site`](@ref) index. The return value `O` can be indexed as `O[q,m]`, where ``0
-≤ q ≤ 6`` labels an irrep and ``m = -q, …, q``. This will produce an ``N×N``
+[`Site`](@ref) index. The return value `O` can be indexed as `O[k,q]`, where ``0
+≤ k ≤ 6`` labels an irrep and ``q = -k, …, k``. This will produce an ``N×N``
 matrix of appropriate dimension ``N``.
 """
 stevens_operators(sys::System{N}, i::Int) where N = StevensMatrices(sys.Ns[i])
 stevens_operators(sys::System{N}, site::Site) where N = StevensMatrices(sys.Ns[to_atom(site)])
 
 
-function spin_operators(sys::System{N}, b::Bond) where N
+function spin_operators_pair(sys::System{N}, b::Bond) where N
     Si = spin_matrices(N=sys.Ns[b.i])
     Sj = spin_matrices(N=sys.Ns[b.j])
     return local_quantum_operators(Si, Sj)

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -280,8 +280,7 @@ end
 Given a [`Bond`](@ref) for the original (unreshaped) crystal, return all
 symmetry equivalent bonds in the [`System`](@ref). Each returned bond is
 represented as a pair of [`Site`](@ref)s, which may be used as input to
-[`set_exchange_at!`](@ref) or [`set_biquadratic_at!`](@ref). Reverse bonds are
-not included (no double counting).
+[`set_exchange_at!`](@ref). Reverse bonds are not included (no double counting).
 
 # Example
 ```julia

--- a/src/System/Types.jl
+++ b/src/System/Types.jl
@@ -16,17 +16,21 @@ struct SingleIonAnisotropy
     stvexp :: StevensExpansion      # Renormalized coefficients for Stevens functions
 end
 
-struct Coupling{T}
+struct PairCoupling
     isculled :: Bool
     bond     :: Bond
-    J        :: T
+
+    bilin    :: Union{Float64, Mat3} # Bilinear exchange as 3×3 matrix
+    biquad   :: Float64              # Scalar biquadratic, only valid in dipole mode
+
+    # General pair interactions, only valid in SU(N) mode
+    # general  :: Vector{Tuple{Hermitian{ComplexF64}, Hermitian{ComplexF64}}}
+    # TODO: update clone_interactions(), set_interactions_from_origin!
 end
 
 mutable struct Interactions
-    aniso    :: SingleIonAnisotropy
-    heisen   :: Vector{Coupling{Float64}}
-    exchange :: Vector{Coupling{Mat3}}
-    biquad   :: Vector{Coupling{Float64}}
+    onsite    :: SingleIonAnisotropy
+    pair      :: Vector{PairCoupling}
 end
 
 const rFTPlan = FFTW.rFFTWPlan{Float64, -1, false, 5, UnitRange{Int64}}

--- a/src/System/Types.jl
+++ b/src/System/Types.jl
@@ -65,7 +65,7 @@ mutable struct System{N}
     # inhomogeneous (defined for every cell in the system).
     interactions_union     :: Union{Vector{Interactions}, Array{Interactions,4}}
 
-    # Optional long-range dipole-dipole interactions (Vector is mutable box)
+    # Optional long-range dipole-dipole interactions
     ewald                  :: Union{Ewald, Nothing}
 
     # Dynamical variables and buffers

--- a/src/System/Types.jl
+++ b/src/System/Types.jl
@@ -11,7 +11,7 @@ struct StevensExpansion
     end
 end
 
-struct SingleIonAnisotropy
+struct OnsiteCoupling
     matrep :: Matrix{ComplexF64}    # Matrix representation in some dimension N
     stvexp :: StevensExpansion      # Renormalized coefficients for Stevens functions
 end
@@ -29,7 +29,7 @@ struct PairCoupling
 end
 
 mutable struct Interactions
-    onsite    :: SingleIonAnisotropy
+    onsite    :: OnsiteCoupling
     pair      :: Vector{PairCoupling}
 end
 

--- a/test/shared.jl
+++ b/test/shared.jl
@@ -41,7 +41,9 @@ function add_quartic_interactions!(sys, mode)
         set_onsite_coupling!(sys, 0.2*(S[1]^4+S[2]^4+S[3]^4), 1)
     end
     if mode == :large_S
-        set_biquadratic!(sys, 0.2, Bond(1, 3, [0, 0, 0]))
+        # We must exclude :dipole because the renormalization will introduce a
+        # quadratic Heisenberg interaction
+        set_exchange!(sys, 0.0, Bond(1, 3, [0, 0, 0]); biquad=0.2)
     end
 end
 

--- a/test/test_energy_consistency.jl
+++ b/test/test_energy_consistency.jl
@@ -27,8 +27,8 @@
             @test energy(sys2) ≈ energy(sys)
             set_vacancy_at!(sys2, (1,1,1,1))
             set_exchange_at!(sys2, 0.5, (1,1,1,1), (2,1,1,2); offset=(1, 0, 0))
-            if mode != :SUN
-               set_biquadratic_at!(sys2, 0.7, (3,2,1,2), (3,1,1,3); offset=(0,-1,0))
+            if mode != :SUN # kbtodo
+               set_exchange_at!(sys2, 0.0, (3,2,1,2), (3,1,1,3); biquad=0.7, offset=(0,-1,0))
             end
 
             S = spin_operators(sys2, 4)

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -137,10 +137,8 @@ end
         α = -0.4 * π
         J = 1.0
         JL, JQ = J * cos(α), J * sin(α) / S^2
-        set_exchange!(sys_SUN, JL,  Bond(1, 1, [1, 0, 0]))
-        set_biquadratic!(sys_SUN, JQ,  Bond(1, 1, [1, 0, 0]))
-        set_exchange!(sys_dip, JL,  Bond(1, 1, [1, 0, 0]))
-        set_biquadratic!(sys_dip, JQ,  Bond(1, 1, [1, 0, 0]))
+        set_exchange!(sys_SUN, JL,  Bond(1, 1, [1, 0, 0]); biquad=JQ)
+        set_exchange!(sys_dip, JL,  Bond(1, 1, [1, 0, 0]); biquad=JQ)
 
         sys_swt_SUN = reshape_geometry(sys_SUN, [1 1 1; -1 1 0; 0 0 1])
         polarize_spin!(sys_swt_SUN, ( 1, 0, 0), position_to_site(sys_swt_SUN, (0, 0, 0)))


### PR DESCRIPTION
Internal cleanups to unify treatment of pair couplings. In particular, each atom now stores only a single list of PairCouplings, which may contain bilinear (scalar or matrix) and biquadratic (scalar-only) exchange.

The function `set_biquadratic!` has been removed. Instead, call `set_exchange!` with the keyword argument `biquad`.

The changes to the internal datastructures will require updates to LSWT, which should also be incorporated into the branches of @Hao-Phys and @hlane33.
