### PR TITLE
Switch docs execution from Literate to Documenter

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ using Literate, Documenter, Sunny
 import DynamicPolynomials # get symbolic functions
 import GLMakie # get plotting functions
 
-execute = true # set `false` to disable cell evaluation
+draft = false # set `true` to disable cell evaluation
 
 example_names = ["fei2_tutorial", "powder_averaging", "ising2d", "binning_tutorial"]
 example_sources = [joinpath(@__DIR__, "..", "examples", name*".jl") for name in example_names]
@@ -13,7 +13,7 @@ example_destination = joinpath(@__DIR__, "src", "examples")
 example_doc_paths = ["examples/$name.md" for name in example_names]
 
 for source in example_sources
-    Literate.markdown(source, example_destination; documenter=true)
+    Literate.markdown(source, example_destination)
 end
 
 makedocs(
@@ -30,7 +30,7 @@ makedocs(
         prettyurls = get(ENV, "CI", nothing) == "true",
         ansicolor = true
     ),
-    draft=!execute
+    draft
 )
 
 deploydocs(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,7 +29,7 @@ makedocs(
     format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",
         ansicolor = true
-    ),
+    );
     draft
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,7 @@ example_destination = joinpath(@__DIR__, "src", "examples")
 example_doc_paths = ["examples/$name.md" for name in example_names]
 
 for source in example_sources
-    Literate.markdown(source, example_destination; execute, documenter=true)
+    Literate.markdown(source, example_destination; documenter=true)
 end
 
 makedocs(
@@ -27,7 +27,8 @@ makedocs(
         "Version History" => "versions.md",
     ],
     format = Documenter.HTML(
-        prettyurls = get(ENV, "CI", nothing) == "true"
+        prettyurls = get(ENV, "CI", nothing) == "true",
+        ansicolor = true
     ),
     draft=!execute
 )


### PR DESCRIPTION
Documenter:

![image](https://github.com/SunnySuite/Sunny.jl/assets/2996388/d0c0bc1b-d5fd-41b5-9388-b44d0e1280f6)

Literate:

![image](https://github.com/SunnySuite/Sunny.jl/assets/2996388/8db4283b-d687-4ef1-b31d-9dfa6af8737f)

This is a PR because it's technically a super big change to how the docs are created. I don't think there are any bad side effects (the docs build OK locally) but maybe this breaks the CI somehow?