### PR TITLE
Optimization of spin configurations (dipoles and coherents)

### DIFF
--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -49,18 +49,26 @@ end
 # Coordinate systems
 ################################################################################
 
+using LinearAlgebra, StaticArrays, BenchmarkTools
 struct StereographicPoint{Nm1}
     chart :: Int
-    coord :: SVector{Nm1, Float64}
+    coord :: NTuple{Nm1, Float64}
 end
 
-function vec_to_stereo(vec::SVector{N, Float64}) where N  # N parameter unnecessary here, but generalizes to ℝP^{N-1}
-    remaining_indices(skip, max) = ntuple(i -> i > (skip-1) ? i + 1 : i, max-1)
+function Base.show(io::IO, ::MIME"text/plain", sp::StereographicPoint{Nm1}) where Nm1
+    println(io, "($(sp.coord[1]), $(sp.coord[2])) in ⟂$(sp.chart)-plane")
+end
 
-    plane_idx = argmax(vec)               
-    is = remaining_indices(plane_idx, N)   
+@inline δ(i,j) = i == j ? 1 : 0
+@inline remaining_indices(skip, max) = ntuple(i -> i > (skip-1) ? i + 1 : i, max-1)
+toNidx(i, c) = i > c ? i - 1 : i
+
+function vec_to_stereo(vec::SVector{N, Float64}) where N  # N parameter unnecessary here, but generalizes to ℝP^{N-1}
+    plane_idx = argmin(vec) # Project onto plane perpendicular to axis corresponding
+                            # to the minimal vector component, i.e. ⟂ ̂x_min
+    other_idxs = remaining_indices(plane_idx, N)   
     denom = 1 - vec[plane_idx]             
-    StereographicPoint{N-1}(plane_idx, ntuple(i -> vec[is[i]]/denom, N-1)) 
+    StereographicPoint{N-1}(plane_idx, ntuple(i -> vec[other_idxs[i]]/denom, N-1)) 
 end
 
 function stereo_to_vec(sp::StereographicPoint{Nm1}) where Nm1
@@ -70,7 +78,7 @@ function stereo_to_vec(sp::StereographicPoint{Nm1}) where Nm1
             if i < sp.chart
                 2sp.coord[i]/(1+r2)
             elseif i == sp.chart
-                (-1 + r2)/(1+r2)
+                (-1+r2)/(1+r2)
             else
                 2sp.coord[i-1]/(1+r2)
             end
@@ -78,21 +86,61 @@ function stereo_to_vec(sp::StereographicPoint{Nm1}) where Nm1
     )
 end
 
+@inline remap_stereo(sp) = sp |> stereo_to_vec |> vec_to_stereo
+
+function stereo_jac!(jac, sp::StereographicPoint{Nm1}) where Nm1 # Hardy-har
+    c, X = sp.chart, sp.coord
+    r2 = mapreduce(x -> x^2, +, X)
+    for j in 1:Nm1+1, k in 1:Nm1
+        jac[k,j] = if j == c
+            (2X[k]/(r2+1))*(1 + (r2-1)/(r2+1))
+        else
+            (2/(r2+1))*(δ(j,k) + (2X[toNidx(j,c)]*X[k])/(r2+1))
+        end
+    end
+    jac
+end
+
+function stereo_jac(sp::StereographicPoint{Nm1}) where Nm1
+    jac = zeros(Nm1, Nm1+1)
+    @time stereo_jac!(jac, sp)
+end
 
 
-# Tests
-# for _ in 1:20
-#     N = 3
-#     vec = SVector{N, Float64}(normalize(rand(N)))
-#     sp = vec_to_stereo(vec)
-#     println(stereo_to_vec(sp) ≈ vec ? "Good" : "Bad")
-# end
-# 
-# begin
-#     N = 3
-#     vec = SVector{N, Float64}(normalize(rand(N)))
-#     sp = vec_to_stereo(vec)
-#     @btime vec_to_stereo($vec)
-#     vec1 = stereo_to_vec(sp)
-#     @btime stereo_to_vec($sp)
-# end
+
+## Tests
+# Test display
+for _ in 1:10
+    N = 3
+    vec = SVector{N, Float64}(normalize(rand(N)))
+    sp = vec_to_stereo(vec)
+    display(sp)
+end
+
+# Test invertibility
+for _ in 1:20
+    N = 3
+    vec = SVector{N, Float64}(normalize(rand(N)))
+    sp = vec_to_stereo(vec)
+    println(stereo_to_vec(sp) ≈ vec ? "Good" : "Bad")
+end
+
+# Test reparameterization
+begin
+    sp = StereographicPoint{2}(1, (2.1, 0.2))
+    vec = stereo_to_vec(sp)
+    sp2 = remap_stereo(sp)
+end
+
+# Benchmark
+begin
+    N = 3
+    vec = SVector{N, Float64}(normalize(rand(N)))
+    sp = vec_to_stereo(vec)
+    @btime vec_to_stereo($vec)
+    vec1 = stereo_to_vec(sp)
+    @btime stereo_to_vec($sp)
+    sp2 = remap_stereo(sp)
+    @btime remap_stereo($sp)
+end
+

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -1,87 +1,161 @@
-# Converts unnormalized representation of coherent state, α, to standard dipole
-# or normalized complex vector representation.
-function projective_to_conventional(α::SVector{N, T}, z::SVector{N, T}) where {N, T}
-    v = (I - z*z')*α  # Automatically infers that `I` should be an SMatrix (no allocations)
-    v2 = v'*v
-    (2v + (1-v2)*z) / (1+v2)  # Guaranteed to be normalized
+# The following four helper functions allow for more code resuse since the
+# projective parameterization is formally the same for both dipoles and coherent
+# states (the element types are just real in the first case, compelx in the
+# second).
+function set_forces_optim!(Hgrad, B, sys::System{N}) where {N}
+    Sunny.set_forces_dipoles!(B, sys.dipoles, sys)
+    Sunny.set_forces_coherents!(Hgrad, B, sys.coherents, sys)
 end
 
-# Calculate du(α)/dα and apply to vec.
-@inline function apply_projective_jacobian(vec, α::SVector{N, T}, z::SVector{N, T}) where {N, T}
+function set_forces_optim!(Hgrad, _, sys::System{0}) 
+    Sunny.set_forces_dipoles!(Hgrad, sys.dipoles, sys)
+end
+
+@inline function set_spin_optim!(sys::System{N}, α, z, site) where N
+    set_coherent_state!(sys, projective_to_conventional(α, z), site)
+end
+
+@inline function set_spin_optim!(sys::System{0}, α, z, site)
+    polarize_spin!(sys, projective_to_conventional(α, z), site)
+end
+
+# Converts unnormalized representation of coherent state, α, to standard dipole
+# or normalized complex vector representation.
+function projective_to_conventional(α, z)
+    v = (I - z*z')*α
+    v2 = v'*v
+    return (2v + (1-v2)*z) / (1+v2)  # Guaranteed to be normalized
+end
+
+# Calculate du(α)/dα and apply to `vec`. u(α) = (2v + (1-v²)z)/(1+v²) with v =
+# (1-zz†)α. Won't allocate if all inputs are StaticArrays.
+@inline function apply_projective_jacobian(vec, α, z)
     P = (I - z*z')
     v = P*α
+    v2 = v'*v 
+
     dv_dα = P 
     dv2_dα = 2*(α' - 2*(α'*z)*z')
-    v2 = v' * v 
-
     jac = (1/(1+v2)) * ((2dv_dα - (z*dv2_dα)') - (1/(1+v2)) * dv2_dα' * ((2v + (1-v2)*z)'))
 
     return jac * vec
 end
 
-# Calculate H(u(α)) for SU(N) mode 
-function optim_energy(αs, zs, sys::System{N}) where N
-    αs = reinterpret(reshape, SVector{N, ComplexF64}, αs)
+# Calculate H(u(α)) 
+function optim_energy(αs, zs, sys::System{N})::Float64 where N
+    T = N == 0 ? Vec3 : CVec{N} 
+    αs = reinterpret(reshape, T, αs)
     for site in all_sites(sys)
-        set_coherent_state!(sys, projective_to_conventional(αs[site], zs[site]), site)
+        set_spin_optim!(sys, αs[site], zs[site], site)
     end
-    return energy(sys)
+    return energy(sys) # Note: `Sunny.energy` seems to allocate and is type-unstable
 end
 
-# Calculate H(u(α)) for dipole mode 
-function optim_energy(αs, zs, sys::System{0})
-    αs = reinterpret(reshape, Vec3, αs)
-    for site in all_sites(sys)
-        polarize_spin!(sys, projective_to_conventional(αs[site], zs[site]), site)
+# Non-allocating check for largest unnormalized coordinate.
+function maxnorm(αs)
+    max = 0.0
+    for α in αs
+        magnitude = norm(α) 
+        max = magnitude > max ? magnitude : max
     end
-    return energy(sys)
+    return max
 end
 
-# Calculate dH(u(α))/dα for coherent states
-function optim_gradient!(buf, αs, zs, B, sys::System{N}) where N
-    αs = reinterpret(reshape, SVector{N, ComplexF64}, αs)
-    Hgrad = reinterpret(reshape, SVector{N, ComplexF64}, buf)
+# Calculate dH(u(α))/dα 
+function optim_gradient!(buf, αs, zs, B, sys::System{N}, halted, quickmode=false) where N
+    T = N == 0 ? Vec3 : CVec{N} 
+    jacsign = N == 0 ? -1 : 1  # Because set_forces_dipoles gives -dH/dS whereas set_forces_coherents gives dH/dZ*
+    αs = reinterpret(reshape, T, αs)
+    Hgrad = reinterpret(reshape, T, buf)
 
-    for site in all_sites(sys)
-        set_coherent_state!(sys, projective_to_conventional(αs[site], zs[site]), site)
+    # Check if any coordinate has gone adrift and signal need to reset if necessary
+    if !quickmode
+        maxdist = maxnorm(αs)
+        if maxdist > 1.5     # 1.5 found empirically, works well for both dipole and SU(3) 
+            Hgrad .*= 0      # Trick Optim.jl to stop by setting gradient to 0 (triggers convergence tests) 
+            halted[] = true  # Let main loop know we haven't really converged
+            return
+        end
     end
-    Sunny.set_forces!(B, sys.dipoles, sys)
-    Sunny.set_complex_forces!(Hgrad, B, sys.coherents, sys)
 
+    # Calculate gradient of energy with respect to α
     for site in all_sites(sys)
-        Hgrad[site] = apply_projective_jacobian(Hgrad[site], αs[site], zs[site])
+        set_spin_optim!(sys, αs[site], zs[site], site)
     end
-end
 
-# Calculate dH(u(α))/dα for dipoles
-function optim_gradient!(buf, αs, zs, _, sys::System{0})
-    αs = reinterpret(reshape, Vec3, αs)
-    Hgrad = reinterpret(reshape, Vec3, buf)
+    set_forces_optim!(Hgrad, B, sys)
 
     for site in all_sites(sys)
-        polarize_spin!(sys, projective_to_conventional(αs[site], zs[site]), site)
-    end
-    Sunny.set_forces!(Hgrad, sys.dipoles, sys)
-
-    for site in all_sites(sys)
-        Hgrad[site] = -apply_projective_jacobian(Hgrad[site], αs[site], zs[site])
+        Hgrad[site] = jacsign * apply_projective_jacobian(Hgrad[site], αs[site], zs[site])
     end
 end
 
-"""
-    minimize_energy!(sys::System{N}; method=Optim.LBFGS, maxiters = 10000, kwargs...) where N
-"""
-function minimize_energy!(sys::System{N}; method=Optim.LBFGS, maxiters = 10000, kwargs...) where N
+# Quick "touchup" optimization that assumes the system is already near the
+# ground state. Never changes the parameterization of coherent states or
+# dipoles. For internal use when setting up a spin wave calculation.
+function minimize_energy_touchup!(sys::System{N}; method=Optim.LBFGS, maxiters = 40, kwargs...) where N
     numbertype = N == 0 ? Float64 : ComplexF64
     buffer = N == 0 ? sys.dipoles : sys.coherents
     B = N == 0 ? nothing : get_dipole_buffers(sys, 1) |> only
 
     zs = copy(buffer)
     αs = zeros(numbertype, (N == 0 ? 3 : N, size(buffer)...))
+    halted = Ref(false)
 
     f(proj_coords) = optim_energy(proj_coords, zs, sys)
-    g!(G, proj_coords) = optim_gradient!(G, proj_coords, zs, B, sys)
+    g!(G, proj_coords) = optim_gradient!(G, proj_coords, zs, B, sys, halted, true) # true skips coordinate drifting test
 
     options = Optim.Options(iterations=maxiters, kwargs...)
-    Optim.optimize(f, g!, αs, method(), options)
+    output = Optim.optimize(f, g!, αs, method(), options)
+    success = Optim.converged(output)
+    if !success
+        @warn "Optimization failed to converge within $(output.iterations) iterations. `System` not in ground state and spin wave calculations may fail."
+    end
+
+    return success 
+end
+
+"""
+    minimize_energy!(sys::System{N}; method=Optim.LBFGS, maxiters = 1000, kwargs...) where N
+
+Optimizes the spin configuration in `sys` to minimize energy. Any method from
+Optim.jl that accepts only a gradient may be used by setting the `method`
+keyword. Defaults to LBFGS.
+"""
+function minimize_energy!(sys::System{N}; method=Optim.LBFGS, maxiters = 1000, kwargs...) where N
+
+    # Set up type and buffer information depending on system type
+    numbertype = N == 0 ? Float64 : ComplexF64
+    buffer = N == 0 ? sys.dipoles : sys.coherents
+    B = N == 0 ? nothing : get_dipole_buffers(sys, 1) |> only
+
+    # Allocate buffers for optimization
+    zs = copy(buffer)
+    αs = zeros(numbertype, (N == 0 ? 3 : N, size(buffer)...))
+    halted = Ref(false)
+
+    # Set up energy and gradient functions using closures to pass "constants" 
+    f(proj_coords) = optim_energy(proj_coords, zs, sys)
+    g!(G, proj_coords) = optim_gradient!(G, proj_coords, zs, B, sys, halted, false)
+
+    # Perform optimization, resetting parameterization of coherent states as necessary
+    options = Optim.Options(iterations=maxiters, kwargs...)
+    totaliters = 0
+    success = false
+    while totaliters < maxiters
+        output = Optim.optimize(f, g!, αs, method(), options)
+        if halted[]
+            zs .= buffer  # Reset parameterization based on current state
+            αs .*= 0      # Reset unnormalized coordinates
+            halted[] = false
+        else
+            if Optim.converged(output)  # Convergence report only meaningful if not halted
+                success = true
+                break  
+            end
+        end
+        totaliters += output.iterations
+    end
+
+    return success
 end

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -1,421 +1,86 @@
-function optim_energy(free_dipoles, sys::System{0})
-    norm_penalty(y) = 1/y^2 - 2/y
-    directions = reinterpret(reshape, SVector{3, Float64}, free_dipoles)
-    E = 0.0
-    for site in all_sites(sys)
-        polarize_spin!(sys, directions[site], site)
-        E += norm_penalty(norm(directions[site]))
-    end
-    return E + energy(sys)
+# Converts unnormalized representation of coherent state, α, to standard dipole
+# or normalized complex vector representation.
+function projective_to_conventional(α::SVector{N, T}, z::SVector{N, T}) where {N, T}
+    v = (I - z*z')*α  # Automatically infers that `I` should be an SMatrix (no allocations)
+    v2 = v'*v
+    (2v + (1-v2)*z) / (1+v2)  # Guaranteed to be normalized
 end
 
-function optim_gradient!(buf, free_dipoles, sys::System{0}) 
-    function grad_norm_penalty(dipole)
-        xx = dipole ⋅ dipole 
-        2*((√xx-1)/xx^2)*dipole
-    end
-    free_dipoles = reinterpret(reshape, SVector{3, Float64}, free_dipoles)
-    Hgrad = reinterpret(reshape, SVector{3, Float64}, buf)
+# Calculate du(α)/dα and apply to vec.
+@inline function apply_projective_jacobian(vec, α::SVector{N, T}, z::SVector{N, T}) where {N, T}
+    P = (I - z*z')
+    v = P*α
+    dv_dα = P 
+    dv2_dα = 2*(α' - 2*(α'*z)*z')
+    v2 = v' * v 
 
-    # Calculate gradient of energy in original coordinates
+    jac = (1/(1+v2)) * ((2dv_dα - (z*dv2_dα)') - (1/(1+v2)) * dv2_dα' * ((2v + (1-v2)*z)'))
+
+    return jac * vec
+end
+
+# Calculate H(u(α)) for SU(N) mode 
+function optim_energy(αs, zs, sys::System{N}) where N
+    αs = reinterpret(reshape, SVector{N, ComplexF64}, αs)
     for site in all_sites(sys)
-        polarize_spin!(sys, free_dipoles[site], site)
+        set_coherent_state!(sys, projective_to_conventional(αs[site], zs[site]), site)
+    end
+    return energy(sys)
+end
+
+# Calculate H(u(α)) for dipole mode 
+function optim_energy(αs, zs, sys::System{0})
+    αs = reinterpret(reshape, Vec3, αs)
+    for site in all_sites(sys)
+        polarize_spin!(sys, projective_to_conventional(αs[site], zs[site]), site)
+    end
+    return energy(sys)
+end
+
+# Calculate dH(u(α))/dα for coherent states
+function optim_gradient!(buf, αs, zs, B, sys::System{N}) where N
+    αs = reinterpret(reshape, SVector{N, ComplexF64}, αs)
+    Hgrad = reinterpret(reshape, SVector{N, ComplexF64}, buf)
+
+    for site in all_sites(sys)
+        set_coherent_state!(sys, projective_to_conventional(αs[site], zs[site]), site)
+    end
+    Sunny.set_forces!(B, sys.dipoles, sys)
+    Sunny.set_complex_forces!(Hgrad, B, sys.coherents, sys)
+
+    for site in all_sites(sys)
+        Hgrad[site] = apply_projective_jacobian(Hgrad[site], αs[site], zs[site])
+    end
+end
+
+# Calculate dH(u(α))/dα for dipoles
+function optim_gradient!(buf, αs, zs, _, sys::System{0})
+    αs = reinterpret(reshape, Vec3, αs)
+    Hgrad = reinterpret(reshape, Vec3, buf)
+
+    for site in all_sites(sys)
+        polarize_spin!(sys, projective_to_conventional(αs[site], zs[site]), site)
     end
     Sunny.set_forces!(Hgrad, sys.dipoles, sys)
 
-    # Calculate gradient in "new coordinates" and incorporate regularizing terms
     for site in all_sites(sys)
-        ixx = 1/(free_dipoles[site] ⋅ free_dipoles[site])
-        jac = √ixx * (I - ixx * (free_dipoles[site] * free_dipoles[site]'))
-        Hgrad[site] = -jac * Hgrad[site] + grad_norm_penalty(free_dipoles[site]) # Note Optim expects ∇, `set_forces!` gives -∇
+        Hgrad[site] = -apply_projective_jacobian(Hgrad[site], αs[site], zs[site])
     end
 end
 
 """
-    minimize_energy!(sys; method=Optim.LBFGS, kwargs...)
-
-Minimize the energy of a spin system using either LBFGS (`method=Optim.LBFGS`)
-or Conjugate Gradient (`method=Optim.ConjugateGradient`) methods. Currently only
-works for systems in dipole mode. 
+    minimize_energy!(sys::System{N}; method=Optim.LBFGS, maxiters = 10000, kwargs...) where N
 """
-function minimize_energy!(sys; method=Optim.LBFGS, kwargs...)
-    f(spins) = optim_energy(spins, sys)
-    g!(G, spins) = optim_gradient!(G, spins, sys)
-    free_dipoles = Array(reinterpret(reshape, Float64, sys.dipoles))
-    Optim.optimize(f, g!, free_dipoles, method(), kwargs...) 
-end
-
-
-################################################################################
-# Coordinates for ℝP^{N-1} 
-################################################################################
-struct StereographicPoint{N}
-    data :: NTuple{N, Float64}
-end
-
-function StereographicPoint(i, coords::NTuple{N, Float64}) where N
-    StereographicPoint{Nm1+1}((coords..., Float64(i)))
-end
-
-Base.getindex(sp::StereographicPoint, i) = getindex(sp.data, i)
-
-function Base.show(io::IO, ::MIME"text/plain", sp::StereographicPoint{Nm1}) where Nm1
-    println(io, "($(sp.data[1]), $(sp.data[2])) in ⟂$(Int(sp.data[3]))-plane")
-end
-
-@inline remaining_indices(skip, max) = ntuple(i -> i > (skip-1) ? i + 1 : i, max-1)
-@inline chart(sp::StereographicPoint) = Int64(sp.data[end])
-
-function vec_to_stereo(vec::SVector{N, Float64}) where N  # N parameter unnecessary here, but generalizes to ℝP^{N-1}
-    plane_idx = argmin(vec) # Project onto closest plane, i.e. the plane 
-                            # perpendicular to the axis corresponding
-                            # to the minimal vector component (⟂ ̂x_min)
-    other_idxs = remaining_indices(plane_idx, N)   
-    denom = 1 - vec[plane_idx]             
-    StereographicPoint{N}(ntuple(i -> i < N ? vec[other_idxs[i]]/denom : Float64(plane_idx), N)) 
-end
-
-function stereo_to_vec(sp::StereographicPoint{N}) where N
-    c = chart(sp)
-    r2 = mapreduce(x -> x^2, +, sp.data[1:end-1])
-    SVector{N,Float64}(
-        ntuple(N) do i
-            if i < c
-                2sp[i]/(1+r2)
-            elseif i == c
-                (-1+r2)/(1+r2)
-            else
-                2sp[i-1]/(1+r2)
-            end
-        end
-    )
-end
-
-@inline remap_stereo(sp) = sp |> stereo_to_vec |> vec_to_stereo
-
-function stereo_jac!(jac, sp::StereographicPoint{N}) where N # Hardy-har
-    δ(i,j) = i == j ? 1 : 0
-    Nidx(i, c) = i > c ? i - 1 : i
-
-    c = chart(sp)
-    r2 = mapreduce(x -> x^2, +, sp.data[1:end-1])
-    for j in 1:N, k in 1:N-1
-        jac[k,j] = if j == c
-            (2sp[k]/(r2+1))*(1 - (r2-1)/(r2+1))
-        else
-            (2/(r2+1))*(δ(Nidx(j,c),k) - (2sp[Nidx(j,c)]*sp[k])/(r2+1))
-        end
-    end
-end
-
-################################################################################
-# Optimization with stereographic coordinates
-################################################################################
-function optim_energy_stereo(stereo_coords, sys::System{0})
-    stereo_coords = reinterpret(reshape, StereographicPoint{3}, stereo_coords)
-    for site in all_sites(sys)
-        set_coherent_state!(sys, stereo_to_vec(stereo_coords[site]), site)
-    end
-    return energy(sys)
-end
-
-function optim_gradient_stereo!(buf, stereo_coords, sys::System{0}) 
-    stereo_coords = reinterpret(reshape, StereographicPoint{3}, stereo_coords)
-    Hgrad = reinterpret(reshape, SVector{3, Float64}, buf)
-
-    # Calculate gradient of energy in original coordinates
-    for site in all_sites(sys)
-        set_coherent_state!(sys, stereo_to_vec(stereo_coords[site]), site)
-    end
-    Sunny.set_forces!(Hgrad, sys.coherents, sys)
-
-    # Calculate gradient, using Jacobian for stereographic coordinates 
-    jac = zeros(3,3)  # Maybe write function to apply matrix multiply and avoid allocation
-    for site in all_sites(sys)
-        stereo_jac!(jac, stereo_coords[site])
-        Hgrad[site] = -jac * Hgrad[site]  # Note Optim expects ∇, `set_forces!` gives -∇
-    end
-end
-
-
-
-# Under construction
-function minimize_energy_stereo!(sys; method=Optim.LBFGS, maxiters = 100, kwargs...)
-    f(stereo_spins) = optim_energy_stereo(stereo_spins, sys)
-    g!(G, stereo_spins) = optim_gradient_stereo!(G, stereo_spins, sys)
-    # fg!(energy_spins, G, x) = stereo_energy_grad!(stereo_spins, G, sys)
-
-    options = Optim.Options(iterations=10, kwargs...)
-
-    # Quick test if any coordinates every go to infinity 
-    niters = 0
-    success = false
-    while niters < maxiters
-        niters += 1
-        stereo_spins = map(vec -> vec_to_stereo(vec), sys.dipoles) 
-        stereo_spins = Array(reinterpret(reshape, Float64, stereo_spins))
-        # stereo_spins = map!(vec -> vec_to_stereo(vec), stereo_spins, sys.dipoles) 
-        optout = Optim.optimize(f, g!, stereo_spins, method(), options)
-        if optout.g_converged
-            println("We got there.")
-            return true
-        end
-        # println("Maximum: ", maximum(stereo_spins))
-        # println(stereo_spins)
-        if maximum(stereo_spins) > 5.0
-            println("Remapping coords...")
-            stereo_spins = reinterpret(reshape, StereographicPoint{3}, stereo_spins)
-            @. stereo_spins = remap_stereo(stereo_spins)
-        end
-        println("Trying again...")
-    end
-
-    return success
-end
-
-################################################################################
-# Coordinates for ℂP^{N-1} 
-################################################################################
-
-struct CPAffineCoordinate{N}
-    data :: NTuple{N, ComplexF64}
-end
-
-function CPAffineCoordinate(i, coords::NTuple{Nm1, ComplexF64}) where Nm1
-    CPAffineCoordinate{Nm1+1}((coords..., ComplexF64(i)))
-end
-
-Base.getindex(sp::CPAffineCoordinate, i) = getindex(sp.data, i)
-
-function Base.show(io::IO, ::MIME"text/plain", cp::CPAffineCoordinate{N}) where N
-    println(io, "$( "(" * prod( [string(round(x; sigdigits=3))*", " for x in cp.data[1:end-2]]) * "$(string(round(cp.data[end-2]; sigdigits=3))))" ) in ⟂$(Int(cp.data[end]))-plane")
-end
-
-@inline chart(cp::CPAffineCoordinate) = Int64(cp.data[end])
-
-function vec_to_affine(vec::SVector{N, ComplexF64}) where N  # N parameter unnecessary here, but generalizes to ℝP^{N-1}
-    plane_idx = argmax(norm.(vec)) # Choose projection coordinate
-    other_idxs = remaining_indices(plane_idx, N)   
-    denom = vec[plane_idx] 
-    CPAffineCoordinate{N}(ntuple(i -> i < N ? vec[other_idxs[i]]/denom : ComplexF64(plane_idx), N)) 
-end
-
-function affine_to_vec(cp::CPAffineCoordinate{N}) where N
-    c = chart(cp)
-    r2 = mapreduce(x -> x^2, +, cp.data[1:end-1])
-    SVector{N,ComplexF64}(
-        ntuple(N) do i
-            if i < c
-                cp[i]/sqrt(1+r2)
-            elseif i == c
-                1/sqrt(1+r2)
-            else
-                cp[i-1]/sqrt(1+r2)
-            end
-        end
-    ) |> normalize
-end
-
-@inline remap_affine(cp) = cp |> affine_to_vec |> vec_to_affine
-
-function affine_jac!(jac, cp::CPAffineCoordinate{N}) where N
-    δ(i,j) = i == j ? 1 : 0
-    Nidx(i, c) = i > c ? i - 1 : i
-
-    c = chart(cp)
-    r2 = mapreduce(x -> x^2, +, cp.data[1:end-1])
-    for j in 1:N, k in 1:N-1
-        jac[k,j] = if j == c
-            -cp[k]/((1+r2)^(3/2))
-        else
-            (1/sqrt(1+r2)) * (δ(Nidx(j,c),k) - cp[k]/(sqrt(1+r2)))
-        end
-    end
-end
-
-################################################################################
-# Optimization with ℂP^{N-1} affine coordinates
-################################################################################
-function optim_energy_affine(affine_coords, sys::System{N}) where N
-    affine_coords = reinterpret(reshape, CPAffineCoordinate{N}, affine_coords)
-    for site in all_sites(sys)
-        set_coherent_state!(sys, affine_to_vec(affine_coords[site]), site)
-    end
-    return energy(sys)
-end
-
-function optim_gradient_affine!(buf, affine_coords, sys::System{N}) where N
-    affine_coords = reinterpret(reshape, CPAffineCoordinate{N}, affine_coords)
-    Hgrad = reinterpret(reshape, SVector{N, ComplexF64}, buf)
-
-    # Calculate gradient of energy in original coordinates
-    for site in all_sites(sys)
-        set_coherent_state!(sys, affine_to_vec(affine_coords[site]), site)
-    end
-    Sunny.set_complex_forces!(Hgrad, sys.coherents, sys)
-
-    # Calculate gradient, using Jacobian for affinegraphic coordinates 
-    jac = zeros(ComplexF64, N, N)  # Maybe write function to apply matrix multiply and avoid allocation
-    for site in all_sites(sys)
-        affine_jac!(jac, affine_coords[site])
-        Hgrad[site] = -jac * Hgrad[site]  # Note Optim expects ∇, `set_forces!` gives -∇
-    end
-end
-
-function minimize_energy_affine!(sys::System{N}; method=Optim.LBFGS, maxiters = 100, kwargs...) where N
-    f(affine_spins) = optim_energy_affine(affine_spins, sys)
-    g!(G, affine_spins) = optim_gradient_affine!(G, affine_spins, sys)
-    # fg!(energy_spins, G, x) = affine_energy_grad!(affine_spins, G, sys)
-
-
-    # Quick test if any coordinates every go to infinity 
-    # niters = 0
-    # success = false
-    # while niters < maxiters
-    #     niters += 1
-    #     affine_spins = map(vec -> vec_to_affine(vec), sys.dipoles) 
-    #     affine_spins = Array(reinterpret(reshape, Float64, affine_spins))
-    #     # affine_spins = map!(vec -> vec_to_affine(vec), affine_spins, sys.dipoles) 
-    #     optout = Optim.optimize(f, g!, affine_spins, method(), options)
-    #     if optout.g_converged
-    #         println("We got there.")
-    #         return true
-    #     end
-    #     # println("Maximum: ", maximum(affine_spins))
-    #     # println(affine_spins)
-    #     if maximum(affine_spins) > 5.0
-    #         println("Remapping coords...")
-    #         affine_spins = reinterpret(reshape, affinegraphicPoint{3}, affine_spins)
-    #         @. affine_spins = remap_affine(affine_spins)
-    #     end
-    #     println("Trying again...")
-    # end
-    # return success
-
-    affine_spins = map(vec -> vec_to_affine(vec), sys.coherents) 
-    affine_spins = Array(reinterpret(reshape, ComplexF64, affine_spins))
-    options = Optim.Options(iterations=1000, kwargs...)
-    Optim.optimize(f, g!, affine_spins, method(), options)
-end
-
-
-################################################################################
-# Complex projective representation of CP^N-1 vector 
-################################################################################
-
-using Sunny, StaticArrays, LinearAlgebra
-
-function vec_to_stereo(u, z)
-    # (I - z*z')*u/(1 - √(u'*z*z'*u))
-
-    zz = z*z'
-    (I - zz)*u/(1 - sqrt(u'*zz*u))
-
-    # (I - z*z')*u/(1 - abs(z'*u))
-end
-
-function stereo_to_vec(v, z)
-    v2 = v' * v
-    denom = 1 + v2
-
-    (2v + (v2-1)*z)/ denom
-end
-
-function spin_expectations(ψ::SVector{N, ComplexF64}) where N
-    S = Sunny.spin_matrices(N)
-    real.((ψ' * S[1] * ψ, ψ' * S[2] * ψ, ψ' * S[3] * ψ))
-end
-
-# Tests
-function there_and_back(u::SVector{N, ComplexF64}, z::SVector{N, ComplexF64}; θ=nothing) where N
-    # u1 = vec_to_stereo(u,z) |> v -> stereo_to_vec(v, z)
-    v = vec_to_stereo(u, z) 
-    u1 = stereo_to_vec(v, z)
-
-    println("Norm of intermediate: ", norm(v))
-    println("Reconstruction error: ", norm(u - u1))
-
-    display(spin_expectations(u))
-    display(spin_expectations(u1))
-    u1 * exp(-im*angle(u1[1]))
-end
-
-function there_and_back2(u::SVector{N, ComplexF64}) where N
-    rv = rand(SVector{N, ComplexF64})
-    ov = rv - (u'*rv)*u
-    z = normalize(ov)
-
-
-    # u1 = vec_to_stereo(u,z) |> v -> stereo_to_vec(v, z)
-    v = vec_to_stereo(u, z) 
-    u1 = stereo_to_vec(v, z)
-
-    println("Norm of intermediate: ", norm(v))
-    println("Reconstruction error: ", norm(u - u1))
-
-    display(spin_expectations(u))
-    display(spin_expectations(u1))
-    u1 * exp(-im*angle(u1[1]))
-end
-
-
-################################################################################
-# Kipton's projection
-################################################################################
-
-function projective_to_conventional(α::SVector{N, ComplexF64}, z::SVector{N, ComplexF64}) where N
-    v = (I - z*z')*α
-    v2 = v'*v
-    normalize((2v + (1-v2)*z) / (1+v2)) # Normalize shouldn't be necessary
-end
-
-# Make non-allocating version
-function projective_jac!(jac, α::SVector{N, ComplexF64}, z::SVector{N, ComplexF64}) where N
-
-    P = (I - z*z')
-    v = P*α
-    v2 = v' * v 
-    dv_dα = P 
-    dv2_dα = 2*(α' - 2*(α'*z)*z')
-
-    jac .= (1/(1+v2)) * (2dv_dα - z * dv2_dα)' - (1/(1+v2))^2 * dv2_dα' * ((2v + (1-v2)*z)')
-end
-
-function optim_energy_projective(αs, zs, sys::System{N}) where N
-    αs = reinterpret(reshape, SVector{N, ComplexF64}, αs)
-    for site in all_sites(sys)
-        set_coherent_state!(sys, projective_to_conventional(αs[site], zs[site]), site)
-    end
-    return energy(sys)
-end
-
-function optim_gradient_projective!(buf, αs, zs, sys::System{N}) where N
-    αs = reinterpret(reshape, SVector{N, ComplexF64}, αs)
-    Hgrad = reinterpret(reshape, SVector{N, ComplexF64}, buf)
-
-    # Calculate gradient of energy in original coordinates
-    for site in all_sites(sys)
-        set_coherent_state!(sys, projective_to_conventional(αs[site], zs[site]), site)
-    end
-    Sunny.set_complex_forces!(Hgrad, sys.coherents, sys)
-
-    # Calculate gradient, using Jacobian for projectivegraphic coordinates 
-    jac = zeros(ComplexF64, N, N)  # Maybe write function to apply matrix multiply and avoid allocation
-    for site in all_sites(sys)
-        projective_jac!(jac, αs[site], zs[site])
-        Hgrad[site] = jac * Hgrad[site]  # Note Optim expects ∇, `set_forces!` gives -∇
-    end
-end
-
-function minimize_energy_projective!(sys::System{N}; method=Optim.LBFGS, maxiters = 1000, kwargs...) where N
-
-    zs = copy(sys.coherents)
-    # αs = zeros(SVector{N, ComplexF64}, size(sys.coherents))
-    # αs = Array(reinterpret(reshape, ComplexF64, αs))
-    αs = zeros(ComplexF64, (N, size(sys.coherents)...))
-
-    f(proj_coords) = optim_energy_projective(proj_coords, zs, sys)
-    g!(G, proj_coords) = optim_gradient_projective!(G, proj_coords, zs, sys)
+function minimize_energy!(sys::System{N}; method=Optim.LBFGS, maxiters = 10000, kwargs...) where N
+    numbertype = N == 0 ? Float64 : ComplexF64
+    buffer = N == 0 ? sys.dipoles : sys.coherents
+    B = N == 0 ? nothing : get_dipole_buffers(sys, 1) |> only
+
+    zs = copy(buffer)
+    αs = zeros(numbertype, (N == 0 ? 3 : N, size(buffer)...))
+
+    f(proj_coords) = optim_energy(proj_coords, zs, sys)
+    g!(G, proj_coords) = optim_gradient!(G, proj_coords, zs, B, sys)
 
     options = Optim.Options(iterations=maxiters, kwargs...)
     Optim.optimize(f, g!, αs, method(), options)

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -2,13 +2,13 @@
 # projective parameterization is formally the same for both dipoles and coherent
 # states (the element types are just real in the first case, compelx in the
 # second).
-function set_forces_optim!(Hgrad, B, sys::System{N}) where {N}
-    Sunny.set_forces_dipoles!(B, sys.dipoles, sys)
-    Sunny.set_forces_coherents!(Hgrad, B, sys.coherents, sys)
+function set_forces_optim!(∇H, ∇H_dip, sys::System{N}) where {N}
+    Sunny.set_energy_grad_dipoles!(∇H_dip, sys.dipoles, sys)
+    Sunny.set_energy_grad_coherents!(∇H, ∇H_dip, sys.coherents, sys)
 end
 
-function set_forces_optim!(Hgrad, _, sys::System{0}) 
-    Sunny.set_forces_dipoles!(Hgrad, sys.dipoles, sys)
+function set_forces_optim!(∇H, _, sys::System{0}) 
+    Sunny.set_energy_grad_dipoles!(∇H, sys.dipoles, sys)
 end
 
 @inline function set_spin_optim!(sys::System{N}, α, z, site) where N
@@ -64,7 +64,6 @@ end
 # Calculate dH(u(α))/dα 
 function optim_gradient!(buf, αs, zs, B, sys::System{N}, halted, quickmode=false) where N
     T = N == 0 ? Vec3 : CVec{N} 
-    jacsign = N == 0 ? -1 : 1  # Because set_forces_dipoles gives -dH/dS whereas set_forces_coherents gives dH/dZ*
     αs = reinterpret(reshape, T, αs)
     Hgrad = reinterpret(reshape, T, buf)
 
@@ -86,7 +85,7 @@ function optim_gradient!(buf, αs, zs, B, sys::System{N}, halted, quickmode=fals
     set_forces_optim!(Hgrad, B, sys)
 
     for site in all_sites(sys)
-        Hgrad[site] = jacsign * apply_projective_jacobian(Hgrad[site], αs[site], zs[site])
+        Hgrad[site] = apply_projective_jacobian(Hgrad[site], αs[site], zs[site])
     end
 end
 

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -1,6 +1,6 @@
 # The following four helper functions allow for more code resuse since the
 # projective parameterization is formally the same for both dipoles and coherent
-# states (the element types are just real in the first case, compelx in the
+# states (the element types are just real in the first case, complex in the
 # second).
 function set_forces_optim!(∇H, ∇H_dip, sys::System{N}) where {N}
     Sunny.set_energy_grad_dipoles!(∇H_dip, sys.dipoles, sys)
@@ -48,7 +48,7 @@ function optim_energy(αs, zs, sys::System{N})::Float64 where N
     for site in all_sites(sys)
         set_spin_optim!(sys, αs[site], zs[site], site)
     end
-    return energy(sys) # Note: `Sunny.energy` seems to allocate and is type-unstable
+    return energy(sys) # Note: `Sunny.energy` seems to allocate and is type-unstable (7/20/2023)
 end
 
 # Non-allocating check for largest unnormalized coordinate.
@@ -92,7 +92,7 @@ end
 # Quick "touchup" optimization that assumes the system is already near the
 # ground state. Never changes the parameterization of coherent states or
 # dipoles. For internal use when setting up a spin wave calculation.
-function minimize_energy_touchup!(sys::System{N}; method=Optim.LBFGS, maxiters = 40, kwargs...) where N
+function minimize_energy_touchup!(sys::System{N}; method=Optim.LBFGS, maxiters=50, kwargs...) where N
     numbertype = N == 0 ? Float64 : ComplexF64
     buffer = N == 0 ? sys.dipoles : sys.coherents
     B = N == 0 ? nothing : get_dipole_buffers(sys, 1) |> only

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -154,7 +154,7 @@ end
 
 # Use FFT to accumulate the entire field -dE/ds for long-range dipole-dipole
 # interactions
-function accum_ewald_force!(B::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, sys::System{N}) where N
+function accum_ewald_grad!(∇E::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, sys::System{N}) where N
     (; ewald, units, gs) = sys
     (; μ, FA, Fμ, Fϕ, ϕ, plan, ift_plan) = ewald
 
@@ -178,7 +178,7 @@ function accum_ewald_force!(B::Array{Vec3, 4}, dipoles::Array{Vec3, 4}, sys::Sys
     mul!(ϕr, ift_plan, Fϕ)
     
     for site in all_sites(sys)
-        B[site] -= 2 * units.μB * (gs[site]' * ϕ[site])
+        ∇E[site] += 2 * units.μB * (gs[site]' * ϕ[site])
     end
 end
 

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -260,7 +260,7 @@ function energy_aux(sys::System{N}, ints::Interactions, i::Int, cells, foreachbo
 end
 
 # Updates B in-place to hold negative energy gradient, -dE/ds, for each spin.
-function set_forces!(B, dipoles::Array{Vec3, 4}, sys::System{N}) where N
+function set_forces_dipoles!(B, dipoles::Array{Vec3, 4}, sys::System{N}) where N
     (; crystal, latsize, extfield, ewald) = sys
 
     fill!(B, zero(Vec3))
@@ -335,7 +335,7 @@ end
 
 # Updates `HZ` in-place to hold `dH/dZ^*`, the analog in the Schroedinger formulation
 # of the classical quantity `dE/ds` (note sign).
-function set_complex_forces!(HZ, B, Z, sys::System{N}) where N
+function set_forces_coherents!(HZ, B, Z, sys::System{N}) where N
     if is_homogeneous(sys)
         ints = interactions_homog(sys)
         for site in all_sites(sys)
@@ -408,6 +408,6 @@ Returns the effective local field (force) at each site, ``𝐁 = -∂E/∂𝐬``
 """
 function forces(sys::System{N}) where N
     B = zero(sys.dipoles)
-    set_forces!(B, sys.dipoles, sys)
+    set_forces_dipoles!(B, sys.dipoles, sys)
     return B
 end

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -290,7 +290,7 @@ function set_energy_grad_dipoles!(∇E, dipoles::Array{Vec3, 4}, sys::System{N})
     end
 end
 
-# Calculate the energy gradient `∇H' for the sublattice `i' at all elements of
+# Calculate the energy gradient `∇E' for the sublattice `i' at all elements of
 # `cells`. The function `foreachbond` enables efficient iteration over
 # neighboring cell pairs.
 function set_energy_grad_aux!(∇E, dipoles::Array{Vec3, 4}, ints::Interactions, sys::System{N}, i::Int, cells, foreachbond) where N
@@ -351,7 +351,7 @@ function set_energy_grad_coherents!(HZ, ∇E, Z, sys::System{N}) where N
     end
 end
 
-# Returns (Λ - ∇E⋅S) Z
+# Returns (Λ + ∇E⋅S) Z
 @generated function mul_spin_matrices(Λ, ∇E::Sunny.Vec3, Z::Sunny.CVec{N}) where N
     S = spin_matrices(; N)
     out = map(1:N) do i

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -1,0 +1,46 @@
+@testitem "Optimization" begin
+
+    # H = -∑Sᵢ⋅Sⱼ - ∑(Sᵢᶻ)² on 2D square lattice (z-polarized ground state)
+    function simple_sys(; mode=:dipole, dims=(4,4,1), seed=nothing)
+        cryst = Crystal(lattice_vectors(1,1,2,90,90,90), [[0,0,0]])
+        sys = System(cryst, dims, [SpinInfo(1,S=1)], mode; seed) 
+        set_exchange!(sys, -1, Bond(1,1,[1,0,0]))
+        set_onsite_coupling!(sys, -1*(Sunny.spin_operators(sys, 1)[3])^2, 1)
+        sys
+    end
+
+    function is_z_polarized(sys; S=1.0)
+        for site in all_sites(sys)
+            !isapprox(abs(sys.dipoles[site][3]), S) && return false
+        end
+        true
+    end
+
+    sys_dip = simple_sys(; mode=:dipole, seed=101)
+    sys_sun = simple_sys(; mode=:SUN, seed=102)
+
+    # Thermalize near ground state a little bit and apply `minimize_energy_touchup!`
+    Δt = 0.05
+    integrator = Langevin(Δt; λ=0.1, kT = 0.1)
+
+    for _ in 1:1000
+        step!(sys_dip, integrator)
+        step!(sys_sun, integrator)
+    end
+
+    Sunny.minimize_energy_touchup!(sys_dip)
+    Sunny.minimize_energy_touchup!(sys_sun)
+
+    @test is_z_polarized(sys_dip)
+    @test is_z_polarized(sys_sun)
+
+    # Randomize initial condition and use `minimize_energy!` 
+    randomize_spins!(sys_dip)
+    randomize_spins!(sys_sun)
+
+    Sunny.minimize_energy!(sys_dip)
+    Sunny.minimize_energy!(sys_sun)
+
+    @test is_z_polarized(sys_dip)
+    @test is_z_polarized(sys_sun)
+end


### PR DESCRIPTION
This should give a general way to optimize spin configurations to minimize energy. Works in both `:dipole` and `:SUN` modes. It relies on `Optim.jl` and defaults to LBFGS.

The intended use is just the touching up of spin configurations near the ground state. The function for this is `minimize_energy_touchup!(sys)`. It just runs for a maximum of 40 iterations and gives a warning if the optimizer hasn't converged.

There's also a function `minimize_energy!(sys)`, which seems to work for random initial configurations. It checks whether any of the quasi-stereographic coordinates has "wandered too far." If so, it halts the optimization, reparameterizes the coherent states, and starts it again.

It seems to be sufficiently fast for small unit cells.

All the functions called inside the optimization procedure are non-allocating except `optim_energy`, which allocates because `energy(sys)` allocates. It would probably be worth looking into this, unless there's some structural reason for it.

(Apologies for my git incompetence. I should have squashed a bunch of things along the way.)