### PR TITLE
Implement several renamings

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -1,23 +1,21 @@
 # Version 0.5.0
 
-This version includes many **breaking changes**.
+**New features**.
 
-Added support for Dipole-mode Linear Spin Wave Theory. (Thanks Hao Zhang!)
+Support for Linear Spin Wave Theory in `:dipole` and `:SUN` modes. (Thanks Hao
+Zhang!)
 
-Split `intensities` into calculation ([`intensity_formula`](@ref)) and
-presentation ([`intensities_interpolated`](@ref), [`intensities_binned`](@ref)).
-This is a **breaking change**, see the docs to migrate your code.
+New function [`minimize_energy!`](@ref) to efficiently find an optimal
+configuration of spin dipoles or SU(_N_) coherent states.
 
-`StructureFactor` type renamed [`SampledCorrelations`](@ref). An appropriate
-`SampledCorrelations` is created by calling either
-[`dynamical_correlations`](@ref) or [`instant_correlations`](@ref) instead of
-`DynamicStructureFactor` or `InstantStructureFactor`.
+Major refactors and enhancements to intensity calculations. This new interface
+allows unification between LSWT and classical spin dynamics calculations. This
+interface allows: Custom observables as local quantum operators, better support
+for linebroadening, and automatic binning to facilitate comparison with
+experimental data. See [`intensity_formula`](@ref) for documentation. Use
+[`load_nxs`](@ref) to load experimental neutron scattering data.
 
-Broadened support for custom observables in `SampledCorrelations` for use in
-`intensity_formula`.
-
-Added function [`load_nxs`](@ref) to load experimental neutron scattering data
-to compare with `intensities_binned`.
+**Breaking changes**.
 
 Replace `set_anisotropy!` with a new function [`set_onsite_coupling!`](@ref)
 (and similarly [`set_onsite_coupling_at!`](@ref)). The latter expects an
@@ -27,11 +25,32 @@ a polynomial of [`spin_operators`](@ref). To understand the mapping between
 these two, the new function [`print_stevens_expansion`](@ref) acts on an
 arbitrary local operator.
 
-Replace `set_biquadratic!` with an optional keyword argument `biquad` to
+Remove `set_biquadratic!`. Instead, use an optional keyword argument `biquad` to
 [`set_exchange!`](@ref).
 
-Symbolic representations of operators are now hidden unless the package
-`DynamicPolynomials` is explicitly loaded by the user. The functionality of
+Rename `DynamicStructureFactor` to [`dynamical_correlations`](@ref).
+Similarly, replace `InstantStructureFactor` with [`instant_correlations`](@ref).
+The return type has been renamed [`SampledCorrelations`](@ref) to emphasize that
+the object may be holding thermodynamic samples, which are collected using
+[`add_sample!`](@ref).
+
+Remove `intensities` function. Instead, use one of
+[`intensities_interpolated`](@ref) or [`intensities_binned`](@ref). These will
+require an [`intensity_formula`](@ref), which defines a calculator (e.g., LSWT).
+
+Rename `polarize_spin!` to [`set_dipole!`](@ref) for consistency with
+[`set_coherent!`](@ref). The behavior of the former function is unchanged: the
+spin at a given site will still be polarized along the provided direction.
+
+Rename `reshape_geometry` to [`reshape_supercell`](@ref), which is the
+fundamental reshaping function. Rename `resize_periodically` to
+[`resize_supercell`](@ref).
+
+The constructor [`SpinInfo`](@ref) now requires a ``g``-factor or tensor as a
+named argument.
+
+Symbolic representations of operators are now hidden unless the external package
+`DynamicPolynomials.jl` is explicitly loaded by the user. The functionality of
 `print_anisotropy_as_stevens` has been replaced with
 [`print_classical_stevens_expansion`](@ref), while
 `print_anisotropy_as_classical_spins` has become
@@ -143,8 +162,8 @@ interface, see the [Structure Factor Calculations](@ref) page.
 
 * [`repeat_periodically`](@ref) replaces `extend_periodically`.
 
-Additional related functions include [`resize_periodically`](@ref) and
-[`reshape_geometry`](@ref), the latter being fundamental.
+Additional related functions include `resize_periodically` and
+`reshape_geometry`, the latter being fundamental.
 
 * [`print_symmetry_table`](@ref) replaces `print_bond_table()`.
 

--- a/docs/src/writevtk.md
+++ b/docs/src/writevtk.md
@@ -28,7 +28,7 @@ types = ["Cu"]
 formfactors  = [FormFactor(1,"Cu2")]
 xtal = Crystal(latvecs,positions;types);
 
-sys = System(xtal, latsize, [SpinInfo(1;S = 1/2)], :SUN; seed=1);
+sys = System(xtal, latsize, [SpinInfo(1, S=1/2, g=2)], :SUN; seed=1);
 
 J = 10.
 set_exchange!(sys,J,Bond(1,1,[1,0,0]))

--- a/examples/binning_tutorial.jl
+++ b/examples/binning_tutorial.jl
@@ -28,7 +28,7 @@ latsize = (6,6,4);
 # and there is a spin-1/2 dipole on each site.
 magxtal = xtal;
 valS = 1/2;
-sys = System(magxtal, latsize, [SpinInfo(1;S = valS)], :dipole; seed=1);
+sys = System(magxtal, latsize, [SpinInfo(1, S=valS, g=2)], :dipole; seed=1);
 
 # Quoted value of J = +6.19(2) meV (antiferromagnetic) between
 # nearest neighbors on the square lattice

--- a/examples/fei2_tutorial.jl
+++ b/examples/fei2_tutorial.jl
@@ -63,15 +63,14 @@ cryst = subcrystal(FeI2, "Fe")
 # ## Spin systems
 # To simulate a system of many spins, construct a [`System`](@ref).
 
-sys = System(cryst, (4,4,4), [SpinInfo(1,S=1)], :SUN, seed=2)
+sys = System(cryst, (4,4,4), [SpinInfo(1, S=1, g=2)], :SUN, seed=2)
 
-# The system includes $4×4×4$ unit cells, i.e. 64 Fe atoms, each with spin
-# $S=1$. The default $g$-factor is 2, but this could be overriden with an
-# additional argument to [`SpinInfo`](@ref). Spin $S=1$ involves a superposition
-# of $2S+1=3$ distinct angular momentum states. In `:SUN` mode, this
-# superposition will be modeled using the formalism of SU(3) coherent states,
-# which captures both dipolar and quadrupolar fluctuations. For the more
-# traditional dipole dynamics, use `:dipole` mode instead.
+# The system includes $4×4×4$ unit cells, i.e. 64 Fe atoms, each with spin $S=1$
+# and a $g$-factor of 2. Quantum mechanically, spin $S=1$ involves a
+# superposition of $2S+1=3$ distinct angular momentum states. In `:SUN` mode,
+# this superposition will be modeled explicitly using the formalism of SU(3)
+# coherent states, which captures both dipolar and quadrupolar fluctuations. For
+# the more traditional dipole dynamics, use `:dipole` mode instead.
 
 # ## Interactions and anisotropies
 
@@ -228,11 +227,11 @@ print_wrapped_intensities(sys)
 
 suggest_magnetic_supercell([[0, -1/4, 1/4]], sys.latsize)
 
-# The function [`reshape_geometry`](@ref) allows an arbitrary reshaping of the
+# The function [`reshape_supercell`](@ref) allows an arbitrary reshaping of the
 # system's supercell. We select the supercell appropriate to the broken-symmetry
 # ground-state, which makes optimization much easier.
 
-sys_min = reshape_geometry(sys, [1 0 0; 0 1 -2; 0 1 2])
+sys_min = reshape_supercell(sys, [1 0 0; 0 1 -2; 0 1 2])
 randomize_spins!(sys_min)
 minimize_energy!(sys_min)
 plot_spins(sys_min; arrowlength=2.5, linewidth=0.75, arrowsize=1.5)

--- a/examples/longer_examples/CoRh2O4-tutorial.jl
+++ b/examples/longer_examples/CoRh2O4-tutorial.jl
@@ -113,12 +113,9 @@ magxtal = subcrystal(xtal,"Co1")
 view_crystal(magxtal,6.0)
 print_symmetry_table(magxtal, 4.0)
 
-# Define spin and g-factors
-valg = 2.0
-valS = 3/2;
-
 # Assign Local Hilbert Space
-lhs  = [SpinInfo(1,S=valS;g=valg)]
+S = 3/2
+lhs  = [SpinInfo(1, S=S, g=2)]
 ffs  = [FormFactor(1,"Co2")];
 
 # Create Spin System and Randomize it
@@ -131,15 +128,15 @@ plot_spins(sys, arrowlength=1.0, linewidth=0.5, arrowsize=1.0)
 # Define Exchange Interactions 
 scaleJ = 0.63
 valJ1  = 1.00*scaleJ
-set_exchange!(sys, valJ1, Bond(1, 3, [0, 0, 0]) );
+set_exchange!(sys, valJ1, Bond(1, 3, [0, 0, 0]));
 
 # ---
 # ### System thermalization to an ordered, yet finite temperature, state
 
 # Define Langevin Integrator and Initialize it 
-Δt0           = 0.05/abs(scaleJ*valS); ## Time steps in Langevin
+Δt0           = 0.05/abs(scaleJ*S); ## Time steps in Langevin
 λ0            = 0.1; ## Langevin damping, usually 0.05 or 0.1 is good.
-kT0           = 0.01*abs(scaleJ*valS); ## Initialize at some temperature
+kT0           = 0.01*abs(scaleJ*S); ## Initialize at some temperature
 integrator    = Langevin(Δt0; λ=λ0, kT=kT0); 
 
 # Thermalization 

--- a/examples/longer_examples/MgCr2O4-tutorial.jl
+++ b/examples/longer_examples/MgCr2O4-tutorial.jl
@@ -135,7 +135,7 @@ xtal_mgcro = subcrystal(xtal_mgcro_2,"Cr")
 # our `Crystal`.
 
 dims = (6, 6, 6)  # Supercell dimensions 
-spininfos = [SpinInfo(1; S=3/2)]  # Specify spin information, note that all sites are symmetry equivalent 
+spininfos = [SpinInfo(1, S=3/2, g=2)]  # Specify spin information, note that all sites are symmetry equivalent 
 sys_pyro = System(xtal_pyro, dims, spininfos, :dipole)    # Make a system in dipole (Landau-Lifshitz) mode on pyrochlore lattice
 sys_mgcro = System(xtal_mgcro, dims, spininfos, :dipole); # Same on MgCr2O4 crystal
 

--- a/examples/powder_averaging.jl
+++ b/examples/powder_averaging.jl
@@ -13,7 +13,7 @@ seed = 1                     # RNG seed for repeatable behavior
 J = Sunny.meV_per_K*7.5413   # Nearest-neighbor exchange parameter
 
 crystal = Sunny.diamond_crystal()
-sys = System(crystal, dims, [SpinInfo(1, S=3/2)], :dipole; seed)
+sys = System(crystal, dims, [SpinInfo(1, S=3/2, g=2)], :dipole; seed)
 set_exchange!(sys, J, Bond(1, 3, [0,0,0]))
 
 # We next set up a [`Langevin`](@ref) integrator and thermalize the system. 

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -50,14 +50,14 @@ function optim_set_spins!(sys::System{0}, αs, ns)
     αs = reinterpret(reshape, Vec3, αs)
     for site in all_sites(sys)
         s = stereographic_projection(αs[site], ns[site])
-        polarize_spin!(sys, s, site)
+        set_dipole!(sys, s, site)
     end
 end
 function optim_set_spins!(sys::System{N}, αs, ns) where N
     αs = reinterpret(reshape, CVec{N}, αs)
     for site in all_sites(sys)
         Z = stereographic_projection(αs[site], ns[site])
-        set_coherent_state!(sys, Z, site)
+        set_coherent!(sys, Z, site)
     end
 end
 

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -259,7 +259,7 @@ function plot_spins(sys::System; linecolor=:grey, arrowcolor=:red,
     )
 
     if !isnothing(sys.origin)
-        sys_origin = resize_periodically(sys,sys.origin.latsize)
+        sys_origin = resize_supercell(sys,sys.origin.latsize)
 
         # Translate to a correct lattice site in the middle of the bigger system
         center_origin = (sys_origin.crystal.latvecs * Vec3(sys_origin.latsize))/2

--- a/src/Reshaping.jl
+++ b/src/Reshaping.jl
@@ -1,6 +1,6 @@
 
 """
-    reshape_geometry(sys::System, A)
+    reshape_supercell(sys::System, A)
 
 Maps an existing [`System`](@ref) to a new one that has the shape and
 periodicity of a requested supercell. The columns of the ``3×3`` integer matrix
@@ -14,13 +14,13 @@ operations will be unavailable for this system, e.g., setting interactions by
 symmetry propagation. In practice, one can set all interactions using the
 original system, and then reshape as a final step.
 """
-function reshape_geometry(sys::System{N}, A) where N
+function reshape_supercell(sys::System{N}, A) where N
     # latsize for new system
     new_latsize = NTuple{3, Int}(gcd.(eachcol(A)))
     # Unit cell for new system, in units of original unit cell. Obtained by
     # dividing each column of A by corresponding new_latsize component.
     new_cell_size = Int.(A / diagm(collect(new_latsize)))
-    return reshape_geometry_aux(sys, new_latsize, new_cell_size)
+    return reshape_supercell_aux(sys, new_latsize, new_cell_size)
 end
 
 
@@ -46,7 +46,7 @@ function set_interactions_from_origin!(sys::System{N}) where N
 end
 
 
-function reshape_geometry_aux(sys::System{N}, new_latsize::NTuple{3, Int}, new_cell_size::Matrix{Int}) where N
+function reshape_supercell_aux(sys::System{N}, new_latsize::NTuple{3, Int}, new_cell_size::Matrix{Int}) where N
     is_homogeneous(sys) || error("Cannot reshape system with inhomogeneous interactions.")
 
     # `origin` describes the unit cell of the original system. For sequential
@@ -126,16 +126,16 @@ function cell_dimensions(sys)
 end
 
 """
-    resize_periodically(sys::System{N}, latsize) where N
+    resize_supercell(sys::System{N}, latsize) where N
 
 Creates a [`System`](@ref) identical to `sys` but enlarged to a given number of
 unit cells in each lattice vector direction.
 
 An error will be thrown if `sys` is incommensurate with `latsize`. Use
-[`reshape_geometry`](@ref) instead to reduce the volume, or to perform an
+[`reshape_supercell`](@ref) instead to reduce the volume, or to perform an
 incommensurate reshaping.
 """
-function resize_periodically(sys::System{N}, latsize::NTuple{3,Int}) where N
+function resize_supercell(sys::System{N}, latsize::NTuple{3,Int}) where N
     # Shape of the original system, in multiples of the original unit cell.
     sysdims = cell_dimensions(sys) * diagm(collect(sys.latsize))
     # Proposed system shape, given in fractional coordinates of original system
@@ -145,7 +145,7 @@ function resize_periodically(sys::System{N}, latsize::NTuple{3,Int}) where N
     if norm(A - round.(A)) > 1e-12
         error("Incommensurate system size.")
     end
-    return reshape_geometry(sys, diagm(collect(latsize)))
+    return reshape_supercell(sys, diagm(collect(latsize)))
 end
 
 """
@@ -158,7 +158,7 @@ function repeat_periodically(sys::System{N}, counts::NTuple{3,Int}) where N
     counts = NTuple{3,Int}(counts)
     @assert all(>=(1), counts)
     # Scale each column by `counts` and reshape
-    return reshape_geometry_aux(sys, counts .* sys.latsize, Matrix(cell_dimensions(sys)))
+    return reshape_supercell_aux(sys, counts .* sys.latsize, Matrix(cell_dimensions(sys)))
 end
 
 

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -142,7 +142,7 @@ end
 function SpinWaveTheory(sys::System{N}; energy_ϵ::Float64=1e-8, energy_tol::Float64=1e-6) where N
     # Reshape into single unit cell
     cellsize_mag = cell_dimensions(sys) * diagm(collect(sys.latsize))
-    sys = reshape_geometry_aux(sys, (1,1,1), cellsize_mag)
+    sys = reshape_supercell_aux(sys, (1,1,1), cellsize_mag)
 
     # Computes the Stevens operator in the local reference frame and the SO(3) rotation matrix from global to local frame
     # (:dipole mode only)

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -64,13 +64,13 @@ include("System/OnsiteCoupling.jl")
 include("System/Ewald.jl")
 include("System/Interactions.jl")
 export SpinInfo, System, Site, all_sites, position_to_site,
-    global_position, magnetic_moment, polarize_spin!, polarize_spins!, randomize_spins!, energy,
+    global_position, magnetic_moment, set_coherent!, set_dipole!, polarize_spins!, randomize_spins!, energy,
     spin_operators, stevens_operators, set_external_field!, set_onsite_coupling!, set_exchange!,
     dmvec, enable_dipole_dipole!, to_inhomogeneous, set_external_field_at!, set_vacancy_at!, set_onsite_coupling_at!,
     symmetry_equivalent_bonds, set_exchange_at!, remove_periodicity!
 
 include("Reshaping.jl")
-export reshape_geometry, resize_periodically, repeat_periodically, 
+export reshape_supercell, resize_supercell, repeat_periodically, 
     print_wrapped_intensities, suggest_magnetic_supercell
 
 include("Integrators.jl")

--- a/src/System/SpinInfo.jl
+++ b/src/System/SpinInfo.jl
@@ -11,7 +11,7 @@ struct SpinInfo
     S      :: Float64 # Spin magnitude in units of ħ
     g      :: Mat3    # Spin g-tensor
 
-    function SpinInfo(atom::Int; S, g=2)
+    function SpinInfo(atom::Int; S, g)
         if !isinteger(2S)
             error("Spin $S for atom $atom is not a multiple of 1/2")
         end

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -219,7 +219,7 @@ end
 Converts a position `r` to four indices of a [`Site`](@ref). The coordinates of
 `r` are given in units of the lattice vectors for the original crystal. This
 function can be useful for working with systems that have been reshaped using
-[`reshape_geometry`](@ref).
+[`reshape_supercell`](@ref).
 
 # Example
 
@@ -384,15 +384,18 @@ end
 
 
 """
-    set_coherent_state!(sys::System, Z, site::Site)
+    set_coherent!(sys::System, Z, site::Site)
 
 Set a coherent spin state at a [`Site`](@ref) using the ``N`` complex amplitudes
-in `Z`, to be interpreted in the eigenbasis of ``𝒮̂ᶻ``. That is, `Z[1]`
-represents the amplitude for the basis state fully polarized along the
-``ẑ``-direction, and subsequent components represent states with decreasing
-angular momentum along this axis (``m = S, S-1, …, -S``).
+in `Z`.
+
+For a standard [`SpinInfo`](@ref), these amplitudes will be interpreted in the
+eigenbasis of ``𝒮̂ᶻ``. That is, `Z[1]` represents the amplitude for the basis
+state fully polarized along the ``ẑ``-direction, and subsequent components
+represent states with decreasing angular momentum along this axis (``m = S, S-1,
+…, -S``).
 """
-function set_coherent_state!(sys::System{N}, Z, site) where N
+function set_coherent!(sys::System{N}, Z, site) where N
     length(Z) != N && error("Length of coherent state does not match system.")
     iszero(N)      && error("Cannot set zero-length coherent state.")
     setspin!(sys, coherent_state(sys, site, Z), to_cartesian(site))
@@ -400,11 +403,11 @@ end
 
 
 """
-    polarize_spin!(sys::System, dir, site::Site)
+    set_dipole!(sys::System, dir, site::Site)
 
 Polarize the spin at a [`Site`](@ref) along the direction `dir`.
 """
-function polarize_spin!(sys::System{N}, dir, site) where N
+function set_dipole!(sys::System{N}, dir, site) where N
     site = to_cartesian(site)
     setspin!(sys, dipolar_state(sys, site, dir), site)
 end
@@ -416,7 +419,7 @@ Polarize all spins in the system along the direction `dir`.
 """
 function polarize_spins!(sys::System{N}, dir) where N
     for site in all_sites(sys)
-        polarize_spin!(sys, dir, site)
+        set_dipole!(sys, dir, site)
     end
 end
 

--- a/test/test_binning.jl
+++ b/test/test_binning.jl
@@ -14,7 +14,7 @@
 
     @test_warn "Non-uniform" unit_resolution_binning_parameters([0.,1,3,7])
 
-    sys = System(Sunny.diamond_crystal(),(4,1,1),[SpinInfo(1,S=1/2)],:SUN,seed=1)
+    sys = System(Sunny.diamond_crystal(),(4,1,1),[SpinInfo(1,S=1/2,g=2)],:SUN,seed=1)
     randomize_spins!(sys)
     sc = dynamical_correlations(sys;Δt = 1.,nω=3,ωmax = 1.)
     add_sample!(sc, sys)

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -6,7 +6,7 @@
         cryst = Sunny.fcc_primitive_crystal()
         S = mode==:SUN ? 1/2 : 1
         κ = mode==:SUN ? 2 : 1
-        sys = System(cryst, latsize, [SpinInfo(1; S)], mode; seed)
+        sys = System(cryst, latsize, [SpinInfo(1; S, g=2)], mode; seed)
         sys.κs .= κ
         set_exchange!(sys, J, Bond(1, 1, [1, 0, 0]))
         return sys
@@ -96,7 +96,7 @@ end
     function diamond_model(; J, dims = (3,3,3), kwargs...)
         crystal = Sunny.diamond_crystal()
         S = 3/2
-        sys = System(crystal, dims, [SpinInfo(1; S)], :dipole; kwargs...)
+        sys = System(crystal, dims, [SpinInfo(1; S, g=2)], :dipole; kwargs...)
         set_exchange!(sys, J, Bond(1, 3, [0,0,0]))
         randomize_spins!(sys)
         return sys

--- a/test/test_energy_consistency.jl
+++ b/test/test_energy_consistency.jl
@@ -4,7 +4,7 @@
 
     function make_system(; mode, inhomog)
         cryst = Sunny.diamond_crystal()
-        sys = System(cryst, (3, 3, 3), [SpinInfo(1, S=2)], mode; seed=0)
+        sys = System(cryst, (3, 3, 3), [SpinInfo(1, S=2, g=2)], mode; seed=0)
         add_linear_interactions!(sys, mode)
         add_quadratic_interactions!(sys, mode)
         add_quartic_interactions!(sys, mode)

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -5,7 +5,7 @@
         latvecs = lattice_vectors(1,1,2,90,90,90)
         crystal = Crystal(latvecs, [[0,0,0]])
         L = 2
-        sys = System(crystal, (L,L,1), [SpinInfo(1, S=1)], mode)
+        sys = System(crystal, (L,L,1), [SpinInfo(1, S=1, g=2)], mode)
         set_exchange!(sys, -1.0, Bond(1,1,(1,0,0)))
         polarize_spins!(sys, (0,0,1))
 
@@ -38,7 +38,7 @@ end
         latvecs = lattice_vectors(1,1,2,90,90,90)
         crystal = Crystal(latvecs, [[0,0,0]])
         L = 2
-        sys = System(crystal, (L,L,1), [SpinInfo(1, S=1)], mode)
+        sys = System(crystal, (L,L,1), [SpinInfo(1, S=1, g=2)], mode)
         set_exchange!(sys, -1.0, Bond(1,1,(1,0,0)))
         polarize_spins!(sys, (0,0,1))
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -18,7 +18,7 @@ end
     # H = -∑Sᵢ⋅Sⱼ - ∑(Sᵢᶻ)² on 2D square lattice (z-polarized ground state)
     function simple_sys(; dims=(4,4,1), mode, seed, S)
         cryst = Crystal(lattice_vectors(1,1,2,90,90,90), [[0,0,0]])
-        sys = System(cryst, dims, [SpinInfo(1; S)], mode; seed) 
+        sys = System(cryst, dims, [SpinInfo(1; S, g=2)], mode; seed) 
         set_exchange!(sys, -1, Bond(1,1,[1,0,0]))
         set_onsite_coupling!(sys, -spin_operators(sys, 1)[3]^2, 1)
         sys

--- a/test/test_samplers.jl
+++ b/test/test_samplers.jl
@@ -26,7 +26,7 @@
 
     function su3_anisotropy_model(; L=20, D=1.0, seed)
         cryst = asymmetric_crystal()
-        sys = System(cryst, (L,1,1), [SpinInfo(1, S=1)], :SUN; seed)
+        sys = System(cryst, (L,1,1), [SpinInfo(1, S=1, g=2)], :SUN; seed)
         S = spin_operators(sys, 1)
         set_onsite_coupling!(sys, D*S[3]^2, 1)
         randomize_spins!(sys)
@@ -36,7 +36,7 @@
 
     function su5_anisotropy_model(; L=20, D=1.0, seed)
         cryst = asymmetric_crystal()
-        sys = System(cryst, (L,1,1), [SpinInfo(1, S=2)], :SUN; seed)
+        sys = System(cryst, (L,1,1), [SpinInfo(1, S=2, g=2)], :SUN; seed)
         randomize_spins!(sys)
 
         S = spin_operators(sys, 1)
@@ -171,7 +171,7 @@ end
         
         S = mode==:SUN ? 1/2 : 1
         κ = mode==:SUN ? 2 : 1
-        sys = to_inhomogeneous(System(cryst, (2,1,1), [SpinInfo(1; S)], mode; seed))
+        sys = to_inhomogeneous(System(cryst, (2,1,1), [SpinInfo(1; S, g=2)], mode; seed))
         sys.κs .= κ
         set_exchange_at!(sys, 1.0, (1,1,1,1), (2,1,1,1); offset=(-1,0,0))
         randomize_spins!(sys)

--- a/test/test_spin_scaling.jl
+++ b/test/test_spin_scaling.jl
@@ -12,7 +12,7 @@
 
         for integrator in integrators
             for mode in (:SUN, :dipole)
-                sys = System(cryst, (3,3,3), [SpinInfo(1, S=5/2)], mode; seed=0)
+                sys = System(cryst, (3,3,3), [SpinInfo(1, S=5/2, g=2)], mode; seed=0)
                 add_linear_interactions!(sys, mode)
                 add_quadratic_interactions!(sys, mode)
                 add_quartic_interactions!(sys, mode)
@@ -34,7 +34,7 @@
     function test_energy_scaling()
         function gen_energy(κ, adder, mode)
             cryst = Sunny.diamond_crystal()
-            sys = System(cryst, (2,2,2), [SpinInfo(1, S=5/2)], mode; seed=0)
+            sys = System(cryst, (2,2,2), [SpinInfo(1, S=5/2, g=2)], mode; seed=0)
             adder(sys, mode)
             sys.κs .= κ
             randomize_spins!(sys)
@@ -64,7 +64,7 @@
     function test_dynamics_scaling()
         function gen_trajectory(κ, Δt, adder, mode)
             cryst = Sunny.diamond_crystal()
-            sys = System(cryst, (4,3,2), [SpinInfo(1, S=5/2)], mode; seed=0)
+            sys = System(cryst, (4,3,2), [SpinInfo(1, S=5/2, g=2)], mode; seed=0)
             adder(sys, mode)
             sys.κs .= κ
             randomize_spins!(sys)

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -182,7 +182,7 @@ end
         cryst = Crystal(latvecs, positions)
 
         for mode in (:dipole, :SUN)
-            sys = System(cryst, (1,1,1), [SpinInfo(1, S=2)], mode)
+            sys = System(cryst, (1,1,1), [SpinInfo(1, S=2, g=2)], mode)
             randomize_spins!(sys)
 
             # Most general allowed anisotropy for this crystal
@@ -221,7 +221,7 @@ end
     
     
     # Dipole system with renormalized anisotropy
-    sys0 = System(cryst, (1,1,1), [SpinInfo(1, S=3)], :dipole)
+    sys0 = System(cryst, (1,1,1), [SpinInfo(1, S=3, g=2)], :dipole)
     randomize_spins!(sys0)
 
     i = 1
@@ -233,9 +233,9 @@ end
     E0 = energy(sys0)
     
     # Corresponding SU(N) system
-    sys = System(cryst, (1,1,1), [SpinInfo(1, S=3)], :SUN)
+    sys = System(cryst, (1,1,1), [SpinInfo(1, S=3, g=2)], :SUN)
     for site in all_sites(sys)
-        polarize_spin!(sys, sys0.dipoles[site], site)
+        set_dipole!(sys, sys0.dipoles[site], site)
     end
     set_onsite_coupling!(sys, Λ, i)
     E = energy(sys)

--- a/test/test_units_scaling.jl
+++ b/test/test_units_scaling.jl
@@ -8,7 +8,7 @@
 
     crystal = Sunny.diamond_crystal()
     latsize = (4, 4, 4)
-    infos = [SpinInfo(1, S=1)]
+    infos = [SpinInfo(1, S=1, g=2)]
 
     units = [Sunny.Units.meV, Sunny.Units.theory]
 


### PR DESCRIPTION
As described in versions.md:

```
Rename `polarize_spin!` to [`set_dipole!`](@ref) for consistency with
[`set_coherent!`](@ref). The behavior of the former function is unchanged: the
spin at a given site will still be polarized along the provided direction.

Rename `reshape_geometry` to [`reshape_supercell`](@ref), which is the
fundamental reshaping function. Rename `resize_periodically` to
[`resize_supercell`](@ref).

The constructor [`SpinInfo`](@ref) now requires a ``g``-factor or tensor as a
named argument.
```