### PR TITLE
Wavevectors should be specified in absolute units.

### DIFF
--- a/src/Intensities/Binning.jl
+++ b/src/Intensities/Binning.jl
@@ -131,6 +131,7 @@ function binning_parameters_aabb(params)
     return lower_aabb_q, upper_aabb_q
 end
 
+# FIXME: various conversions go away. Always absolute units.
 """
 If `params` expects to bin values `(k,ω)` in absolute units, then calling
 
@@ -247,6 +248,7 @@ function unit_resolution_binning_parameters(ωvals::AbstractVector{Float64})
     return ωstart, ωend, ωbinwidth
 end
 
+# FIXME: remove `units` arg -- always absolute
 """
     slice_2D_binning_parameter(sc::SampledCorrelations, cut_from_q, cut_to_q, cut_bins::Int64, cut_width::Float64; plane_normal = [0,0,1],cut_height = cutwidth, units = :absolute)
 
@@ -408,7 +410,6 @@ function intensities_binned(sc::SampledCorrelations, params::BinningParameters;
     output_intensities = zeros(Float64,numbins...)
     output_counts = zeros(Float64,numbins...)
     ωvals = ωs(sc)
-    recip_vecs = 2π*inv(sc.crystal.latvecs)'
 
     # Find an axis-aligned bounding box containing the histogram.
     # The AABB needs to be in q-space because that's where we index
@@ -452,7 +453,7 @@ function intensities_binned(sc::SampledCorrelations, params::BinningParameters;
         # Which is the analog of this scattering mode in the first BZ?
         base_cell = CartesianIndex(mod1.(cell.I,Ls)...)
         q .= ((cell.I .- 1) ./ Ls) # q is in R.L.U.
-        k .= recip_vecs * q # But binning is done in absolute units
+        k .= sc.crystal.recipvecs * q # FIXME -- no scaling factor needed, q will already in absolute units.
         for (iω,ω) in enumerate(ωvals)
             if isnothing(integrated_kernel) # `Delta-function energy' logic
                 # Figure out which bin this goes in

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -9,7 +9,7 @@ struct SampledCorrelations{N}
     # 𝒮^{αβ}(q,ω) data and metadata
     data           :: Array{ComplexF64, 7}   # Raw SF data for 1st BZ (numcorrelations × natoms × natoms × latsize × energy)
     crystal        :: Crystal                # Crystal for interpretation of q indices in `data`
-    origin_crystal :: Union{Nothing,Crystal} # Original user-specified crystal (if different from above)
+    origin_crystal :: Union{Nothing,Crystal} # Original user-specified crystal (if different from above)  # FIXME: Eliminate
     Δω             :: Float64                # Energy step size (could make this a virtual property)
 
     # Correlation info (αβ indices of 𝒮^{αβ}(q,ω))

--- a/src/SpinWaveTheory/kpm.jl
+++ b/src/SpinWaveTheory/kpm.jl
@@ -36,8 +36,7 @@ function intensity_formula_kpm(f::Function,swt::SpinWaveTheory,corr_ix::Abstract
     stuff = setup_stuff(swt)
     formula = function(swt::SpinWaveTheory,q::Vec3,ω::Float64)
         Sαβ = do_KPM(swt,stuff)
-        k = swt.recipvecs_chem * q
-        intensity = f(k,ω,Sαβ[corr_ix])
+        return f(q,ω,Sαβ[corr_ix])
     end
     KPMIntensityFormula{return_type}(P,kT,σ,broadening,kernel,string_formula,formula)
 end

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -49,7 +49,7 @@ include("Symmetry/AllowedCouplings.jl")
 include("Symmetry/AllowedAnisotropy.jl")
 include("Symmetry/Parsing.jl")
 include("Symmetry/Printing.jl")
-export Crystal, subcrystal, lattice_vectors, lattice_params, Bond, 
+export Crystal, subcrystal, lattice_vectors, lattice_params, Bond,
     reference_bonds, print_site, print_bond, print_symmetry_table,
     print_suggested_frame
 

--- a/src/Symmetry/SymmetryAnalysis.jl
+++ b/src/Symmetry/SymmetryAnalysis.jl
@@ -159,13 +159,10 @@ function all_bonds_for_atom(cryst::Crystal, i::Int, max_dist; min_dist=0.0)
     max_dist += 4 * cryst.symprec * ℓ
     min_dist -= 4 * cryst.symprec * ℓ
 
-    # columns are the reciprocal vectors
-    recip_vecs = 2π * inv(cryst.latvecs)'
-
     # box_lengths[i] represents the perpendicular distance between two parallel
     # boundary planes spanned by lattice vectors a_j and a_k (where indices j
     # and k differ from i)
-    box_lengths = [a⋅b/norm(b) for (a,b) = zip(eachcol(cryst.latvecs), eachcol(recip_vecs))]
+    box_lengths = [a⋅b/norm(b) for (a,b) = zip(eachcol(cryst.latvecs), eachcol(cryst.recipvecs))]
     n_max = round.(Int, max_dist ./ box_lengths, RoundUp)
 
     bonds = Bond[]

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -11,45 +11,35 @@
 end
 
 @testitem "Single Ion" begin
-    J, J′, D = 1.0, 0.1, 5.0
-
-    a = b = 1.0
+    # Tetragonal crystal
+    a = 1.0
     c = 1.5
-    lat_vecs = lattice_vectors(a, b, c, 90, 90, 90)
-    types = ["A"]
-    basis_vecs = [[0, 0, 0]]
+    latvecs = lattice_vectors(a, a, c, 90, 90, 90)
+    positions = [[0, 0, 0]]
+    cryst = Crystal(latvecs, positions)
 
-    cryst = Crystal(lat_vecs, basis_vecs; types)
-
-    # Spin System
-    dims = (2, 2, 2)
+    # System
+    J, J′, D = 1.0, 0.1, 5.0
     infos = [SpinInfo(1, S=1, g=2)]
-    sys = System(cryst, dims, infos, :SUN)
-
+    sys = System(cryst, (1, 1, 1), infos, :SUN; seed=0)
     set_exchange!(sys, J,  Bond(1, 1, [1, 0, 0]))
     set_exchange!(sys, J′, Bond(1, 1, [0, 0, 1]))
     S = spin_operators(sys, 1)
     set_onsite_coupling!(sys, D * S[3]^2, 1)
 
-    Δt  = abs(0.05 / D)
-    λ = 0.1
-    langevin = Langevin(Δt; kT=0, λ)
-
-    randomize_spins!(sys)
+    # Reshape to sheared supercell and minimize energy
     A = [1 1 1; -1 1 0; 0 0 1]
-    sys_swt = reshape_supercell(sys, A)
+    sys = reshape_supercell(sys, A)
+    randomize_spins!(sys)
+    @test minimize_energy!(sys) > 0
 
-    langevin.kT = 0
-    for i in 1:50_000
-        step!(sys_swt, langevin)
-    end
+    k = cryst.recipvecs * rand(Float64, 3)
+    swt = SpinWaveTheory(sys)
+    ωk_num = dispersion(swt, [k])[1, :]
 
-    swt = SpinWaveTheory(sys_swt)
-
-    function sion_analytical_disp(k :: Vector{Float64})
-        # analytical solutions
-        γkxy = cos(2*π*k[1]) + cos(2*π*k[2])
-        γkz  = cos(2*π*k[3])
+    function single_ion_analytical_disp(k)
+        γkxy = cos(a*k[1]) + cos(a*k[2])
+        γkz  = cos(c*k[3])
         x = 1/2 - D/(8*(2*J+J′))
         Ak₊ = -8 * (x-1) * x * (2*J+J′) - (x-1) * D + 2 * (2*x-1) * (J *γkxy + J′*γkz)
         Bk₊ = -2 * (J * γkxy + J′ * γkz)
@@ -59,41 +49,36 @@ end
         ωk₋ = √(Ak₋^2-Bk₋^2)
         return ωk₊, ωk₋
     end
+    ωk1, ωk2 = single_ion_analytical_disp(k)
+    ωk3, ωk4 = single_ion_analytical_disp(k + [π/a, π/a, π/c])
+    ωk_ref = sort([ωk1, ωk2, ωk3, ωk4]; rev=true)
 
-    k = rand(Float64, 3)
-    ωk1, ωk2 = sion_analytical_disp(k)
-    ωk3, ωk4 = sion_analytical_disp(k .+= 0.5)
-    ωk_ana = [ωk1, ωk2, ωk3, ωk4]
-    index  = sortperm(ωk_ana, rev=true)
-    ωk_ana = ωk_ana[index]
-
-    ωk_num = dispersion(swt, [k])'
-
-    @test isapprox(ωk_ana, ωk_num)
+    @test ωk_num ≈ ωk_ref
 end
 
 @testitem "Intensities" begin
     using LinearAlgebra
 
+    # Crystal
     a = 8.289
-    lat_vecs = lattice_vectors(a, a, a, 90, 90, 90)
+    latvecs = lattice_vectors(a, a, a, 90, 90, 90)
     types = ["MzR1"]
-    basis_vecs = [[0, 0, 0]]
-    fcc = Crystal(lat_vecs, basis_vecs, 225; types)
-    S = 5/2
+    positions = [[0, 0, 0]]
+    fcc = Crystal(latvecs, positions, 225; types)
 
-    # According to a renormalized classical theory for spins (the details will be presented in a manuscript in preparation), the large-S expansion and the :dipole mode should produce the same results when apply the proper renormalization factor for the single-ion interaction strength.
-    cov_factor = (1 - 3/S + 11/(4*S^2)- 3/(4*S^3))
-    J = 22.06 * Sunny.meV_per_K
-    K = 0.15  * Sunny.meV_per_K
+    S = 5/2
+    J = 22.06 * meV_per_K
+    K = 0.15  * meV_per_K
     C = J + K
     J₁ = diagm([J, J, C])
     D_ST = 0.2
-    D = D_ST / cov_factor
-    dims = (1, 1, 1)
-    infos = [SpinInfo(1, S=S, g=2)]
+    # Undo Sunny-applied renormalization of quartic anisotropy
+    D = D_ST / Sunny.anisotropy_renormalization(2S+1)[4]
 
-    function compute_trace(mode::Symbol)
+    dims = (1, 1, 1)
+    infos = [SpinInfo(1; S, g=2)]
+
+    function compute(mode)
         sys = System(fcc, dims, infos, mode)
         set_exchange!(sys, J₁, Bond(1, 2, [0, 0, 0]))
         S = spin_operators(sys, 1)
@@ -104,7 +89,7 @@ end
         set_dipole!(sys, (-1, -1, 1), position_to_site(sys, (1/2, 0, 1/2)))
         set_dipole!(sys, (-1, 1, -1), position_to_site(sys, (0, 1/2, 1/2)))
         swt = SpinWaveTheory(sys)
-        k = [0.8, 0.6, 0.1]
+        k = fcc.recipvecs * [0.8, 0.6, 0.1]
         _, Sαβs =  Sunny.dssf(swt, [k])
 
         sunny_trace = [real(tr(Sαβs[1,a])) for a in axes(Sαβs)[2]]
@@ -113,104 +98,88 @@ end
         return sunny_trace
     end
 
-    spintools_trace = [1.1743243223274487, 1.229979802236658, 1.048056653379038]
-    SUN_trace = compute_trace(:SUN)
-    dipole_trace = compute_trace(:dipole)
-    @test SUN_trace ≈ dipole_trace ≈ spintools_trace
+    reference = [1.1743243223274487, 1.229979802236658, 1.048056653379038]
+    @test compute(:SUN) ≈ compute(:dipole) ≈ reference
 end
 
 @testitem "Biquadratic interactions" begin
-    function test_biquad(k :: Vector{Float64}, S)
-
-        a = 1.0
-        lat_vecs = lattice_vectors(a, a, a, 90, 90, 90)
-        types = ["A"]
-        basis_vecs = [[0, 0, 0]]
-
-        cryst = Crystal(lat_vecs, basis_vecs; types)
-
-        # Spin System
+    # Cubic crystal
+    a = 2.0
+    lat_vecs = lattice_vectors(a, a, a, 90, 90, 90)
+    basis_vecs = [[0, 0, 0]]
+    cryst = Crystal(lat_vecs, basis_vecs)
+    
+    function test_biquad(mode, k, S)
+        # System
         dims = (2, 2, 2)
-        infos = [SpinInfo(1, S=S, g=2)]
-        sys_SUN = System(cryst, dims, infos, :SUN)
-        sys_dip = System(cryst, dims, infos, :dipole)
-
-        α = -0.4 * π
+        infos = [SpinInfo(1; S, g=2)]
+        sys = System(cryst, dims, infos, mode)        
+        α = -0.4π
         J = 1.0
         JL, JQ = J * cos(α), J * sin(α) / S^2
-        set_exchange!(sys_SUN, JL,  Bond(1, 1, [1, 0, 0]); biquad=JQ)
-        set_exchange!(sys_dip, JL,  Bond(1, 1, [1, 0, 0]); biquad=JQ)
+        set_exchange!(sys, JL,  Bond(1, 1, [1, 0, 0]); biquad=JQ)
 
-        sys_swt_SUN = reshape_supercell(sys_SUN, [1 1 1; -1 1 0; 0 0 1])
-        set_dipole!(sys_swt_SUN, ( 1, 0, 0), position_to_site(sys_swt_SUN, (0, 0, 0)))
-        set_dipole!(sys_swt_SUN, (-1, 0, 0), position_to_site(sys_swt_SUN, (0, 1, 0)))
+        # Initialize Néel order
+        sys = reshape_supercell(sys, [1 1 1; -1 1 0; 0 0 1])
+        set_dipole!(sys, ( 1, 0, 0), position_to_site(sys, (0, 0, 0)))
+        set_dipole!(sys, (-1, 0, 0), position_to_site(sys, (0, 1, 0)))
 
-        sys_swt_dip = reshape_supercell(sys_dip, [1 1 1; -1 1 0; 0 0 1])
-        set_dipole!(sys_swt_dip, ( 1, 0, 0), position_to_site(sys_swt_dip, (0, 0, 0)))
-        set_dipole!(sys_swt_dip, (-1, 0, 0), position_to_site(sys_swt_dip, (0, 1, 0)))
+        # Numerical result
+        swt = SpinWaveTheory(sys)
+        disp = dispersion(swt, [k])
 
-        swt_SUN = SpinWaveTheory(sys_swt_SUN)
-        swt_dip = SpinWaveTheory(sys_swt_dip)
-
-        γk(k :: Vector{Float64}) = 2 * (cos(2π*k[1]) + cos(2π*k[2]) + cos(2π*k[3]))
-        ϵk₁(k :: Vector{Float64}) = J * (S*cos(α) - (2*S-2+1/S) * sin(α)) * √(36 - γk(k)^2) 
-
-        ϵk_num_SUN = dispersion(swt_SUN, [k])
-        ϵk_num_dip = dispersion(swt_dip, [k])
-        ϵk_ana = ϵk₁(k)
-
-        ϵk_num_SUN[end-1] ≈ ϵk_num_SUN[end] ≈ ϵk_num_dip[end] ≈ ϵk_ana
+        # Analytical result
+        γk = 2 * (cos(k[1]*a) + cos(k[2]*a) + cos(k[3]*a))
+        disp_ref = J * (S*cos(α) - (2*S-2+1/S) * sin(α)) * √(36 - γk^2)
+        
+        @test disp[end-1] ≈ disp[end] ≈ disp_ref
     end
 
     k = [0.12, 0.23, 0.34]
-    @test test_biquad(k, 1)
-    @test test_biquad(k, 3/2)
+    for mode in (:SUN, :dipole), S in (1, 3/2)
+        test_biquad(mode, k, S)
+    end
 end
 
-@testitem "Canted afm" begin
+@testitem "Canted AFM" begin
 
-    function disp_analytical_canted_afm(J, D, h, S, qs)
-        c₂ = 1 - 1/(2S)
-        θ = acos(h / (2S*(4J+c₂*D)))
-        disp = zeros(Float64, 2, length(qs))
-        for (iq, q) in enumerate(qs)
-            Jq = 2J*(cos(2π*q[1])+cos(2π*q[2]))
-            ωq₊ = real(√Complex(4J*S*(4J*S+2D*S*c₂*sin(θ)^2) + cos(2θ)*(Jq*S)^2 + 2S*Jq*(4J*S*cos(θ)^2 + c₂*D*S*sin(θ)^2)))
-            ωq₋ = real(√Complex(4J*S*(4J*S+2D*S*c₂*sin(θ)^2) + cos(2θ)*(Jq*S)^2 - 2S*Jq*(4J*S*cos(θ)^2 + c₂*D*S*sin(θ)^2)))
-            disp[:, iq] = [ωq₊, ωq₋]
-        end
-        return Sunny.reshape_dispersions(disp)
-    end
-
-    function test_canted_afm(q :: Vector{Float64}, S)
+    function test_canted_afm(S)
         J, D, h = 1.0, 0.54, 0.76
         a = 1
         latvecs = lattice_vectors(a, a, 10a, 90, 90, 90)
         positions = [[0, 0, 0]]
         cryst = Crystal(latvecs, positions)
-
+        q = cryst.recipvecs * [0.12, 0.23, 0.34]
+        
         dims = (2, 2, 1)
-        sys_dip = System(cryst, dims, [SpinInfo(1, S=S, g=1)], :dipole; units=Units.theory)
+        sys = System(cryst, dims, [SpinInfo(1; S, g=1)], :dipole; units=Units.theory)
+        set_exchange!(sys, J, Bond(1, 1, [1, 0, 0]))
+        Sz = spin_operators(sys,1)[3]
+        set_onsite_coupling!(sys, D*Sz^2, 1)
+        set_external_field!(sys, [0, 0, h])
 
-        set_exchange!(sys_dip, J, Bond(1, 1, [1, 0, 0]))
-
-        Sz = spin_operators(sys_dip,1)[3]
-        set_onsite_coupling!(sys_dip, D*Sz^2, 1)
-
-        set_external_field!(sys_dip, [0, 0, h])
-        sys_swt_dip = reshape_supercell(sys_dip, [1 -1 0; 1 1 0; 0 0 1])
+        # Numerical
+        sys_swt_dip = reshape_supercell(sys, [1 -1 0; 1 1 0; 0 0 1])
         c₂ = 1 - 1/(2S)
         θ = acos(h / (2S*(4J+D*c₂)))
         set_dipole!(sys_swt_dip, ( sin(θ), 0, cos(θ)), position_to_site(sys_swt_dip, (0,0,0)))
         set_dipole!(sys_swt_dip, (-sin(θ), 0, cos(θ)), position_to_site(sys_swt_dip, (1,0,0)))
         swt_dip = SpinWaveTheory(sys_swt_dip)
-        ϵq_num = dispersion(swt_dip, [q])
-        ϵq_ana = disp_analytical_canted_afm(J, D, h, S, [q])
+        ϵq_num = dispersion(swt_dip, [q])[1,:]
+
+        # Analytical
+        c₂ = 1 - 1/(2S)
+        θ = acos(h / (2S*(4J+c₂*D)))
+        Jq = 2J*(cos(q[1])+cos(q[2]))
+        ωq₊ = real(√Complex(4J*S*(4J*S+2D*S*c₂*sin(θ)^2) + cos(2θ)*(Jq*S)^2 + 2S*Jq*(4J*S*cos(θ)^2 + c₂*D*S*sin(θ)^2)))
+        ωq₋ = real(√Complex(4J*S*(4J*S+2D*S*c₂*sin(θ)^2) + cos(2θ)*(Jq*S)^2 - 2S*Jq*(4J*S*cos(θ)^2 + c₂*D*S*sin(θ)^2)))
+        ϵq_ana = [ωq₊, ωq₋]
+
         ϵq_num ≈ ϵq_ana
     end
-    q = [0.12, 0.23, 0.34]
-    @test test_canted_afm(q, 1)
-    @test test_canted_afm(q, 2)
+
+    @test test_canted_afm(1)
+    @test test_canted_afm(2)
 end
 
 @testitem "Local stevens expansion" begin


### PR DESCRIPTION
This is a work in progress.

Provide `cryst.recipvecs` in analogy to `cryst.latvecs`. Using this, it becomes easy to manually convert from RLU to absolute units before calling Sunny functions.

The FeI2 tutorial has been updated. Averaging of 120 degree rotations becomes natural in absolute units.

Significant simplifications to LSWT become possible by working in absolute units everywhere. In particular, it is no longer necessary to keep track of an "original" crystal.

The tests involving SampledCorrelations and binning are failing. This part of the code needs to be updated to use absolute units. I think this will lead to nice simplifications. See some "FIXME" markers for a subset of things that should change. Functions like  `bin_absolute_units_as_rlu!` and `bin_rlu_as_absolute_units!` are no longer needed.
