### PR TITLE
FormFactor update

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -55,6 +55,10 @@ fundamental reshaping function. Rename `resize_periodically` to
 The constructor [`SpinInfo`](@ref) now requires a ``g``-factor or tensor as a
 named argument.
 
+The constructor [`FormFactor`](@ref) no longer accepts an atom index. Instead,
+the form factors are associated with site-symmetry classes in order of
+appearance.
+
 Symbolic representations of operators are now hidden unless the external package
 `DynamicPolynomials.jl` is explicitly loaded by the user. The functionality of
 `print_anisotropy_as_stevens` has been replaced with

--- a/docs/src/writevtk.md
+++ b/docs/src/writevtk.md
@@ -25,7 +25,7 @@ latsize = (12,12,1);
 latvecs = lattice_vectors(8.,8.,12.,90,100,90)
 positions = [[0,0,0]]
 types = ["Cu"]
-formfactors  = [FormFactor(1,"Cu2")]
+formfactors = [FormFactor("Cu2")]
 xtal = Crystal(latvecs,positions;types);
 
 sys = System(xtal, latsize, [SpinInfo(1, S=1/2, g=2)], :SUN; seed=1);

--- a/examples/binning_tutorial.jl
+++ b/examples/binning_tutorial.jl
@@ -17,7 +17,7 @@ using Sunny, GLMakie
 latvecs = lattice_vectors(8.113,8.119,12.45,90,100,90)
 positions = [[0,0,0]]
 types = ["Cu"]
-formfactors  = [FormFactor(1,"Cu2")]
+formfactors = [FormFactor("Cu2")]
 xtal = Crystal(latvecs,positions;types);
 
 # We will use a somewhat small periodic lattice size of 6x6x4 in order

--- a/examples/longer_examples/CoRh2O4-tutorial.jl
+++ b/examples/longer_examples/CoRh2O4-tutorial.jl
@@ -115,8 +115,8 @@ print_symmetry_table(magxtal, 4.0)
 
 # Assign Local Hilbert Space
 S = 3/2
-lhs  = [SpinInfo(1, S=S, g=2)]
-ffs  = [FormFactor(1,"Co2")];
+lhs = [SpinInfo(1, S=S, g=2)]
+formfactors = [FormFactor("Co2")];
 
 # Create Spin System and Randomize it
 sunmode = :dipole
@@ -174,7 +174,7 @@ Qxpts  = range(-10.0, 10.0, length=nQpts);
 Qypts  = range(-10.0, 10.0, length=nQpts);
 qz     = 1.0;
 Qpts   = [[qx, qy, qz] for qx in Qxpts, qy in Qypts];
-@time  iq = instant_intensities(eqsf, Qpts, :perp; interpolation = :none, kT=integrator.kT, formfactors=ffs); 
+@time  iq = instant_intensities(eqsf, Qpts, :perp; interpolation = :none, kT=integrator.kT, formfactors);
 
 # Plot the resulting I(Q)
 heatmap(Qxpts, Qypts, iq;
@@ -215,14 +215,14 @@ symQpts   = [[0.75, 0.75, 0.00],  # List of wave vectors that define a path
             [0.00, 1.00, 0.00],
             [0.00,-4.00, 0.00]];
 (Qpts, xticks) = connected_path_from_rlu(magxtal, symQpts, densQpts);
-@time  iqw = intensities(sc, Qpts, :perp; interpolation = :none, kT=integrator.kT, formfactors=ffs); 
+@time  iqw = intensities(sc, Qpts, :perp; interpolation = :none, kT=integrator.kT, formfactors); 
 
 # If desired, broaden the sc in energy
 η     = 0.02 ## Lorentzian energy broadening parameter
 iqwc  = broaden_energy(sc, iqw, (ω, ω₀) -> lorentzian(ω-ω₀, η));
 
 # If desired, calculated the energy-integrated structure factor
-@time  iqt = instant_intensities(sc, Qpts, :perp; interpolation = :none, kT=integrator.kT, formfactors=ffs); 
+@time  iqt = instant_intensities(sc, Qpts, :perp; interpolation = :none, kT=integrator.kT, formfactors); 
 
 # Plot the resulting I(Q,W)    
 heatmap(1:size(iqwc, 1), ωs(sc), iqwc;
@@ -242,7 +242,7 @@ nQpts      = 100;
 Qpow       = range(0, Qmax, length=nQpts);  
 η          = 0.1;
 npts       = 300;
-@time pqw = powder_average(sc, Qpow, npts; η, kT=integrator.kT, formfactors=ffs);
+@time pqw = powder_average(sc, Qpow, npts; η, kT=integrator.kT, formfactors);
 
 # Plot resulting Ipow(Q,W)    
 heatmap(Qpow, ωs(sc), pqw;
@@ -265,8 +265,8 @@ for (i, kT) in enumerate(kTs)
     dwell!(sys, integrator;kTtarget=kT,ndwell=1000);
     sc_loc = dynamical_correlations(sys; Δt=2Δt0, nω=nω, ωmax=ωmax, process_trajectory=:symmetrize); 
     add_sample!(sc_loc, sys)
-    iqw_res[i] = intensities(sc_loc, Qpts, :perp; interpolation = :none, kT=kT, formfactors=ffs); 
-    pqw_res[i] = powder_average(sc_loc, Qpow, npts; η, kT=kT, formfactors=ffs);
+    iqw_res[i] = intensities(sc_loc, Qpts, :perp; interpolation = :none, kT, formfactors); 
+    pqw_res[i] = powder_average(sc_loc, Qpow, npts; η, kT, formfactors);
 end
 
 # Plot the resulting Ipow(Q,W) as a function of temperature,

--- a/examples/powder_averaging.jl
+++ b/examples/powder_averaging.jl
@@ -53,11 +53,14 @@ plot_spins(sys; arrowlength=1.0, linewidth=0.4, arrowsize=0.5)
 # We can now estimate ``𝒮(𝐪,ω)`` with [`SpinWaveTheory`](@ref) and
 # [`intensity_formula`](@ref). The mode `:perp` contracts with a dipole factor
 # to return the unpolarized intensity. We will also apply broadening with the
-# [`lorentzian`](@ref) kernel.
+# [`lorentzian`](@ref) kernel, and will dampen intensities using the
+# [`FormFactor`](@ref) for Cobalt(2+).
 
 swt = SpinWaveTheory(sys)
-η = 0.3 # (meV)
-formula = intensity_formula(swt, :perp, kernel=lorentzian(η)) # TODO: formfactors=[FormFactor(1, "Co2")]
+η = 0.4 # (meV)
+kernel = lorentzian(η)
+formfactors = [FormFactor("Co2")]
+formula = intensity_formula(swt, :perp; kernel, formfactors)
 
 # First, we consider the "single crystal" results. Use
 # [`connected_path_from_rlu`](@ref) to construct a path that connects

--- a/src/Intensities/Interpolation.jl
+++ b/src/Intensities/Interpolation.jl
@@ -170,9 +170,11 @@ function intensities_interpolated!(intensities, sc::SampledCorrelations, q_targe
     li_intensities = LinearIndices(intensities)
     ci_qs = CartesianIndices(q_targets)
     (; qs_all, ks_all, idcs_all, counts) = stencil_info 
-    for (iω, ω) in enumerate(ωvals)
+    for iω in eachindex(ωvals)
         iq = 0
         for (qs, ks, idcs, numrepeats) in zip(qs_all, ks_all, idcs_all, counts)
+            # The closure `formula.calc_intensity` is defined in
+            # intensity_formula(f, ::SampledCorrelations, ...)
             local_intensities = SVector{NInterp, T}(formula.calc_intensity(sc, ks[n], idcs[n], iω) for n in 1:NInterp)
             for _ in 1:numrepeats
                 iq += 1

--- a/src/SampledCorrelations/BasisReduction.jl
+++ b/src/SampledCorrelations/BasisReduction.jl
@@ -1,12 +1,11 @@
-function phase_averaged_elements(data, k::Vec3, sc::SampledCorrelations{N}, ffdata::Vector{FormFactor{FFType}}, ::Val{NCorr}, ::Val{NAtoms}) where {FFType, N, NCorr, NAtoms} 
+function phase_averaged_elements(data, k::Vec3, sc::SampledCorrelations{N}, ff_atoms, ::Val{NCorr}, ::Val{NAtoms}) where {N, NCorr, NAtoms}
     elems = zero(MVector{NCorr,ComplexF64})
-    knorm = norm(k)
-    ffs = ntuple(i -> compute_form(knorm, ffdata[i]), NAtoms)
+    ffs = ntuple(i -> compute_form_factor(ff_atoms[i], k⋅k), NAtoms)
     rs = ntuple(i -> sc.crystal.latvecs * sc.crystal.positions[i], NAtoms)
 
     for j in 1:NAtoms, i in 1:NAtoms
         phase = exp(im*(k ⋅ (rs[j] - rs[i])))
-        elems .+= phase .* ffs[i] .* ffs[j] .* view(data,:, i, j)
+        elems .+= phase .* ffs[i] .* ffs[j] .* view(data, :, i, j)
     end
 
     return SVector{NCorr,ComplexF64}(elems)

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -68,7 +68,7 @@ function intensity_formula(f::Function,sc::SampledCorrelations,corr_ix::Abstract
         error("`kT` must be greater than zero.")
     end
 
-    ffdata = prepare_form_factors(sc, formfactors)
+    ff_atoms = propagate_form_factors_to_atoms(formfactors, sc.crystal)
     NAtoms = Val(size(sc.data)[2])
     NCorr = Val(length(corr_ix))
 
@@ -79,7 +79,7 @@ function intensity_formula(f::Function,sc::SampledCorrelations,corr_ix::Abstract
     # momentum transfer may be different than the one inferred from `ix_q`, so it needs
     # to be provided independently of `ix_q`.
     formula = function (sc::SampledCorrelations,k::Vec3,ix_q::CartesianIndex{3},ix_ω::Int64)
-        correlations = phase_averaged_elements(view(sc.data,corr_ix,:,:,ix_q,ix_ω), k, sc, ffdata, NCorr, NAtoms)
+        correlations = phase_averaged_elements(view(sc.data,corr_ix,:,:,ix_q,ix_ω), k, sc, ff_atoms, NCorr, NAtoms)
 
         ω = ωs_sc[ix_ω]
         return f(k,ω,correlations) * classical_to_quantum(ω, kT)

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -79,13 +79,13 @@ function intensity_formula(f::Function,sc::SampledCorrelations,corr_ix::Abstract
     # Additionally, for momentum transfers outside of the first BZ, the norm `k` of the
     # momentum transfer may be different than the one inferred from `ix_q`, so it needs
     # to be provided independently of `ix_q`.
-    formula = function (sc::SampledCorrelations,k::Vec3,ix_q::CartesianIndex{3},ix_ω::Int64)
+    calc_intensity = function (sc::SampledCorrelations,k::Vec3,ix_q::CartesianIndex{3},ix_ω::Int64)
         correlations = phase_averaged_elements(view(sc.data,corr_ix,:,:,ix_q,ix_ω), k, sc, ff_atoms, NCorr, NAtoms)
 
         ω = ωs_sc[ix_ω]
         return f(k,ω,correlations) * classical_to_quantum(ω, kT)
     end
-    ClassicalIntensityFormula{return_type}(kT,formfactors,string_formula,formula)
+    ClassicalIntensityFormula{return_type}(kT,formfactors,string_formula,calc_intensity)
 end
 
 """

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -59,8 +59,9 @@ There are keyword arguments providing temperature and form factor corrections:
     experimental data. If `kT` is not specified, infinite temperature (no
     correction) is assumed.
 - `formfactors`: To apply form factor corrections, provide this keyword with a
-    vector of `FormFactor`s, one for each unique site in the unit cell. The form factors
-    will be symmetry propagated to all equivalent sites.
+    list of `FormFactor`s, one for each symmetry-distinct site in the crystal.
+    The order of `FormFactor`s must correspond to the order of site symmetry
+    classes, e.g., as they appear when printed in `display(crystal)`.
 """
 function intensity_formula(f::Function,sc::SampledCorrelations,corr_ix::AbstractVector{Int64}; kT = Inf, formfactors = nothing, return_type = Float64, string_formula = "f(Q,ω,S{α,β}[ix_q,ix_ω])")
     # If temperature given, ensure it's greater than 0.0

--- a/src/SampledCorrelations/FormFactor.jl
+++ b/src/SampledCorrelations/FormFactor.jl
@@ -1,177 +1,130 @@
-const EMPTY_FF = 1
-const SINGLE_FF = 2 
-const DOUBLE_FF = 3
+# The intention is to replace src/SampledCorreslations/FormFactor.jl with
+# src/System/FormFactor.jl. The code duplication here is temporary to aid the
+# transition.
 
-Base.@kwdef struct FormFactor{FFType}
-    atom      :: Int64
-    J0_params :: NTuple{7, Float64} = (1, 0, 0, 0, 0, 0, 0)  # Default values so there is no effect if FFType is promoted
-    J2_params :: NTuple{7, Float64} = (0, 0, 0, 0, 0, 0, 0)
-    g_lande   :: Float64 = 1
+# Expansion of the form ``A*exp(-a*s^2) + B*exp(-b*s^2) + C*exp(-c*s^2) + D``
+struct ExpandedBesselIntegral
+    # !! Order of fields is tied to data table format !! 
+    A :: Float64
+    a :: Float64
+    B :: Float64
+    b :: Float64
+    C :: Float64
+    c :: Float64
+    D :: Float64
+end
+
+struct FormFactor
+    j0 :: ExpandedBesselIntegral
+    j2 :: ExpandedBesselIntegral
+    g :: Float64
+end
+
+const identity_form_factor = let
+    j0 = ExpandedBesselIntegral(0, 0, 0, 0, 0, 0, 1)
+    j2 = ExpandedBesselIntegral(0, 0, 0, 0, 0, 0, 0)
+    g = 2
+    FormFactor(j0, j2, g)
 end
 
 """
-    FormFactor(atom::Int64, elem::String; g_lande=nothing)
+    FormFactor(ion::String; g_lande=2)
 
-Basic type for specifying form factor parameters. Must be provided a site within
-the unit cell (`atom`) and a string specifying the element name. This used when
-creating an [`intensity_formula`](@ref), which accepts a list of `FormFactors`s.
-Note that these corrections assume S(q,ω) is being calculated in the dipole
-approximation; they may not be appropriate for a general SU(N) system.
+The magnetic form factor for a given magnetic ion and charge state. These can
+optionally be provided to [`intensity_formula`](@ref), and will be used to scale
+the structure factor intensities as a function of wavevector magnitude.
 
-A list of supported element names is available at:
-
-https://www.ill.eu/sites/ccsl/ffacts/ffachtml.html
-
-The Landé g-factor may also be specified. 
-
-In more detail, the data stored in a `FormFactor` will be used to compute the
-form factor for each momentum space magnitude `|k|`, measured in inverse
-angstroms. The result is dependent on the magnetic ion species. By default, a
-first order form factor ``f`` is returned. If the keyword `g_lande` is given a
-numerical value, then a second order form factor ``F`` is returned.
-
-It is traditional to define the form factors using a sum of Gaussian broadening
-functions in the scalar variable ``s = |k|/4π``, where ``|k|`` can be
-interpreted as the magnitude of momentum transfer.
-
-The Neutron Data Booklet, 2nd ed., Sec. 2.5 Magnetic Form Factors, defines the
-approximation
-
-`` \\langle j_l(s) \\rangle = A e^{-as^2} + B e^{-bs^2} + Ce^{-cs^2} + D, ``
-
-where coefficients ``A, B, C, D, a, b, c`` are obtained from semi-empirical
-fits, depending on the orbital angular momentum index ``l = 0, 2``. For
-transition metals, the form-factors are calculated using the Hartree-Fock
-method. For rare-earth metals and ions, Dirac-Fock form is used for the
-calculations.
+The parameter `ion` must be one of the following allowed strings:
+```
+Sc0,Sc1,Sc2,Ti0,Ti1,Ti2,Ti3,V0,V1,V2,V3,V4,Cr0,Cr1,Cr2,Cr3,Cr4,Mn0,Mn1,Mn2,Mn3,
+Mn4,Fe0,Fe1,Fe2,Fe3,Fe4,Co0,Co1,Co2,Co3,Co4,Ni0,Ni1,Ni2,Ni3,Ni4,Cu0,Cu1,Cu2,Cu3,
+Cu4,Y0,Zr0,Zr1,Nb0,Nb1,Mo0,Mo1,Tc0,Tc1,Ru0,Ru1,Rh0,Rh1,Pd0,Pd1,Ce2,Nd2,Nd3,Sm2,
+Sm3,Eu2,Eu3,Gd2,Gd3,Tb2,Tb3,Dy2,Dy3,Ho2,Ho3,Er2,Er3,Tm2,Tm3,Yb2,Yb3,Pr3,U3,U4,
+U5,Np3,Np4,Np5,Np6,Pu3,Pu4,Pu5,Pu6,Am2,Am3,Am4,Am5,Am6,Am7
+```
 
 A first approximation to the magnetic form factor is
 
-``f(s) = \\langle j_0(s) \\rangle``
+``f(s) = \\langle j_0(s) \\rangle``,
 
-A second order correction is given by
+where ``\\langle j_l(s) \\rangle`` is a Bessel function integral of the magnetic
+dipole.
 
-``F(s) = \\frac{2-g}{g} \\langle j_2(s) \\rangle s^2 + f(s)``, where ``g`` is
-the Landé g-factor.  
+If Landé ``g``-factor is distinct from 2, then a correction will be applied,
 
-Digital tables are available at:
+``F(s) = \\frac{2-g}{g} \\langle j_2(s) \\rangle s^2 + f(s)``.
 
-* https://www.ill.eu/sites/ccsl/ffacts/ffachtml.html
+Sunny uses the semi-empirical fits for ``j_0`` and ``j_2`` listed from Refs. [1]
+and [2]. These functions are approximated as a sum of Gaussians in the scalar
+variable ``s = |k|/4π``, where ``|k|`` can be interpreted as the magnitude of
+momentum transfer:
 
-Additional references are:
+``\\langle j_l(s) \\rangle = A e^{-as^2} + B e^{-bs^2} + Ce^{-cs^2} + D,``
 
- * Marshall W and Lovesey S W, Theory of thermal neutron scattering Chapter 6
-   Oxford University Press (1971)
- * Clementi E and Roetti C,  Atomic Data and Nuclear Data Tables, 14 pp 177-478
-   (1974)
- * Freeman A J and Descleaux J P, J. Magn. Mag. Mater., 12 pp 11-21 (1979)
- * Descleaux J P and Freeman A J, J. Magn. Mag. Mater., 8 pp 119-129 (1978) 
+where ``A, B, C, D, a, b, c`` are ``l``-dependent fitting parameters. For
+transition metals, the parameters are estimated using the Hartree-Fock method.
+For rare-earth metals and ions, the Dirac-Fock form is used.
+
+References:
+
+ 1. https://www.ill.eu/sites/ccsl/ffacts/ffachtml.html
+ 2. J. Brown, The Neutron Data Booklet, 2nd ed., Sec. 2.5 Magnetic Form Factors
+    (2003).
+ 3. Marshall W and Lovesey S W, Theory of thermal neutron scattering Chapter 6
+    Oxford University Press (1971)
+ 4. Clementi E and Roetti C,  Atomic Data and Nuclear Data Tables, 14 pp 177-478
+    (1974)
+ 5. Freeman A J and Descleaux J P, J. Magn. Mag. Mater., 12 pp 11-21 (1979)
+    Descleaux J P and Freeman A J, J. Magn. Mag. Mater., 8 pp 119-129 (1978) 
 """
-function FormFactor(atom::Int64, elem::Union{Nothing, String}; g_lande=nothing) # default g_lande = 1.0 will never affect calculation -- better than Nothing
-
-    function lookup_ff_params(elem, datafile) :: NTuple{7, Float64}
+function FormFactor(ion::String; g_lande=2)
+    function lookup_ff_params(ion, datafile)
         path = joinpath(@__DIR__, "data", datafile)
         lines = collect(eachline(path))
-        matches = filter(line -> startswith(line, elem), lines)
+        matches = filter(line -> startswith(line, ion), lines)
         if isempty(matches)
-            error("'ff_elem = $elem' not a valid choice of magnetic ion.")
+            error("'$ion' not a valid magnetic ion.")
         end
-        Tuple(parse.(Float64, split(matches[1])[2:end]))
+        ExpandedBesselIntegral(parse.(Float64, split(matches[1])[2:end])...)
     end
 
-    return if !isnothing(g_lande) # Only attempt to lookup J2 parameters if Lande g-factor is provided
-        J0_params = lookup_ff_params(elem, "form_factor_J0.dat")
-        J2_params = lookup_ff_params(elem, "form_factor_J2.dat")
-        FormFactor{DOUBLE_FF}(; atom, J0_params, J2_params, g_lande)
-    elseif !isnothing(elem)
-        J0_params = lookup_ff_params(elem, "form_factor_J0.dat")
-        FormFactor{SINGLE_FF}(; atom, J0_params)
+    j0 = lookup_ff_params(ion, "form_factor_J0.dat")
+    j2 = lookup_ff_params(ion, "form_factor_J2.dat")
+    FormFactor(j0, j2, g_lande)
+end
+
+
+function compute_gaussian_expansion(j::ExpandedBesselIntegral, s2)
+    (; A, a, B, b, C, c, D) = j
+    return A*exp(-a*s2) + B*exp(-b*s2) + C*exp(-c*s2) + D
+end
+
+function compute_form_factor(form_factor::FormFactor, k2::Float64)
+    (; j0, j2, g) = form_factor
+
+    # Return early if this is the identity form factor
+    (j0.A == j0.B == j0.C == 0) && (j0.D == 1) && (g == 2) && return 1.0
+
+    s2 = k2 / (4π)^2
+    if g == 2
+        return compute_gaussian_expansion(j0, s2)
     else
-        FormFactor{EMPTY_FF}(; atom)
+        form1 = compute_gaussian_expansion(j0, s2)
+        form2 = compute_gaussian_expansion(j2, s2)
+        return ((2-g)/g) * form2 * s2 + form1
     end
 end
 
-
-# Make sure `FormFactor` type parameter is uniform for all elements of list.
-# This ensures that `phase_averaged_elements` knows which version of
-# `compute_form` to call at compile time.
-function upconvert_form_factors(ffs)
-    FFType = maximum([only(typeof(ff).parameters) for ff in ffs])
-    return map(ffs) do ff
-        (; atom, J0_params, J2_params, g_lande) = ff
-        FormFactor{FFType}(; atom, J0_params, J2_params, g_lande)
-    end
-end
-
-# If necessary, update the indices of FormFactors from original crystal
-# to the corresponding indices of the new crystal.
-# TODO: Moving ion information into `SpinInfo` will eliminate the need for this as well
-# as symmetry propagation.
-function map_form_factors_to_crystal(sc::SampledCorrelations, ffs::Vector{FormFactor{FFType}}) where FFType
-    (; crystal, origin_crystal) = sc
-
-    (isnothing(origin_crystal)) && (return ffs)
-
-    ffs_new = []
-    for ff in ffs
-        old_ri = origin_crystal.positions[ff.atom]  
-        ri = crystal.latvecs \ origin_crystal.latvecs * old_ri
-        atom_new = position_to_atom(crystal, ri)
-
-        (; J0_params, J2_params, g_lande) = ff
-        push!(ffs_new, FormFactor{FFType}(; atom=atom_new, J0_params, J2_params, g_lande))
+# Given a form factor for each "symmetry class" of sites, return a form factor
+# for each atom in the crystal.
+function propagate_form_factors_to_atoms(ffs, cryst::Crystal)
+    isnothing(ffs) && return fill(identity_form_factor, natoms(cryst))
+    
+    ref_classes = unique(cryst.classes)
+    if length(ffs) != length(ref_classes)
+        error("""Received $(length(ffs)) form factors, but $(length(ref_classes)) are
+                 required, one for each symmetry-distinct site in the crystal.""")
     end
 
-    return ffs_new
-end
-
-# Remap form factors to reshaped crystal (if necessary) and propagate to symmetry
-# equivalent sites.
-function propagate_form_factors(sc::SampledCorrelations, ffs::Vector{FormFactor{FFType}}) where FFType
-    ffs = map_form_factors_to_crystal(sc, ffs)
-    ref_atoms = [ff.atom for ff in ffs]
-    atom_to_ref_atom = propagate_reference_atoms(sc.crystal, ref_atoms)
-
-    return map(enumerate(atom_to_ref_atom)) do (atom, atom′)
-        ff = ffs[findfirst(==(atom′), ref_atoms)]
-        (; J0_params, J2_params, g_lande) = ff
-        FormFactor{FFType}(; atom, J0_params, J2_params, g_lande)
-    end
-end
-
-# Process form factor information into optimal form for efficient calculation.
-function prepare_form_factors(sc, formfactors)
-    if isnothing(formfactors)
-        cryst = isnothing(sc.origin_crystal) ? sc.crystal : sc.origin_crystal 
-        class_indices = [findfirst(==(class_label), cryst.classes) for class_label in unique(cryst.classes)]
-        formfactors = [FormFactor{Sunny.EMPTY_FF}(; atom) for atom in class_indices]
-    end
-    formfactors = upconvert_form_factors(formfactors) # Ensure formfactors have consistent type
-    return propagate_form_factors(sc, formfactors)
-end
-
-# Second-order form factor calculation.
-function compute_form(k::Float64, params::FormFactor{DOUBLE_FF})
-    s = k/4π
-    g = params.g_lande
-
-    (A, a, B, b, C, c, D) = params.J0_params
-    form1 = A*exp(-a*s^2) + B*exp(-b*s^2) + C*exp(-c*s^2) + D
-
-    (A, a, B, b, C, c, D) = params.J2_params
-    form2 = A*exp(-a*s^2) + B*exp(-b*s^2) + C*exp(-c*s^2) + D
-
-    return ((2-g)/g) * (form2*s^2) + form1
-end
-
-# First-order form factor calculation.
-function compute_form(k::Float64, params::FormFactor{SINGLE_FF})
-    s = k/4π
-    (A, a, B, b, C, c, D) = params.J0_params
-    return A*exp(-a*s^2) + B*exp(-b*s^2) + C*exp(-c*s^2) + D
-end
-
-# No form factor correction.
-function compute_form(::Float64, ::FormFactor{EMPTY_FF})
-    return 1.0
+    return [ffs[findfirst(==(c), ref_classes)] for c in cryst.classes]
 end

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -9,7 +9,6 @@ struct SampledCorrelations{N}
     # 𝒮^{αβ}(q,ω) data and metadata
     data           :: Array{ComplexF64, 7}   # Raw SF data for 1st BZ (numcorrelations × natoms × natoms × latsize × energy)
     crystal        :: Crystal                # Crystal for interpretation of q indices in `data`
-    origin_crystal :: Union{Nothing,Crystal} # Original user-specified crystal (if different from above) -- needed for FormFactor accounting
     Δω             :: Float64                # Energy step size (could make this a virtual property)  
 
     # Correlation info (αβ indices of 𝒮^{αβ}(q,ω))
@@ -275,11 +274,9 @@ function dynamical_correlations(sys::System{N}; Δt, nω, ωmax,
 
     # Other initialization
     nsamples = Int64[0]
-    origin_crystal = !isnothing(sys.origin) ? sys.origin.crystal : nothing
 
     # Make Structure factor and add an initial sample
-    sc = SampledCorrelations{N}(data, sys.crystal, origin_crystal, Δω,
-                                observables, observable_ixs, correlations,
+    sc = SampledCorrelations{N}(data, sys.crystal, Δω, observables, observable_ixs, correlations,
                                 samplebuf, fft!, copybuf, measperiod, apply_g, Δt, nsamples, processtraj!)
 
     return sc

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -37,7 +37,8 @@ struct SpinWaveTheory
 end
 
 function SpinWaveTheory(sys::System{N}; energy_ϵ::Float64=1e-8, energy_tol::Float64=1e-6) where N
-    # Reshape into single unit cell
+    # Reshape into single unit cell. A clone will always be performed, even if
+    # no reshaping happens.
     cellsize_mag = cell_dimensions(sys) * diagm(collect(sys.latsize))
     sys = reshape_supercell_aux(sys, (1,1,1), cellsize_mag)
 

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -63,8 +63,8 @@
 
 
     # Test form factor correction works and is doing something. ddtodo: add example with sublattice
-    formfactors = [FormFactor(1, "Fe2")]
-    vals = intensities_interpolated(sc, qgrid; formula = intensity_formula(sc,:trace;formfactors = formfactors), negative_energies=true)
+    formfactors = [FormFactor("Fe2")]
+    vals = intensities_interpolated(sc, qgrid; formula = intensity_formula(sc,:trace; formfactors), negative_energies=true)
     total_intensity_ff = sum(vals)
     @test total_intensity_ff != total_intensity_trace
 


### PR DESCRIPTION
FormFactor no longer requires an atom index. Instead, the list of FormFactors must appear in the same order as the site symmetry "classes" of the crystal, i.e. as the `crystal.classes` field. The order of these classes is invariant to crystal reshaping.

FormFactors now work for LSWT.

David says this code is on the performance critical path for SampledCorrelations measurements, so we should do a benchmark before merging.
