### PR TITLE
Estimate variance on classical SF calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ profile.pb.gz
 .DS_Store
 .vscode
 *.ipynb
-*.lyx*
+*.lyx~
+*.lyx#

--- a/docs/lyx_notes/complex_welford.lyx
+++ b/docs/lyx_notes/complex_welford.lyx
@@ -297,7 +297,7 @@ noprefix "false"
 
 \end_inset
 
-Rearranging this expression yeilds the desired recursion:
+Rearranging this expression yields the desired recursion:
 \begin_inset Formula 
 \begin{equation}
 \sigma_{N+1}^{2}=\sigma_{N}^{2}+\frac{N\left(z_{N+1}-\mu_{N}\right)\left(z_{N+1}^{*}-\mu_{N}^{*}\right)-\left(N+1\right)\sigma_{N}^{2}}{\left(N+1\right)^{2}}.\label{eq:recursion_initial}

--- a/docs/lyx_notes/complex_welford.lyx
+++ b/docs/lyx_notes/complex_welford.lyx
@@ -1,0 +1,432 @@
+#LyX 2.3 created this file. For more info see http://www.lyx.org/
+\lyxformat 544
+\begin_document
+\begin_header
+\save_transient_properties true
+\origin unavailable
+\textclass article
+\use_default_options true
+\maintain_unincluded_children false
+\language english
+\language_package default
+\inputencoding auto
+\fontencoding global
+\font_roman "default" "default"
+\font_sans "default" "default"
+\font_typewriter "default" "default"
+\font_math "auto" "auto"
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100 100
+\font_tt_scale 100 100
+\use_microtype false
+\use_dash_ligatures true
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\use_hyperref false
+\papersize default
+\use_geometry false
+\use_package amsmath 1
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 1
+\use_minted 0
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\is_math_indent 0
+\math_numbering_side default
+\quotes_style english
+\dynamic_quotes 0
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Title
+Running Variance Estimates in Sunny: Complex generalization of Welford's
+ Algorithm
+\end_layout
+
+\begin_layout Standard
+When calculating a structure factor, Sunny first generates a trajectory,
+ 
+\begin_inset Formula $s_{i,\mu}^{\alpha}\left({\bf r},t\right)$
+\end_inset
+
+, where 
+\begin_inset Formula ${\bf r}$
+\end_inset
+
+ is a position on the Bravais lattice, 
+\begin_inset Formula $t$
+\end_inset
+
+ time, 
+\begin_inset Formula $\alpha$
+\end_inset
+
+ spin component, 
+\begin_inset Formula $\mu$
+\end_inset
+
+ the atom, and 
+\begin_inset Formula $i$
+\end_inset
+
+ sample number.
+ For each trajectory, Sunny determines a sample structure factor, 
+\begin_inset Formula $S_{i,\mu\nu}^{\alpha\beta}\text{\left({\bf q},\omega\right)}$
+\end_inset
+
+, where 
+\begin_inset Formula $\alpha$
+\end_inset
+
+ and 
+\begin_inset Formula $\beta$
+\end_inset
+
+ are spin indices, 
+\begin_inset Formula $\mu$
+\end_inset
+
+ and 
+\begin_inset Formula $\nu$
+\end_inset
+
+ are atom indices, 
+\begin_inset Formula ${\bf q}$
+\end_inset
+
+ is a reciprocal lattice vector, and 
+\begin_inset Formula $\omega$
+\end_inset
+
+ is an energy.
+ This can be thought of as an 8-index array of complex numbers.
+ These sample structure factors are averaged to produce a final estimate,
+ 
+\begin_inset Formula 
+\[
+S_{\mu\nu}^{\alpha\beta}\text{\left({\bf q},\omega\right)}=\frac{1}{N}\sum_{i=1}^{N}S_{i,\mu\nu}^{\alpha\beta}\text{\left({\bf q},\omega\right)}
+\]
+
+\end_inset
+
+where 
+\begin_inset Formula $N$
+\end_inset
+
+ is the total number of samples.
+ 
+\end_layout
+
+\begin_layout Standard
+In practice, the average structure factor is calculated iteratively, since
+ each 
+\begin_inset Formula $S_{i,\mu\nu}^{\alpha\beta}\text{\left({\bf q},\omega\right)}$
+\end_inset
+
+ is generally very large.
+ It would be valuable to calculate a running estimate of the variance as
+ well.
+ A standard way to estimate variance iteratively is Welford's algorithm.
+ However, this method is generally stated in terms of real variables, whereas
+ each entry of 
+\series bold
+
+\begin_inset Formula $S_{i,\mu\nu}^{\alpha\beta}\text{\left({\bf q},\omega\right)}$
+\end_inset
+
+
+\series default
+ is a complex number (i.e., for any choice of 
+\begin_inset Formula ${\bf q}$
+\end_inset
+
+, 
+\begin_inset Formula $\omega$
+\end_inset
+
+ and indices).
+ This note outlines how this algorithm is generalized to the complex case.
+\end_layout
+
+\begin_layout Standard
+We will make the assumption that the values associated with all wave vectors,
+ energies and indices are decorrelated, i.e., we will assume every complex
+ number in the array representing 
+\begin_inset Formula $S_{i,\mu\nu}^{\alpha\beta}\text{\left({\bf q},\omega\right)}$
+\end_inset
+
+ is an independent random variable.
+ Will refer to an arbitrary matrix element (single complex random variable)
+ as 
+\begin_inset Formula $z_{i}$
+\end_inset
+
+.
+ Further, we will assume that the real and complex components of 
+\begin_inset Formula $z_{i}$
+\end_inset
+
+ are not correlated.
+ Under this assumption (circularly-symmetric Gaussian), the variance of
+ the complex random variable 
+\begin_inset Formula $Z$
+\end_inset
+
+ that generates the samples may be estimated as
+\begin_inset Formula 
+\[
+\sigma_{Z}^{2}={\rm Var}\left[Z\right]={\rm E}\left[\left|Z\right|^{2}\right]-\left|{\rm E}\left[Z\right]\right|^{2}.
+\]
+
+\end_inset
+
+(If the real and complex components are correlated, it is also necessary
+ to track the pseudovariance, which we disregard.) This definition yields
+ the sum of the variances of the real and imaginary components of 
+\begin_inset Formula $Z$
+\end_inset
+
+.
+ 
+\end_layout
+
+\begin_layout Standard
+To derive the algorithm, we observe that, for 
+\begin_inset Formula $N$
+\end_inset
+
+ samples, the estimated variance is given by,
+\begin_inset Formula 
+\[
+\sigma_{N}^{2}=\frac{1}{N}\sum_{i=1}^{N}z_{i}z_{i}^{*}-\mu_{N}\mu_{N}^{*},
+\]
+
+\end_inset
+
+where the mean,
+\begin_inset Formula 
+\[
+\mu_{N}=\frac{1}{N}\sum_{i=1}^{N}z_{i},
+\]
+
+\end_inset
+
+is a complex number.
+ From this it follows that
+\begin_inset Formula 
+\[
+\begin{alignedat}{1}N\sigma_{N} & =\sum_{i=1}^{N}z_{i}z_{i}^{*}-N\mu_{N}\mu_{N}^{*}\end{alignedat}
+\]
+
+\end_inset
+
+and
+\begin_inset Formula 
+\begin{equation}
+\begin{alignedat}{1}\left(N+1\right)\sigma_{N+1} & =\sum_{i=1}^{N+1}z_{i}z_{i}^{*}-\left(N+1\right)\mu_{N+1}\mu_{N+1}^{*}\\
+ & =\sum_{i=1}^{N}z_{i}z_{i}^{*}+z_{N+1}z_{N+1}^{*}-\left(N+1\right)\mu_{N+1}\mu_{N+1}^{*}\\
+ & =N\left(\sigma_{N}^{2}+\mu_{N}\mu_{N}^{*}\right)+z_{N+1}z_{N+1}^{*}-\left(N+1\right)\mu_{N+1}\mu_{N+1}^{*}.
+\end{alignedat}
+\label{eq:intermediate_1}
+\end{equation}
+
+\end_inset
+
+Further, 
+\begin_inset Formula 
+\[
+\begin{alignedat}{1}\mu_{N+1}\mu_{N+1}^{*} & =\frac{1}{\left(N+1\right)^{2}}\left(N\mu_{N}+z_{N}\right)\left(N\mu_{N}^{*}+z_{N}^{*}\right)\end{alignedat}
+.
+\]
+
+\end_inset
+
+Substituting this into Eq.
+ (
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "eq:intermediate_1"
+plural "false"
+caps "false"
+noprefix "false"
+
+\end_inset
+
+), expanding and simplifying, yields,
+\begin_inset Formula 
+\[
+\left(N+1\right)^{2}\sigma_{N+1}=N\left(N+1\right)\sigma_{N}^{2}+N\left(\mu_{N}-z_{N+1}\right)\left(\mu_{N}^{*}-z_{N+1}\right).
+\]
+
+\end_inset
+
+Rearranging this expression yeilds the desired recursion:
+\begin_inset Formula 
+\begin{equation}
+\sigma_{N+1}^{2}=\sigma_{N}^{2}+\frac{N\left(z_{N+1}-\mu_{N}\right)\left(z_{N+1}^{*}-\mu_{N}^{*}\right)-\left(N+1\right)\sigma_{N}^{2}}{\left(N+1\right)^{2}}.\label{eq:recursion_initial}
+\end{equation}
+
+\end_inset
+
+The same result essentially holds in the real case, with the product of
+ conjugates replaced by ordinary squaring.
+\end_layout
+
+\begin_layout Standard
+We will massage this a bit further.
+ Note that,
+\begin_inset Formula 
+\[
+z_{N+1}=\left(N+1\right)\mu_{N+1}-N\mu_{N}.
+\]
+
+\end_inset
+
+Substituting this into the numerator of the 
+\begin_inset Quotes eld
+\end_inset
+
+update
+\begin_inset Quotes erd
+\end_inset
+
+ term of Eq.
+ (
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "eq:recursion_initial"
+plural "false"
+caps "false"
+noprefix "false"
+
+\end_inset
+
+) and simplifying, we find
+\begin_inset Formula 
+\begin{equation}
+\sigma_{N+1}^{2}=\sigma_{N}^{2}+\frac{N\left(\mu_{N+1}-\mu_{N}\right)\left(z_{N+1}^{*}-\mu_{N}^{*}\right)-\sigma_{N}^{2}}{\left(N+1\right)}.\label{eq:almost_there}
+\end{equation}
+
+\end_inset
+
+Finally, note that 
+\begin_inset Formula 
+\[
+\begin{alignedat}{1}N\left(\mu_{N+1}-\mu_{N}\right) & =\frac{N}{N+1}\sum_{i=1}^{N+1}z_{i}-\sum_{i=1}^{N}z_{i}\\
+ & =\sum_{i=1}^{N+1}z_{i}-\frac{1}{N+1}\sum_{i=1}^{N+1}z_{i}-\sum_{i}^{N}z_{i}\\
+ & =\left(z_{N+1}-\mu_{N+1}\right).
+\end{alignedat}
+\]
+
+\end_inset
+
+Substituting this result into Eq.
+ (
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "eq:almost_there"
+plural "false"
+caps "false"
+noprefix "false"
+
+\end_inset
+
+) yields the desired result:
+\begin_inset Formula 
+\begin{equation}
+\sigma_{N+1}^{2}=\sigma_{N}+\frac{\left(z_{N+1}-\mu_{N+1}\right)\left(z_{N+1}^{*}-\mu_{N}^{*}\right)-\sigma_{N}^{2}}{N+1}.\label{eq:final_recursion}
+\end{equation}
+
+\end_inset
+
+Note that since Eq.
+ (
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "eq:recursion_initial"
+plural "false"
+caps "false"
+noprefix "false"
+
+\end_inset
+
+) is clearly real valued, so is Eq.
+ (
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "eq:final_recursion"
+plural "false"
+caps "false"
+noprefix "false"
+
+\end_inset
+
+), which results from simple manipulations of Eq.
+ (
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "eq:recursion_initial"
+plural "false"
+caps "false"
+noprefix "false"
+
+\end_inset
+
+).
+ This is true despite the fact that it is not immediately obvious that 
+\begin_inset Formula $\left(z_{N+1}-\mu_{N+1}\right)\left(z_{N+1}^{*}-\mu_{N}^{*}\right)$
+\end_inset
+
+ should be real.
+\end_layout
+
+\begin_layout Standard
+This iterative estimation can be implemented in a straightforward way alongside
+ the cumulative average.
+ It requires the allocation of an array with the same number of entries
+ as 
+\begin_inset Formula $S_{\mu\nu}^{\alpha\beta}\text{\left({\bf q},\omega\right)}$
+\end_inset
+
+, but these entries need only contain real variables.
+\end_layout
+
+\end_body
+\end_document

--- a/src/Intensities/ElementContraction.jl
+++ b/src/Intensities/ElementContraction.jl
@@ -177,6 +177,8 @@ function intensity_formula(sc::SampledCorrelations, mode::Symbol; kwargs...)
     intensity_formula(sc,contractor;string_formula,kwargs...)
 end
 
+error_formula(sc::SampledCorrelations, mode::Symbol; kwargs...) = intensity_formula(sc, mode; errors=true, kwargs...)
+
 function intensity_formula(sc::SampledCorrelations, contractor::Contraction{T}; kwargs...) where T
     intensity_formula(sc,required_correlations(contractor); return_type = T,kwargs...) do k,ω,correlations
         intensity = contract(correlations, k, contractor)

--- a/src/Intensities/ElementContraction.jl
+++ b/src/Intensities/ElementContraction.jl
@@ -129,6 +129,20 @@ required_correlations(::FullTensor{NCorr}) where NCorr = 1:NCorr
 ################################################################################
 Base.zeros(::Contraction{T}, dims...) where T = zeros(T, dims...)
 
+function contractor_from_mode(source, mode::Symbol)
+    if mode == :trace
+        contractor = Trace(source)
+        string_formula = "Tr S"
+    elseif mode == :perp
+        contractor = DipoleFactor(source)
+        string_formula = "∑_ij (I - Q⊗Q){i,j} S{i,j}\n\n(i,j = Sx,Sy,Sz)"
+    elseif mode == :full
+        contractor = FullTensor(source)
+        string_formula = "S{α,β}"
+    end
+    return contractor, string_formula
+end
+
 """
     intensity_formula([swt or sc], contraction_mode::Symbol)
 
@@ -139,17 +153,8 @@ Sunny has several built-in formulas that can be selected by setting `contraction
 - `:full`, which will return all elements ``𝒮^{αβ}(𝐪,ω)`` without contraction.
 """
 function intensity_formula(swt::SpinWaveTheory, mode::Symbol; kwargs...)
-    if mode == :trace
-        contractor = Trace(swt)
-        string_formula = "Tr S"
-    elseif mode == :perp
-        contractor = DipoleFactor(swt)
-        string_formula = "∑_ij (I - Q⊗Q){i,j} S{i,j}\n\n(i,j = Sx,Sy,Sz)"
-    elseif mode == :full
-        contractor = FullTensor(swt)
-        string_formula = "S{α,β}"
-    end
-    intensity_formula(swt,contractor;string_formula,kwargs...)
+    contractor, string_formula = contractor_from_mode(swt, mode)
+    intensity_formula(swt, contractor; string_formula, kwargs...)
 end
 
 function intensity_formula(swt::SpinWaveTheory, contractor::Contraction{T}; kwargs...) where T
@@ -162,22 +167,11 @@ function intensity_formula(sc::SampledCorrelations, elem::Tuple{Symbol,Symbol}; 
     string_formula = "S{$(elem[1]),$(elem[2])}[ix_q,ix_ω]"
     intensity_formula(sc,Element(sc, elem); string_formula, kwargs...)
 end
-#intensity_formula(sc::SampledCorrelations, elem::Vector{Tuple{Symbol,Symbol}}; kwargs...) = intensity_formula(sc,Element(sc, elem); kwargs...)
-function intensity_formula(sc::SampledCorrelations, mode::Symbol; kwargs...)
-    if mode == :trace
-        contractor = Trace(sc)
-        string_formula = "Tr S"
-    elseif mode == :perp
-        contractor = DipoleFactor(sc)
-        string_formula = "∑_ij (I - Q⊗Q){i,j} S{i,j}\n\n(i,j = Sx,Sy,Sz)"
-    elseif mode == :full
-        contractor = FullTensor(sc)
-        string_formula = "S{α,β}"
-    end
-    intensity_formula(sc,contractor;string_formula,kwargs...)
-end
 
-error_formula(sc::SampledCorrelations, mode::Symbol; kwargs...) = intensity_formula(sc, mode; errors=true, kwargs...)
+function intensity_formula(sc::SampledCorrelations, mode::Symbol; kwargs...)
+    contractor, string_formula = contractor_from_mode(sc, mode)
+    intensity_formula(sc, contractor; string_formula, kwargs...)
+end
 
 function intensity_formula(sc::SampledCorrelations, contractor::Contraction{T}; kwargs...) where T
     intensity_formula(sc,required_correlations(contractor); return_type = T,kwargs...) do k,ω,correlations
@@ -185,4 +179,4 @@ function intensity_formula(sc::SampledCorrelations, contractor::Contraction{T}; 
     end
 end
 
-
+error_formula(sc::SampledCorrelations, mode::Symbol; kwargs...) = intensity_formula(sc, mode; calculate_errors=true, kwargs...)

--- a/src/Intensities/ElementContraction.jl
+++ b/src/Intensities/ElementContraction.jl
@@ -179,4 +179,9 @@ function intensity_formula(sc::SampledCorrelations, contractor::Contraction{T}; 
     end
 end
 
-error_formula(sc::SampledCorrelations, mode::Symbol; kwargs...) = intensity_formula(sc, mode; calculate_errors=true, kwargs...)
+function error_formula(sc::SampledCorrelations, mode::Symbol; kwargs...)
+    if isnothing(sc.variance)
+        error("Error information not available for this `SampledCorrelation`.")
+    end
+    intensity_formula(sc, mode; calculate_errors=true, kwargs...)
+end

--- a/src/Intensities/Interpolation.jl
+++ b/src/Intensities/Interpolation.jl
@@ -98,10 +98,8 @@ end
 
 
 function errors_interpolated(sc::SampledCorrelations, qs, formula; kwargs...)
-    # Add field to ClassicalIntensityFormula so can verify it's an error formula?
+    # Add `error`` field to ClassicalIntensityFormula so can verify it's an error formula?
     is = intensities_interpolated(sc, qs, formula; kwargs...)
-    n = sc.nsamples[1]
-    # @. is = √(is/(n+1))  # Return standard deviation, not variance
     @. is = √(is)  # Return standard deviation, not variance
     return is
 end

--- a/src/Intensities/Interpolation.jl
+++ b/src/Intensities/Interpolation.jl
@@ -102,6 +102,11 @@ function errors_interpolated(sc::SampledCorrelations, qs, formula; kwargs...)
     # formula. This is important because only error_formula will use the correct
     # buffer (by configuring a closure). Revisit this.
 
+    # We can, however, check if `sc` has error information.
+    if isnothing(sc.variance)
+        error("Error information not available for this `SampledCorrelation`.")
+    end
+
     is = intensities_interpolated(sc, qs, formula; kwargs...)
     @. is = √is  # Return standard deviation, not variance
 

--- a/src/Intensities/Interpolation.jl
+++ b/src/Intensities/Interpolation.jl
@@ -98,9 +98,13 @@ end
 
 
 function errors_interpolated(sc::SampledCorrelations, qs, formula; kwargs...)
-    # Add `error`` field to ClassicalIntensityFormula so can verify it's an error formula?
+    # Note: There's currently no way to check whether the formula is an error
+    # formula. This is important because only error_formula will use the correct
+    # buffer (by configuring a closure). Revisit this.
+
     is = intensities_interpolated(sc, qs, formula; kwargs...)
-    @. is = √(is)  # Return standard deviation, not variance
+    @. is = √is  # Return standard deviation, not variance
+
     return is
 end
 

--- a/src/Intensities/Interpolation.jl
+++ b/src/Intensities/Interpolation.jl
@@ -97,6 +97,14 @@ function pruned_stencil_info(sc::SampledCorrelations, qs, interp::InterpolationS
 end
 
 
+function errors_interpolated(sc::SampledCorrelations, qs, formula; kwargs...)
+    # Add field to ClassicalIntensityFormula so can verify it's an error formula?
+    is = intensities_interpolated(sc, qs, formula; kwargs...)
+    n = sc.nsamples[1]
+    # @. is = √(is/(n+1))  # Return standard deviation, not variance
+    @. is = √(is)  # Return standard deviation, not variance
+    return is
+end
 
 """
     intensities_interpolated(sc::SampledCorrelations, qs, formula:ClassicalIntensityFormula; interpolation=nothing, negative_energies=false)

--- a/src/SampledCorrelations/BasisReduction.jl
+++ b/src/SampledCorrelations/BasisReduction.jl
@@ -14,10 +14,12 @@ function phase_averaged_elements(data, q_absolute::Vec3, crystal::Crystal, ff_at
 end
 
 # Weighted average over variances to propagate error. This is essentially a
-# "random phase" approximation, i.e., the interference effects from phase
-# averaging will average out. The weighting in the average comes from
-# formfactors only. This approximation seems to give results very similar to
+# "random phase" approximation, i.e., assumes the interference effects from
+# phase averaging will average out. The weighting in the average comes from the
+# form factors only. This approximation seems to give results very similar to
 # those achieved by directly pulling out statistics during the sampling process.
+# But it seems to me that the correct thing to do is simply to add all the
+# variances from all the sites that contribute. Revisit this.
 function error_basis_reduction(data, q_absolute::Vec3, _::Crystal, ff_atoms, ::Val{NCorr}, ::Val{NAtoms}) where {NCorr, NAtoms}
     elems = zero(MVector{NCorr,ComplexF64})
     ffs = ntuple(i -> compute_form_factor(ff_atoms[i], q_absolute⋅q_absolute), NAtoms)

--- a/src/SampledCorrelations/BasisReduction.jl
+++ b/src/SampledCorrelations/BasisReduction.jl
@@ -12,3 +12,17 @@ function phase_averaged_elements(data, q_absolute::Vec3, crystal::Crystal, ff_at
 
     return SVector{NCorr,ComplexF64}(elems)
 end
+
+function error_basis_reduction(data, q_absolute::Vec3, crystal::Crystal, ff_atoms, ::Val{NCorr}, ::Val{NAtoms}) where {NCorr, NAtoms}
+    elems = zero(MVector{NCorr,ComplexF64})
+    ffs = ntuple(i -> compute_form_factor(ff_atoms[i], q_absolute⋅q_absolute), NAtoms)
+
+    # Real space position of each atom within the unit cell
+    rs = ntuple(i -> crystal.latvecs * crystal.positions[i], NAtoms)
+
+    for j in 1:NAtoms, i in 1:NAtoms
+        elems .+= ffs[i] .* ffs[j] .* view(data, :, i, j)
+    end
+
+    return SVector{NCorr,Float64}(elems)
+end

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -1,6 +1,6 @@
 struct ClassicalIntensityFormula{T} <: IntensityFormula
     kT :: Float64
-    formfactors
+    formfactors :: Union{Nothing, Vector{FormFactor}}
     string_formula :: String
     calc_intensity :: Function
 end

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -92,7 +92,6 @@ function intensity_formula(f::Function, sc::SampledCorrelations, corr_ix::Abstra
     # calculated.
     data_buffer = calculate_errors ? sc.variance : sc.data
     reduce_basis = calculate_errors ? error_basis_reduction : phase_averaged_elements
-    # reduce_basis = phase_averaged_elements
 
     # Intensity is calculated at the discrete (ix_q,ix_ω) modes available to the system.
     # Additionally, for momentum transfers outside of the first BZ, the norm `q_absolute` of the

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -91,8 +91,8 @@ function intensity_formula(f::Function, sc::SampledCorrelations, corr_ix::Abstra
     # This is determined by whether or not the running variance will be
     # calculated.
     data_buffer = calculate_errors ? sc.variance : sc.data
-    # reduce_basis = calculate_errors ? error_basis_reduction : phase_averaged_elements
-    reduce_basis = phase_averaged_elements
+    reduce_basis = calculate_errors ? error_basis_reduction : phase_averaged_elements
+    # reduce_basis = phase_averaged_elements
 
     # Intensity is calculated at the discrete (ix_q,ix_ω) modes available to the system.
     # Additionally, for momentum transfers outside of the first BZ, the norm `q_absolute` of the

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -67,6 +67,7 @@ function intensity_formula(f::Function, sc::SampledCorrelations, corr_ix::Abstra
     kT = Inf, 
     formfactors = nothing, 
     return_type = Float64, 
+    errors = false, 
     string_formula = "f(Q,ω,S{α,β}[ix_q,ix_ω])"
 )
     # If temperature given, ensure it's greater than 0.0
@@ -85,13 +86,14 @@ function intensity_formula(f::Function, sc::SampledCorrelations, corr_ix::Abstra
     ff_atoms = propagate_form_factors_to_atoms(formfactors, sc.crystal)
     NAtoms = Val(size(sc.data)[2])
     NCorr = Val(length(corr_ix))
+    databuffer = errors ? sc.errdata : sc.data
 
     # Intensity is calculated at the discrete (ix_q,ix_ω) modes available to the system.
     # Additionally, for momentum transfers outside of the first BZ, the norm `q_absolute` of the
     # momentum transfer may be different than the one inferred from `ix_q`, so it needs
     # to be provided independently of `ix_q`.
     calc_intensity = function (sc::SampledCorrelations, q_absolute::Vec3, ix_q::CartesianIndex{3}, ix_ω::Int64)
-        correlations = phase_averaged_elements(view(sc.data, corr_ix, :, :, ix_q, ix_ω), q_absolute, sc.crystal, ff_atoms, NCorr, NAtoms)
+        correlations = phase_averaged_elements(view(databuffer, corr_ix, :, :, ix_q, ix_ω), q_absolute, sc.crystal, ff_atoms, NCorr, NAtoms)
 
         # This is NaN if sc is instant_correlations
         ω = (typeof(ωs_sc) == Float64 && isnan(ωs_sc)) ? NaN : ωs_sc[ix_ω] 

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -21,7 +21,6 @@ struct SampledCorrelations{N}
     # Specs for sample generation and accumulation
     samplebuf    :: Array{ComplexF64, 6}   # New sample buffer
     fft!         :: FFTW.AbstractFFTs.Plan # Pre-planned FFT
-    copybuf      :: Array{ComplexF64, 4}   # Copy cache for accumulating samples
     measperiod   :: Int                    # Steps to skip between saving observables (downsampling for dynamical calcs)
     apply_g      :: Bool                   # Whether to apply the g-factor
     Δt           :: Float64                # Step size for trajectory integration 
@@ -267,7 +266,6 @@ function dynamical_correlations(sys::System{N}; Δt, nω, ωmax,
     na = natoms(sys.crystal)
     ncorr = length(correlations)
     samplebuf = zeros(ComplexF64, length(observables), sys.latsize..., na, nω) 
-    copybuf = zeros(ComplexF64, sys.latsize..., nω) 
     data = zeros(ComplexF64, ncorr, na, na, sys.latsize..., nω)
     variance = calculate_errors ? zeros(Float64, size(data)...) : nothing
 
@@ -281,7 +279,7 @@ function dynamical_correlations(sys::System{N}; Δt, nω, ωmax,
     # Make Structure factor and add an initial sample
     origin_crystal = isnothing(sys.origin) ? nothing : sys.origin.crystal
     sc = SampledCorrelations{N}(data, variance, sys.crystal, origin_crystal, Δω, observables, observable_ixs, correlations,
-                                samplebuf, fft!, copybuf, measperiod, apply_g, Δt, nsamples, processtraj!)
+                                samplebuf, fft!, measperiod, apply_g, Δt, nsamples, processtraj!)
 
     return sc
 end

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -8,8 +8,7 @@ initialized by calling either [`dynamical_correlations`](@ref) or
 struct SampledCorrelations{N}
     # 𝒮^{αβ}(q,ω) data and metadata
     data           :: Array{ComplexF64, 7}                 # Raw SF data for 1st BZ (numcorrelations × natoms × natoms × latsize × energy)
-    absdata        :: Union{Nothing, Array{Float64, 7}}
-    errdata        :: Union{Nothing, Array{Float64, 7}}    # Running sum of squares of the differences between current samples and mean (for standard error estimate)
+    variance       :: Union{Nothing, Array{Float64, 7}}    # Running variance calculation for Welford's algorithm 
     crystal        :: Crystal                              # Crystal for interpretation of q indices in `data`
     origin_crystal :: Union{Nothing,Crystal}               # Original user-specified crystal (if different from above) -- needed for FormFactor accounting
     Δω             :: Float64                              # Energy step size (could make this a virtual property)  
@@ -270,8 +269,7 @@ function dynamical_correlations(sys::System{N}; Δt, nω, ωmax,
     samplebuf = zeros(ComplexF64, length(observables), sys.latsize..., na, nω) 
     copybuf = zeros(ComplexF64, sys.latsize..., nω) 
     data = zeros(ComplexF64, ncorr, na, na, sys.latsize..., nω)
-    absdata = calculate_errors ? zeros(Float64, size(data)...) : nothing
-    errdata = calculate_errors ? zeros(Float64, size(data)...) : nothing
+    variance = calculate_errors ? zeros(Float64, size(data)...) : nothing
 
     # Normalize FFT according to physical convention
     normalizationFactor = 1/(nω * √(prod(sys.latsize)))
@@ -282,7 +280,7 @@ function dynamical_correlations(sys::System{N}; Δt, nω, ωmax,
 
     # Make Structure factor and add an initial sample
     origin_crystal = isnothing(sys.origin) ? nothing : sys.origin.crystal
-    sc = SampledCorrelations{N}(data, absdata, errdata, sys.crystal, origin_crystal, Δω, observables, observable_ixs, correlations,
+    sc = SampledCorrelations{N}(data, variance, sys.crystal, origin_crystal, Δω, observables, observable_ixs, correlations,
                                 samplebuf, fft!, copybuf, measperiod, apply_g, Δt, nsamples, processtraj!)
 
     return sc

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -28,6 +28,7 @@ import Random: randstring, RandomDevice
 
 const Vec3 = SVector{3, Float64}
 const Mat3 = SMatrix{3, 3, Float64, 9}
+const Mat2 = SMatrix{2, 2, ComplexF64, 4}
 const CVec{N} = SVector{N, ComplexF64}
 
 

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -28,7 +28,6 @@ import Random: randstring, RandomDevice
 
 const Vec3 = SVector{3, Float64}
 const Mat3 = SMatrix{3, 3, Float64, 9}
-const Mat2 = SMatrix{2, 2, ComplexF64, 4}
 const CVec{N} = SVector{N, ComplexF64}
 
 


### PR DESCRIPTION
The only new thing that this PR publicly exposes is the keyword `calculate_errors` to `dynamical_correlations` and `instant_correlations`. However, I have not documented it because I don't want to make it official yet.

If `calculate_errors` is set to `true`, Sunny will use a modified Welford algorithm to iteratively estimate the complex variance on each matrix element of S(q,w). The exact approach is documented in a lyx file. This variance is recorded into an array called `variance` in `SampledCorrelations`. Its type is `Union{Nothing, Array{Float64, 7}}` and it is only allocated if the keyword is set to true.

The provisional (non-exposed) way to retrieve error estimates is by creating a `error_formula`, which is simply an `intensity_formula` that sets a flag when creating a `ClassicalIntensityFormula`. This flag in turn ensures that the `calc_intensity` closure uses the correct buffer and correct basis reduction function. Error information is then retrieved with `errors_interpolated(sc, qs, err_formula)`.

Adding full error propagation through intensities calculation opens up the possibility of more complexity (e.g., potentially parallel contraction functions), and I don't really want to confront that at this point. There are other higher priority issues. But I'd like to get this merged so I can save structure factor data with variance estimates. This will get me unstuck in another project. We can reexamine the interface and error propagation with more care at a later point.

@Lazersmoke I don't think this affects you very much, but I did remove the `copybuf` from `SampledCorrelations`. I believe you added this in one of your initial optimization passes. Writing the relevant loop explicitly and storing intermediate values on the stack seems to be slightly faster, and it saves memory. `accum_sample!` still has some small allocations due to the iteration on the `SortedDict` (this hasn't changed), but this doesn't seem to be performance sensitive. (I hardcoded a particular case that removes the iteration on the sorteddict, and it wasn't noticeably faster even though it eliminated the allocations.)

I'm letting you know in case I overlooked some aspect of this.