### PR TITLE
Invert axes labels when loading from Mantid

### DIFF
--- a/src/Intensities/ExperimentData.jl
+++ b/src/Intensities/ExperimentData.jl
@@ -108,6 +108,7 @@ function load_nxs(filename)
 
                 if i <= 3 # This is long_name contains a covector
                     covectors[i,:] .= parse_long_name(long_name)
+                    covectors[i,:] .= transpose(pinv(covectors[i,:]))
                 end
             end
 


### PR DESCRIPTION
This needs to happen because Mantid axes labels like `[H,H,0]` (meaning that the coordinate displayed on the axis is `H` and you can compute `Q` from `H` using `Q = [H,H,0]`) are related to the coordinate covectors used by Sunny by a pseudo-inverese (which means transpose and divide by the norm-squared). This way, multiplying (dot product) `[qx,qy,qz]` with `pinv([1,1,0])` gives `(qx+qy)/2`, which is the correct way to extract the label `H` from a vector like `[H,H,0]`.