### PR TITLE
Short circuiting `mod1` to speed `offsetc`

### DIFF
--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -165,8 +165,13 @@ const Site = Union{NTuple{4, Int}, CartesianIndex{4}}
 @inline to_cartesian(i::CartesianIndex{N}) where N = i
 @inline to_cartesian(i::NTuple{N, Int})    where N = CartesianIndex(i)
 
+# Like mod1(x, L), but short-circuits early in the common case.
+@inline function altmod1(x::Int, L::Int)
+    1 <= x <= L ? x : mod1(x, L)
+end
+
 # Offset a `cell` by `ncells`
-@inline offsetc(cell::CartesianIndex{3}, ncells, latsize) = CartesianIndex(mod1.(Tuple(cell) .+ Tuple(ncells), latsize))
+@inline offsetc(cell::CartesianIndex{3}, ncells, latsize) = CartesianIndex(altmod1.(Tuple(cell) .+ Tuple(ncells), latsize))
 
 # Split a site `site` into its cell and sublattice parts
 @inline to_cell(site) = CartesianIndex((site[1],site[2],site[3]))


### PR DESCRIPTION
For systems with very simple interactions, wrapping indices to the system's periodic boundaries can absorb a significant chunk of the total simulation time. The culprit is the modulo operation (used as `mod1` in Julia). In the common case, the index will already be in-bounds, so no wrapping is needed. If this situation is detected, we can short-circuit the `mod1` operation and immediately return the original index. Doing so reduces the overhead for index-wrapping from 16% to about 8% of the total run-time in the dynamics benchmark below. It should also provide speedups for the `LocalSampler` use-case.

```julia
using Sunny, Random, BenchmarkTools

# Simple model on square lattice
latvecs = lattice_vectors(1, 1, 10, 90, 90, 90)
cryst = Crystal(latvecs, [[0,0,0]])
sys = System(cryst, (10,10,1), [SpinInfo(1, S=1, g=2)], :dipole; seed=1)
J = -1.0
set_exchange!(sys, J, Bond(1, 1, (1, 0, 0)))

Random.seed!(0)
randomize_spins!(sys)

Δt = 0.1
integrator = ImplicitMidpoint(Δt)

function f(sys, integrator)
    for _ in 1:100_000
        step!(sys, integrator)
    end
end

@btime f(sys, integrator)

# Before PR: 4.31s
# After PR:  4.02s

@profview f(sys, integrator)

# Before PR: 16% in offsetc
# After PR:  8% in offsetc
```