### PR TITLE
Dipole LSWT Optimizations

### DIFF
--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -335,16 +335,16 @@ function intensity_formula(f::Function,swt::SpinWaveTheory,corr_ix::AbstractVect
             else
                 @assert sys.mode in (:dipole, :dipole_large_S)
                 Avec = zeros(ComplexF64, 3)
-                (; R_mat) = data
+                R = data.local_rotations
                 for i = 1:Nm
                     Vtmp = [v[i+nmodes] + v[i], im * (v[i+nmodes] - v[i]), 0.0]
-                    Avec += Avec_pref[i] * sqrt_halfS * (R_mat[i] * Vtmp)
+                    Avec += Avec_pref[i] * sqrt_halfS * (R[i] * Vtmp)
                 end
 
                 @assert observables.observable_ixs[:Sx] == 1
                 @assert observables.observable_ixs[:Sy] == 2
                 @assert observables.observable_ixs[:Sz] == 3
-                corrs = Vector{ComplexF64}(undef,num_correlations(observables))
+                corrs = Vector{ComplexF64}(undef, num_correlations(observables))
                 for (ci,i) in observables.correlations
                     (α,β) = ci.I
                     corrs[i] = Avec[α] * conj(Avec[β])

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -173,11 +173,13 @@ end
 
 # Compute Stevens coefficients in the local reference frame
 function swt_data_dipole(sys::System{0})
+    N = sys.Ns[1]
+    S = (N-1)/2
+    L = natoms(sys.crystal)  # Number of bands
+
     cs = StevensExpansion[]
     Rs = Mat3[]
     Vs = Mat5[]
-    N = sys.Ns[1]
-    S = (N-1)/2
 
     for atom in 1:natoms(sys.crystal)
         # SO(3) rotation that aligns the quantization axis. Important: since we
@@ -222,7 +224,6 @@ function swt_data_dipole(sys::System{0})
     end
 
     # Precompute onsite Hamiltonian
-    L = natoms(sys.crystal)
     H = zeros(ComplexF64, 2L, 2L)
     (; extfield, gs, units) = sys
     for i in 1:L

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -2,8 +2,8 @@
 # Below takes Sunny to construct `SpinWave` for LSWT calculations.  #
 ###########################################################################
 struct SWTDataDipole
-    local_rotations     :: Vector{Mat3}
-    onsite_hamiltonian  :: Array{ComplexF64, 2} 
+    local_rotations  :: Vector{Mat3}
+    stevens_coefs    :: Vector{StevensExpansion}
 end
 
 struct SWTDataSUN
@@ -175,7 +175,6 @@ end
 function swt_data_dipole!(sys::System{0})
     N = sys.Ns[1]
     S = (N-1)/2
-    L = natoms(sys.crystal)  # Number of bands
 
     cs = StevensExpansion[]
     Rs = Mat3[]
@@ -223,25 +222,5 @@ function swt_data_dipole!(sys::System{0})
         end
     end
 
-    # Precompute onsite Hamiltonian.
-    H = zeros(ComplexF64, 2L, 2L)
-    (; extfield, gs, units) = sys
-
-    for i in 1:L
-
-        # Zeeman term 
-        B = units.μB * (gs[1, 1, 1, i]' * extfield[1, 1, 1, i]) 
-        B′ = dot(B, Rs[i][:, 3]) / 2 
-        H[i, i]     += B′
-        H[i+L, i+L] += B′
-
-        # Single-ion anisotropy
-        (; c2, c4, c6) = cs[i]
-        H[i, i]     += -3S*c2[3] - 40*S^3*c4[5] - 168*S^5*c6[7]
-        H[i+L, i+L] += -3S*c2[3] - 40*S^3*c4[5] - 168*S^5*c6[7]
-        H[i, i+L]   += -im*(S*c2[5] + 6S^3*c4[7] + 16S^5*c6[9]) + (S*c2[1] + 6S^3*c4[3] + 16S^5*c6[5])
-        H[i+L, i]   +=  im*(S*c2[5] + 6S^3*c4[7] + 16S^5*c6[9]) + (S*c2[1] + 6S^3*c4[3] + 16S^5*c6[5])
-    end
-
-    return SWTDataDipole(Rs, H)
+    return SWTDataDipole(Rs, cs)
 end

--- a/src/System/Types.jl
+++ b/src/System/Types.jl
@@ -36,7 +36,7 @@ end
 const scalar_biquad_metric = Vec5(1/2, 2, 1/6, 2, 1/2)
 
 # Pair couplings are counted only once per bond
-mutable struct PairCoupling
+struct PairCoupling
     isculled :: Bool # Bond directionality is used to avoid double counting
     bond     :: Bond
 

--- a/src/System/Types.jl
+++ b/src/System/Types.jl
@@ -36,7 +36,7 @@ end
 const scalar_biquad_metric = Vec5(1/2, 2, 1/6, 2, 1/2)
 
 # Pair couplings are counted only once per bond
-struct PairCoupling
+mutable struct PairCoupling
     isculled :: Bool # Bond directionality is used to avoid double counting
     bond     :: Bond
 


### PR DESCRIPTION
A few optimizations for dipole LSWT (starting with removal of allocations associated with biquadratic interactions).