### PR TITLE
Numerically stable accumulation of intensity variance

### DIFF
--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -128,7 +128,7 @@ end
     # Merge correlations and check if result equal to running calculation.
     sc_merged = merge_correlations([sc1, sc2])
     @test sc0.data ≈ sc_merged.data
-    @test sc0.variance ≈ sc_merged.variance
+    @test sc0.M[1] ≈ sc_merged.M[1]
 end
 
 @testitem "Sampled correlations reference" begin

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -128,7 +128,7 @@ end
     # Merge correlations and check if result equal to running calculation.
     sc_merged = merge_correlations([sc1, sc2])
     @test sc0.data ≈ sc_merged.data
-    @test sc0.M[1] ≈ sc_merged.M[1]
+    @test sc0.M ≈ sc_merged.M
 end
 
 @testitem "Sampled correlations reference" begin


### PR DESCRIPTION
Replace running calculation of variance with running calculation of `M=(n-1)*σ²`, where `n` is the number of samples.

The modifications reproduce previous results when `M` is divided by `n-1`. Note that there is currently no interface for retrieving this data. Any future interface will need to divide by `n-1` to recover the variance.