### PR TITLE
Fix `available_energies`

### DIFF
--- a/src/SampledCorrelations/CorrelationUtils.jl
+++ b/src/SampledCorrelations/CorrelationUtils.jl
@@ -33,14 +33,10 @@ output of `intensities`. Set `negative_energies` to true to retrieve all ω
 values.
 """
 function available_energies(sc::SampledCorrelations; negative_energies=false)
-    Δω = sc.Δω
-    isnan(Δω) && (return NaN)
+    isnan(sc.Δω) && (return NaN)
 
     nω = size(sc.data, 7)
     hω = div(nω, 2) + 1
-    ωvals = collect(0:(nω-1)) .* Δω
-    for i ∈ hω+1:nω
-        ωvals[i] -= 2ωvals[hω]
-    end
+    ωvals = FFTW.fftfreq(nω, nω * sc.Δω)
     return negative_energies ? ωvals : ωvals[1:hω]
 end

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -133,7 +133,7 @@ function dynamical_correlations(sys::System{N}; Δt, nω, ωmax,
     if nω != 1
         @assert π/Δt > ωmax "Desired `ωmax` not possible with specified `Δt`. Choose smaller `Δt` value."
         measperiod = floor(Int, π/(Δt * ωmax))
-        nω = 2nω-1  # Ensure there are nω _non-negative_ energies. Question: performance benefit for removing `-1`, or are modern FFT algorithms largely unaffected?
+        nω = 2nω-1  # Ensure there are nω _non-negative_ energies.
         Δω = 2π / (Δt*measperiod*nω)
     else
         measperiod = 1

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -105,7 +105,9 @@ calculation.
 - `Δt`: The time step used for calculating the trajectory from which dynamic
     spin-spin correlations are calculated. The trajectories are calculated with
     an [`ImplicitMidpoint`](@ref) integrator.
-- `ωmax`: The maximum energy, ``ω``, that will be resolved.
+- `ωmax`: The maximum energy, ``ω``, that will be resolved. Note that allowed
+    values of `ωmax` are constrained by the given `Δt`, so Sunny will choose the
+    smallest possible value that is no smaller than the specified `ωmax`.
 - `nω`: The number of energy bins to calculated between 0 and `ωmax`.
 
 Additional keyword options are the following:
@@ -131,7 +133,7 @@ function dynamical_correlations(sys::System{N}; Δt, nω, ωmax,
     if nω != 1
         @assert π/Δt > ωmax "Desired `ωmax` not possible with specified `Δt`. Choose smaller `Δt` value."
         measperiod = floor(Int, π/(Δt * ωmax))
-        nω = 2nω-1  # Ensure there are nω _non-negative_ energies
+        nω = 2nω-1  # Ensure there are nω _non-negative_ energies. Question: performance benefit for removing `-1`, or are modern FFT algorithms largely unaffected?
         Δω = 2π / (Δt*measperiod*nω)
     else
         measperiod = 1


### PR DESCRIPTION
This is a fix for the `available_energies` function, which was previously handling negative energies incorrectly. @Lazersmoke identified the problem and suggested the solution.