### PR TITLE
Add checks on Langevin parameters

### DIFF
--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -56,7 +56,11 @@ mutable struct Langevin
     kT  :: Float64
 
     function Langevin(Δt; λ, kT)
-        Δt <= 0 && error("Select positive Δt")
+        Δt <= 0   && error("Select positive Δt")
+        kT < 0    && error("Select nonnegative kT")
+        λ < 0     && error("Select positive damping λ")
+        iszero(λ) && error("Use ImplicitMidpoint instead for energy-conserving dynamics")
+        λ < 0.1   && @info "Langevin currently uses Heun integration, which loses statistical accuracy at small λ"
         return new(Δt, λ, kT)
     end
 end


### PR DESCRIPTION
Small damping can lead the large statistical error, and the user should be guided towards ImplicitMidpoint for now.