### PR TITLE
Catch errors during show(System)

### DIFF
--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -97,10 +97,10 @@ function lattice_to_str(sys::System)
 end
 
 function energy_to_str(sys::System)
-    try
+    if is_valid_normalization(sys)
         "Energy per site "*number_to_math_string(energy_per_site(sys))
-    catch e
-        "Unknown energy per site: $(e.msg)"
+    else
+        "[Incorrectly normalized spin state!]"
     end
 end
 
@@ -412,16 +412,19 @@ end
     return
 end
 
-function validate_normalization(sys::System{0})
-    for (s, κ) in zip(sys.dipoles, sys.κs)
-        norm(s) ≈ κ || error("Detected non-normalized dipole. Consider using `set_dipole!` to automatically normalize.")
+function is_valid_normalization(sys::System{0})
+    all(zip(sys.dipoles, sys.κs)) do (s, κ)
+        norm2(s) ≈ κ^2
+    end
+end
+function is_valid_normalization(sys::System{N}) where N
+    all(zip(sys.coherents, sys.κs)) do (Z, κ)
+        norm2(Z) ≈ κ
     end
 end
 
-function validate_normalization(sys::System{N}) where N
-    for (Z, κ) in zip(sys.coherents, sys.κs)
-        norm(Z) ≈ √κ || error("Detected non-normalized coherent state. Consider using `set_coherent!` to automatically normalize.")
-    end
+function validate_normalization(sys::System)
+    is_valid_normalization(sys) || error("Detected non-normalized spin state.")
 end
 
 """

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -97,7 +97,11 @@ function lattice_to_str(sys::System)
 end
 
 function energy_to_str(sys::System)
-    return "Energy per site "*number_to_math_string(energy_per_site(sys))
+    try
+        "Energy per site "*number_to_math_string(energy_per_site(sys))
+    catch e
+        "Unknown energy per site: $(e.msg)"
+    end
 end
 
 function Base.show(io::IO, sys::System{N}) where N


### PR DESCRIPTION
Now that `energy(sys)` sometimes errors (e.g. if dipoles are not normalized), typing in `sys` at the REPL can clobber the terminal with a huge error message. This PR makes it so the error message is relatively tame