### PR TITLE
Remove most unicode from public API

### DIFF
--- a/docs/src/parallelism.md
+++ b/docs/src/parallelism.md
@@ -44,14 +44,14 @@ A serial calculation of [`dynamical_correlations`](@ref) involving the
 
 ```julia
 # Thermalize the system
-Δt = 0.05
-integrator = Langevin(Δt; damping=0.2, kT=0.5)
+dt = 0.05
+integrator = Langevin(dt; damping=0.2, kT=0.5)
 for _ in 1:5000
     step!(sys, integrator)
 end
 
 # Accumulator for S(q,ω) samples
-sc = dynamical_correlations(sys; Δt=0.1, nω=100, ωmax=10.0)
+sc = dynamical_correlations(sys; dt=0.1, nω=100, ωmax=10.0)
 
 # Collect 10 samples
 for _ in 1:10
@@ -82,7 +82,7 @@ preallocate a number of systems and correlations.
 ```julia
 npar = Threads.nthreads()
 systems = [make_system(; seed=id) for id in 1:npar]
-scs = [dynamical_correlations(sys; Δt=0.1, nω=100, ωmax=10.0) for _ in 1:npar]
+scs = [dynamical_correlations(sys; dt=0.1, nω=100, ωmax=10.0) for _ in 1:npar]
 ```
 
 !!! warning "Dealing with memory constraints"
@@ -99,7 +99,7 @@ with each thread acting on a unique `System` and `SampledCorrelations`.
 
 ```julia
 Threads.@threads for id in 1:npar
-    integrator = Langevin(Δt; damping=0.2, kT=0.5)
+    integrator = Langevin(dt; damping=0.2, kT=0.5)
     for _ in 1:5000
         step!(systems[id], integrator)
     end
@@ -180,7 +180,7 @@ called `scs`.
 ```julia
 scs = pmap(1:ncores) do id
     sys = make_system(; seed=id)
-    sc = dynamical_correlations(sys; Δt=0.1, nω=100, ωmax=10.0)
+    sc = dynamical_correlations(sys; dt=0.1, nω=100, ωmax=10.0)
     integrator = Langevin(0.05; damping=0.2, kT=0.5)
 
     for _ in 1:5000

--- a/docs/src/parallelism.md
+++ b/docs/src/parallelism.md
@@ -45,7 +45,7 @@ A serial calculation of [`dynamical_correlations`](@ref) involving the
 ```julia
 # Thermalize the system
 Δt = 0.05
-integrator = Langevin(Δt; kT=0.5, λ=0.1)
+integrator = Langevin(Δt; damping=0.2, kT=0.5)
 for _ in 1:5000
     step!(sys, integrator)
 end
@@ -99,7 +99,7 @@ with each thread acting on a unique `System` and `SampledCorrelations`.
 
 ```julia
 Threads.@threads for id in 1:npar
-    integrator = Langevin(Δt; kT=0.5, λ=0.1)
+    integrator = Langevin(Δt; damping=0.2, kT=0.5)
     for _ in 1:5000
         step!(systems[id], integrator)
     end
@@ -181,7 +181,7 @@ called `scs`.
 scs = pmap(1:ncores) do id
     sys = make_system(; seed=id)
     sc = dynamical_correlations(sys; Δt=0.1, nω=100, ωmax=10.0)
-    integrator = Langevin(0.05; kT=0.5, λ=0.1)
+    integrator = Langevin(0.05; damping=0.2, kT=0.5)
 
     for _ in 1:5000
         step!(sys, integrator)

--- a/docs/src/structure-factor.md
+++ b/docs/src/structure-factor.md
@@ -69,19 +69,11 @@ $𝒮^{αβ}(𝐪,ω)$, may be created by calling [`dynamical_correlations`](@re
 requires three keyword arguments. These will determine the dynamics used to
 calculate samples and, consequently, the $ω$ information that will be available. 
 
-1. `Δt`: Determines the step size used for simulating the dynamics. A smaller
-   number will require proportionally more calculation time. While a smaller
-   `Δt` will enable the resolution of higher energies, `Δt` is typically
-   selected to ensure numerical stability rather than to maximize the largest
-   $ω$ value. A safe choice is to use the smaller value of `Δt = 0.1/(J* S^2)`
-   or `Δt = 0.1/(D * S)`, where `S` is magnetic moment of the largest local spin
-   (as specified in [`SpinInfo`](@ref)), `J` is the parameter governing the
-   largest bilinear interaction (e.g. exchange), and `D` is the parameter
-   governing the largest single-site term of the Hamiltonian (e.g., anisotropy
-   or Zeeman term).
-2. `ωmax`: Sets the maximum resolved energy. Note that this is not independent
-   of `Δt`. If `ωmax` too large, Sunny will throw an error and ask you to choose
-   a smaller `Δt`. 
+1. `dt`: Determines the step size used for simulating the dynamics. Typically
+   this will be limited by numerical stability. The function
+   [`suggest_timestep`](@ref) can recommend a value.
+2. `ωmax`: Sets the maximum resolved energy. Very large `ωmax` may require
+   smaller `dt`. 
 3. `nω`: Determines the number of energy bins to resolve. A larger number will
    require more calculation time.
 
@@ -95,7 +87,7 @@ calling `add_sample!` on each configuration.
 The outline of typical use case might look like this:
 ```
 # Make a `SampledCorrelations`
-sc = dynamical_correlations(sys; Δt=0.05, ωmax=10.0, nω=100) 
+sc = dynamical_correlations(sys; dt=0.05, ωmax=10.0, nω=100) 
 
 # Add samples
 for _ in 1:nsamples

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -10,9 +10,8 @@
   spin wave theory). Set `apply_g = false` to measure correlations of spin
   angular momentum instead. [Issue
   #236](https://github.com/SunnySuite/Sunny.jl/issues/236).
-* **[In Progress]** The simulated intensity will now scale linearly with
-  magnetic cell size, in a consistent way. This behavior deviates from SpinW,
-  which divides the intensity by the number of atoms in the unit cell. [Issue
+* **[In Progress]** The intensity magnitude now scales linearly with magnetic
+  cell size, consistent with SpinW. [Issue
   #235](https://github.com/SunnySuite/Sunny.jl/issues/235).
 * New function [`suggest_timestep`](@ref) to assist in performing accurate and
   efficient simulation of spin dynamics. [Issue
@@ -20,6 +19,8 @@
 * Significantly speed up [`dynamical_correlations`](@ref) for crystals with many
   atoms in the unit cell. [Issue
   #204](https://github.com/SunnySuite/Sunny.jl/issues/204).
+* Unicode keyword arguments are replaced with non-unicode alternatives: `Δt` to
+  `dt`, and `λ` to `damping`.
 
 
 ## v0.5.8

--- a/docs/src/writevtk.md
+++ b/docs/src/writevtk.md
@@ -34,9 +34,9 @@ J = 10.
 set_exchange!(sys, J, Bond(1,1,[1,0,0]))
 set_exchange!(sys, J, Bond(1,1,[0,1,0]))
 
-Δt = 0.01
+dt = 0.01
 kT = 0.5
-langevin = Langevin(Δt; damping=0.5, kT)
+langevin = Langevin(dt; damping=0.5, kT)
 randomize_spins!(sys)
 for i in 1:10_000 # Long enough to reach equilibrium
     step!(sys, langevin)
@@ -44,7 +44,7 @@ end
 
 ωmax=10.
 
-dsf = dynamical_correlations(sys; Δt, nω=48, ωmax, process_trajectory=:symmetrize)
+dsf = dynamical_correlations(sys; dt, nω=48, ωmax, process_trajectory=:symmetrize)
 
 nsamples = 10
 for _ in 1:nsamples

--- a/docs/src/writevtk.md
+++ b/docs/src/writevtk.md
@@ -36,7 +36,7 @@ set_exchange!(sys, J, Bond(1,1,[0,1,0]))
 
 Δt = 0.01
 kT = 0.5
-langevin = Langevin(Δt; λ=0.5, kT)
+langevin = Langevin(Δt; damping=0.5, kT)
 randomize_spins!(sys)
 for i in 1:10_000 # Long enough to reach equilibrium
     step!(sys, langevin)
@@ -44,11 +44,7 @@ end
 
 ωmax=10.
 
-dsf = dynamical_correlations(sys
-                             ;Δt=Δt
-                             ,nω=48
-                             ,ωmax=ωmax
-                             ,process_trajectory=:symmetrize)
+dsf = dynamical_correlations(sys; Δt, nω=48, ωmax, process_trajectory=:symmetrize)
 
 nsamples = 10
 for _ in 1:nsamples

--- a/examples/03_LLD_CoRh2O4.jl
+++ b/examples/03_LLD_CoRh2O4.jl
@@ -38,7 +38,7 @@ langevin = Langevin(; damping=0.2, kT)
 # configuration will also work reasonably well.
 
 suggest_timestep(sys, langevin; tol=1e-2)
-langevin.Δt = 0.025;
+langevin.dt = 0.025;
 
 # Now run a dynamical trajectory to sample spin configurations. Keep track of
 # the energy per site at each time step.
@@ -49,12 +49,12 @@ for _ in 1:1000
     push!(energies, energy_per_site(sys))
 end
 
-# Now that the spin configuration has relaxed, we can learn that `Δt` was a
+# Now that the spin configuration has relaxed, we can learn that `dt` was a
 # little smaller than necessary; increasing it will make the remaining
 # simulations faster.
 
 suggest_timestep(sys, langevin; tol=1e-2)
-langevin.Δt = 0.042;
+langevin.dt = 0.042;
 
 # The energy per site has converged, which suggests that the system has reached
 # thermal equilibrium.
@@ -124,15 +124,15 @@ heatmap(q1s, q2s, iq;
 
 # To collect statistics for the dynamical structure factor intensities
 # ``I(𝐪,ω)`` at finite temperature, use [`dynamical_correlations`](@ref). The
-# integration timestep `Δt` used for measuring dynamical correlations can be
+# integration timestep `dt` used for measuring dynamical correlations can be
 # somewhat larger than that used by the Langevin dynamics. We must also specify
 # `nω` and `ωmax`, which determine the frequencies over which intensity data
 # will be collected.
 
-Δt = 2*langevin.Δt
+dt = 2*langevin.dt
 ωmax = 6.0  # Maximum energy to resolve (meV)
 nω = 50     # Number of energies to resolve
-sc = dynamical_correlations(sys; Δt, nω, ωmax, process_trajectory=:symmetrize)
+sc = dynamical_correlations(sys; dt, nω, ωmax, process_trajectory=:symmetrize)
 
 # Use Langevin dynamics to sample spin configurations from thermal equilibrium.
 # For each sample, use [`add_sample!`](@ref) to run a classical spin dynamics

--- a/examples/03_LLD_CoRh2O4.jl
+++ b/examples/03_LLD_CoRh2O4.jl
@@ -26,12 +26,11 @@ sys = resize_supercell(sys, (10, 10, 10))
 @assert energy_per_site(sys) ≈ -2J*S^2
 
 # We will be using a [`Langevin`](@ref) spin dynamics to thermalize the system.
-# This involves a damping term of strength `λ` and a noise term determined by
-# the target temperature `kT`.
+# This dynamics involves a dimensionless `damping` magnitude and target
+# temperature `kT` for thermal fluctuations.
 
-λ  = 0.2             # Magnitude of damping (dimensionless)
 kT = 16 * meV_per_K  # 16K, a temperature slightly below ordering
-langevin = Langevin(; λ, kT)
+langevin = Langevin(; damping=0.2, kT)
 
 # Use [`suggest_timestep`](@ref) to select an integration timestep for the given
 # error tolerance, e.g. `tol=1e-2`. The spin configuration in `sys` should

--- a/examples/04_GSD_FeI2.jl
+++ b/examples/04_GSD_FeI2.jl
@@ -85,12 +85,11 @@ plot_spins(sys; color=[s[3] for s in sys.dipoles])
 # Alternatively, one can search for the ordered state by sampling spin
 # configurations from thermal equilibrium. Sunny supports this via a
 # [`Langevin`](@ref) dynamics of SU(_N_) coherent states. This dynamics involves
-# a damping term of strength `λ` and a noise term determined by the target
-# temperature `kT`.
+# a dimensionless `damping` magnitude and target temperature `kT` for thermal
+# fluctuations.
 
-λ  = 0.2  # Dimensionless damping time-scale
 kT = 0.2  # Temperature in meV
-langevin = Langevin(; λ, kT)
+langevin = Langevin(; damping=0.2, kT)
 
 # Use [`suggest_timestep`](@ref) to select an integration timestep for the given
 # error tolerance, e.g. `tol=1e-2`. The spin configuration in `sys` should

--- a/examples/04_GSD_FeI2.jl
+++ b/examples/04_GSD_FeI2.jl
@@ -97,7 +97,7 @@ langevin = Langevin(; damping=0.2, kT)
 # configuration will also work reasonably well.
 
 suggest_timestep(sys, langevin; tol=1e-2)
-langevin.Δt = 0.027;
+langevin.dt = 0.027;
 
 # Sample spin configurations using Langevin dynamics. We have carefully selected
 # a temperature of 0.2 eV that is below the ordering temperature, but large
@@ -109,7 +109,7 @@ for _ in 1:10_000
 end
 
 # Calling [`suggest_timestep`](@ref) shows that thermalization has not
-# substantially altered the suggested `Δt`.
+# substantially altered the suggested `dt`.
 
 suggest_timestep(sys, langevin; tol=1e-2)
 
@@ -145,7 +145,7 @@ end
 # With this increase in temperature, the suggested timestep has increased slightly.
 
 suggest_timestep(sys_large, langevin; tol=1e-2)
-langevin.Δt = 0.040;
+langevin.dt = 0.040;
 
 # The next step is to collect correlation data ``S^{\alpha\beta}``. This will
 # involve sampling spin configurations from thermal equilibrium, and then
@@ -158,15 +158,15 @@ langevin.Δt = 0.040;
 # (the resolution scales like inverse system size).
 #
 # The function [`dynamical_correlations`](@ref) creates an object to store
-# sampled correlations. The integration timestep `Δt` used for measuring
+# sampled correlations. The integration timestep `dt` used for measuring
 # dynamical correlations can be somewhat larger than that used by the Langevin
 # dynamics. We must also specify `nω` and `ωmax`, which determine the
 # frequencies over which intensity data will be collected.
 
-Δt = 2*langevin.Δt
+dt = 2*langevin.dt
 ωmax = 7.5  # Maximum energy to resolve (meV)
 nω = 120    # Number of energies to resolve
-sc = dynamical_correlations(sys_large; Δt, nω, ωmax)
+sc = dynamical_correlations(sys_large; dt, nω, ωmax)
 
 # The function [`add_sample!`](@ref) will collect data by running a dynamical
 # trajectory starting from the current system configuration. 

--- a/examples/06_CP2_Skyrmions.jl
+++ b/examples/06_CP2_Skyrmions.jl
@@ -88,7 +88,7 @@ suggest_timestep(sys, integrator; tol=0.025)
 
 # Apply the suggested timestep.
 
-integrator.Δt = 0.01
+integrator.dt = 0.01
 
 # Now run the dynamical quench starting from a randomized configuration. We will
 # record the state of the system at three different times during the quenching
@@ -99,7 +99,7 @@ randomize_spins!(sys)
 frames = []         # Empty array to store snapshots
 for i in eachindex(τs)
     dur = i == 1 ? τs[1] : τs[i] - τs[i-1] # Determine the length of time to simulate 
-    numsteps = round(Int, dur/Δt)
+    numsteps = round(Int, dur/integrator.dt)
     for _ in 1:numsteps                    # Perform the integration
         step!(sys, integrator)
     end
@@ -127,10 +127,9 @@ plot_triangular_plaquettes(sun_berry_curvature, frames; size=(600,200),
     offset_spacing=10, texts=["\tt = "*string(τ) for τ in τs], text_offset=(0, 6)
 )
 
-# The times are given in $\hbar/|J_1|$. The white
-# background corresponds to a quantum paramagnetic state, where the local spin
-# exhibits a strong quadrupole moment and little or no dipole moment. Observe
-# that the process has generated a number of well-formed skyrmions of both
-# positive (red) and negative (blue) charge in addition to a number of other
-# metastable spin configurations. A full-sized version of this figure is
-# available in [Dahlbom et al.](https://doi.org/10.1103/PhysRevB.106.235154).
+# The times are given in $\hbar/|J_1|$. The white background corresponds to a
+# quantum paramagnetic state, where the local spin exhibits a strong quadrupole
+# moment and little or no dipole moment. At late times, there are well-formed
+# skyrmions of positive (red) and negative (blue) charge, and various metastable
+# spin configurations. A full-sized version of this figure is available in
+# [Dahlbom et al.](https://doi.org/10.1103/PhysRevB.106.235154).

--- a/examples/06_CP2_Skyrmions.jl
+++ b/examples/06_CP2_Skyrmions.jl
@@ -25,7 +25,7 @@ using Sunny, GLMakie
 # field, $h$, and easy-plane single-ion anisotropy, $D > 0$. We begin by
 # implementing the [`Crystal`](@ref).
 
-lat_vecs = lattice_vectors(1.0, 1.0, 2.0, 90, 90, 120)
+lat_vecs = lattice_vectors(1, 1, 10, 90, 90, 120)
 basis_vecs = [[0,0,0]]
 cryst = Crystal(lat_vecs, basis_vecs)
 
@@ -67,31 +67,34 @@ set_onsite_coupling!(sys, S -> D*S[3]^2, 1)
 # Initialize system to an infinite temperature (fully randomized) initial
 # condition.
 
+# We will study a temperature quench process using a generalized
+# [`Langevin`](@ref) spin dynamics. In this SU(3) treatment of quantum spin-1,
+# the dynamics include coupled dipoles and quadrupoles. Select a relatively
+# small damping magnitude to overcome local minima, and disable thermal
+# fluctuations.
+
+damping = 0.05
+kT = 0
+
+# The first step is to determine a reasonable integration timestep. To determine
+# this, we can initialize the system to some relatively low-energy
+# configuration. A relatively large error tolerance of 0.025 is OK for this
+# phenomenological study.
+
 randomize_spins!(sys)
+minimize_energy!(sys) # (this optimization does not need to converge)
+integrator = Langevin(; damping, kT)
+suggest_timestep(sys, integrator; tol=0.025)
 
-# We are now ready to simulate the quenching process using a generalized
-# [`Langevin`](@ref) spin dynamics. If we were working with spin dipoles only,
-# then `Langevin` dynamics would be the usual Landau-Lifshitz spin dynamics,
-# augmented with damping and noise terms. In the present study, we are instead
-# working with quantum spin-1 (an ($N=3$)-level system that includes both
-# dipoles and quadrupoles). Here, `Langevin` captures the coupled
-# dipole-quadrupole dynamics using the formalism of SU($N$) coherent states.
-#
-# Selecting `kT = 0` in the Langevin dynamics will effective disable the noise
-# term. Then the parameter `λ` effectively determines the damping time-scale.
+# Apply the suggested timestep.
 
-Δt = 0.2/D  # Integration time step (inverse meV). Typically this will be
-            ## inversely proportional to the largest energy scale in the
-            ## system. We can use a fairly large time-step here because
-            ## accuracy isn't critical.
-kT = 0      # Target equilibrium temperature (meV)
-λ = 0.1     # Magnitude of coupling to thermal bath (dimensionless)
-integrator = Langevin(Δt; kT, λ)
+integrator.Δt = 0.01
 
-# Finally we run the dynamics. We will record the state of the system at three
-# different times during the quenching process by copying the `coherents` field
-# of the `System`.
+# Now run the dynamical quench starting from a randomized configuration. We will
+# record the state of the system at three different times during the quenching
+# process by copying the `coherents` field of the `System`.
 
+randomize_spins!(sys)
 τs = [4, 16, 256]   # Times to record snapshots
 frames = []         # Empty array to store snapshots
 for i in eachindex(τs)

--- a/examples/extra/heisenberg_animation.jl
+++ b/examples/extra/heisenberg_animation.jl
@@ -12,8 +12,8 @@ randomize_spins!(sys)
 
 fig = plot_spins(sys; colorfn=i->sys.dipoles[i][3], colorrange=(-1, 1), dims=2)
 
-Δt = 0.1/abs(J)
-integrator = Langevin(Δt; damping=0.05, kT=0)
+dt = 0.1/abs(J)
+integrator = Langevin(dt; damping=0.05, kT=0)
 
 # View an animation in real time
 for _ in 1:500

--- a/examples/extra/heisenberg_animation.jl
+++ b/examples/extra/heisenberg_animation.jl
@@ -13,12 +13,12 @@ randomize_spins!(sys)
 fig = plot_spins(sys; colorfn=i->sys.dipoles[i][3], colorrange=(-1, 1), dims=2)
 
 Δt = 0.1/abs(J)
-langevin = Langevin(Δt; kT=0, λ=0.05)
+integrator = Langevin(Δt; damping=0.05, kT=0)
 
 # View an animation in real time
 for _ in 1:500
     for _ in 1:5
-        step!(sys, langevin)
+        step!(sys, integrator)
     end
     notify(fig)
     sleep(1/60)
@@ -28,7 +28,7 @@ end
 randomize_spins!(sys)
 record(fig, "animation.mp4", 1:500; framerate=30) do _
     for _ in 1:5
-        step!(sys, langevin)
+        step!(sys, integrator)
     end
     notify(fig)
 end

--- a/ext/PlottingExt.jl
+++ b/ext/PlottingExt.jl
@@ -576,7 +576,7 @@ end
 
 
 function Sunny.view_crystal(cryst::Crystal, max_dist::Number)
-    @warn "view_crystal(cryst, max_dist) will soon be removed! Use `view_crystal(cryst)` instead. See also optional `ghost_radius` argument."
+    @warn "view_crystal(cryst, max_dist) is deprecated! Use `view_crystal(cryst)` instead. See also optional `ghost_radius` argument."
     Sunny.view_crystal(cryst; ghost_radius=max_dist)
 end
 

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -1,9 +1,9 @@
 """
-    Langevin(Δt::Float64; damping::Float64, kT::Float64)
+    Langevin(dt::Float64; damping::Float64, kT::Float64)
 
 An integrator for Langevin spin dynamics using the explicit Heun method. The
 `damping` parameter controls the coupling to an implicit thermal bath. One call
-to the [`step!`](@ref) function will advance a [`System`](@ref) by `Δt` units of
+to the [`step!`](@ref) function will advance a [`System`](@ref) by `dt` units of
 time. Can be used to sample from the Boltzmann distribution at temperature `kT`.
 An alternative approach to sampling states from thermal equilibrium is
 [`LocalSampler`](@ref), which proposes local Monte Carlo moves. For example, use
@@ -51,25 +51,23 @@ References:
    (2022)](https://arxiv.org/abs/2209.01265).
 """
 mutable struct Langevin
-    Δt      :: Float64
+    dt      :: Float64
     damping :: Float64
     kT      :: Float64
 
-    function Langevin(Δt; λ=nothing, damping=nothing, kT)
+    function Langevin(dt; λ=nothing, damping=nothing, kT)
         if !isnothing(λ)
-            isnothing(damping) || error("Cannot specify both λ and damping")
             @warn "`λ` argument is deprecated! Use `damping` instead."
-            damping = λ
-        else
-            isnothing(damping) && error("`damping` parameter required")
+            damping = @something damping λ
         end
+        isnothing(damping) && error("`damping` parameter required")
 
-        Δt <= 0         && error("Select positive Δt")
+        dt <= 0         && error("Select positive dt")
         kT < 0          && error("Select nonnegative kT")
         damping < 0     && error("Select positive damping")
         iszero(damping) && error("Use ImplicitMidpoint instead for energy-conserving dynamics")
         damping < 1e-2  && @info "For small `damping` values, the ImplicitMidpoint integrator will be more accurate"
-        return new(Δt, damping, kT)
+        return new(dt, damping, kT)
     end
 end
 
@@ -80,11 +78,11 @@ end
 
 
 """
-    ImplicitMidpoint(Δt::Float64; damping=0, kT=0, atol=1e-12) where N
+    ImplicitMidpoint(dt::Float64; damping=0, kT=0, atol=1e-12) where N
 
 The implicit midpoint method for integrating the Landau-Lifshitz spin dynamics
 or its generalization to SU(_N_) coherent states [1]. One call to the
-[`step!`](@ref) function will advance a [`System`](@ref) by `Δt` units of time.
+[`step!`](@ref) function will advance a [`System`](@ref) by `dt` units of time.
 This integration scheme is exactly symplectic and eliminates energy drift over
 arbitrarily long simulation trajectories.
 
@@ -103,24 +101,24 @@ References:
    (2022)](https://arxiv.org/abs/2204.07563).
 """
 mutable struct ImplicitMidpoint
-    Δt      :: Float64
+    dt      :: Float64
     damping :: Float64
     kT      :: Float64
     atol    :: Float64
 
-    function ImplicitMidpoint(Δt; damping=0, kT=0, atol=1e-12)
-        Δt <= 0      && error("Select positive Δt")
+    function ImplicitMidpoint(dt; damping=0, kT=0, atol=1e-12)
+        dt <= 0      && error("Select positive dt")
         kT < 0       && error("Select nonnegative kT")
         damping < 0  && error("Select nonnegative damping")
         (kT > 0 && iszero(damping)) && error("Select positive damping for positive kT")
-        return new(Δt, damping, kT, atol)
+        return new(dt, damping, kT, atol)
     end    
 end
 ImplicitMidpoint(; atol) = ImplicitMidpoint(NaN; atol)
 
 
 function check_timestep_available(integrator)
-    isnan(integrator.Δt) && error("Set integration timestep `Δt`.")
+    isnan(integrator.dt) && error("Set integration timestep `dt`.")
 end
 
 """
@@ -128,9 +126,9 @@ end
 
 Suggests a timestep for the numerical integration of spin dynamics according to
 a given error tolerance `tol`. The `integrator` should be [`Langevin`](@ref) or
-[`ImplicitMidpoint`](@ref). The suggested ``Δt`` will be inversely proportional
+[`ImplicitMidpoint`](@ref). The suggested ``dt`` will be inversely proportional
 to the magnitude of the effective field ``|dE/d𝐬|`` arising from the current
-spin configuration in `sys`. The recommended timestep ``Δt`` scales like `√tol`,
+spin configuration in `sys`. The recommended timestep ``dt`` scales like `√tol`,
 which assumes second-order accuracy of the integrator.
 
 The system `sys` should be initialized to an equilibrium spin configuration for
@@ -144,27 +142,27 @@ approximate the factor ``1/damping``. If `kT` is the largest energy scale, then
 the suggested timestep will scale like `1/(damping*kT)`. Quantification of
 numerical error for stochastic dynamics is subtle. The stochastic Heun
 integration scheme is weakly convergent of order-1, such that errors in the
-estimates of averaged observables may scale like `Δt`. This implies that the
+estimates of averaged observables may scale like `dt`. This implies that the
 `tol` argument may actually scale like the _square_ of the true numerical error,
 and should be selected with this in mind.
 """
 function suggest_timestep(sys::System{N}, integrator::Union{Langevin, ImplicitMidpoint}; tol) where N
-    (; Δt) = integrator
-    Δt_bound = suggest_timestep_aux(sys, integrator; tol)
+    (; dt) = integrator
+    dt_bound = suggest_timestep_aux(sys, integrator; tol)
 
     # Print suggestion
-    bound_str, tol_str = number_to_simple_string.((Δt_bound, tol); digits=4)
-    print("Consider Δt ≈ $bound_str for this spin configuration at tol = $tol_str.")
+    bound_str, tol_str = number_to_simple_string.((dt_bound, tol); digits=4)
+    print("Consider dt ≈ $bound_str for this spin configuration at tol = $tol_str.")
 
-    # Compare with existing Δt if present
-    if !isnan(Δt)
-        Δt_str = number_to_simple_string(Δt; digits=4)
-        if Δt <= Δt_bound/2
-            println("\nCurrent value Δt = $Δt_str seems small! Increasing it will make the simulation faster.")
-        elseif Δt >= 2Δt_bound
-            println("\nCurrent value Δt = $Δt_str seems LARGE! Decreasing it will improve accuracy.")
+    # Compare with existing dt if present
+    if !isnan(dt)
+        dt_str = number_to_simple_string(dt; digits=4)
+        if dt <= dt_bound/2
+            println("\nCurrent value dt = $dt_str seems small! Increasing it will make the simulation faster.")
+        elseif dt >= 2dt_bound
+            println("\nCurrent value dt = $dt_str seems LARGE! Decreasing it will improve accuracy.")
         else
-            println(" Current value is Δt = $Δt_str.")
+            println(" Current value is dt = $dt_str.")
         end
     else
         println()
@@ -227,21 +225,21 @@ function suggest_timestep_aux(sys::System{N}, integrator; tol) where N
     # for some empirical constants c₁ and c₂.
     c1 = 1.0
     c2 = 1.0
-    Δt_bound = sqrt(tol / ((c1*drift_rms)^2 + (c2*λ*kT)^2))
-    return Δt_bound
+    dt_bound = sqrt(tol / ((c1*drift_rms)^2 + (c2*λ*kT)^2))
+    return dt_bound
 end
 
 
 function Base.show(io::IO, integrator::Langevin)
-    (; Δt, damping, kT) = integrator
-    Δt = isnan(integrator.Δt) ? "<missing>" : repr(Δt)
-    println(io, "Langevin($Δt; damping=$damping, kT=$kT)")
+    (; dt, damping, kT) = integrator
+    dt = isnan(integrator.dt) ? "<missing>" : repr(dt)
+    println(io, "Langevin($dt; damping=$damping, kT=$kT)")
 end
 
 function Base.show(io::IO, integrator::ImplicitMidpoint)
-    (; Δt, atol) = integrator
-    Δt = isnan(integrator.Δt) ? "<missing>" : repr(Δt)
-    println(io, "ImplicitMidpoint($Δt; atol=$atol)")
+    (; dt, atol) = integrator
+    dt = isnan(integrator.dt) ? "<missing>" : repr(dt)
+    println(io, "ImplicitMidpoint($dt; atol=$atol)")
 end
 
 
@@ -251,36 +249,36 @@ end
 
 
 @inline function rhs_dipole!(Δs, s, ξ, ∇E, integrator)
-    (; Δt, damping) = integrator
+    (; dt, damping) = integrator
     λ = damping
 
     if iszero(λ)
-        @. Δs = -s × (- Δt*∇E)
+        @. Δs = -s × (- dt*∇E)
     else
-        @. Δs = -s × (- Δt*∇E + ξ - Δt*λ*(s × ∇E))
+        @. Δs = -s × (- dt*∇E + ξ - dt*λ*(s × ∇E))
     end
 end
 
 function rhs_sun!(ΔZ, Z, ξ, HZ, integrator)
-    (; damping, Δt) = integrator
+    (; damping, dt) = integrator
     λ = damping
 
     if iszero(λ)
-        @. ΔZ = - im*Δt*HZ
+        @. ΔZ = - im*dt*HZ
     else
-        @. ΔZ = - proj(Δt*(im+λ)*HZ + ξ, Z)
+        @. ΔZ = - proj(dt*(im+λ)*HZ + ξ, Z)
     end
 end
 
 function fill_noise!(rng, ξ, integrator)
-    (; Δt, damping, kT) = integrator
+    (; dt, damping, kT) = integrator
     λ = damping
 
     if iszero(λ) || iszero(kT)
         fill!(ξ, zero(eltype(ξ)))
     else
         randn!(rng, ξ)
-        ξ .*= √(2Δt*λ*kT)
+        ξ .*= √(2dt*λ*kT)
     end
 end
 
@@ -361,7 +359,7 @@ end
 # Integrates ds/dt = s × ∂E/∂s one timestep s → s′ via implicit equations
 #   s̄ = (s′ + s) / 2
 #   ŝ = s̄ / |s̄|
-#   (s′ - s)/Δt = 2(s̄ - s)/Δt = - ŝ × B,
+#   (s′ - s)/dt = 2(s̄ - s)/dt = - ŝ × B,
 # where B = -∂E/∂ŝ.
 function step!(sys::System{0}, integrator::ImplicitMidpoint; max_iters=100)
     check_timestep_available(integrator)
@@ -404,7 +402,7 @@ end
 # proposed in Phys. Rev. B 106, 054423 (2022). Integrates dZ/dt = - i H(Z) Z one
 # timestep Z → Z′ via the implicit equation
 #
-#   (Z′-Z)/Δt = - i H(Z̄) Z, where Z̄ = (Z+Z′)/2
+#   (Z′-Z)/dt = - i H(Z̄) Z, where Z̄ = (Z+Z′)/2
 #
 function step!(sys::System{N}, integrator::ImplicitMidpoint; max_iters=100) where N
     check_timestep_available(integrator)

--- a/src/System/PairExchange.jl
+++ b/src/System/PairExchange.jl
@@ -290,7 +290,7 @@ set_exchange!(sys, J2, bond)
 """
 function set_exchange!(sys::System{N}, J, bond::Bond; biquad=nothing, large_S=nothing) where N
     if !isnothing(biquad)
-        @warn "The `biquad` argument to `set_exchange!` will soon be removed! Use `set_pair_coupling!` instead."
+        @warn "The `biquad` argument to `set_exchange!` is deprecated! Use `set_pair_coupling!` instead."
         !isnothing(large_S) && @error "The `large_S` argument is no longer supported. Instead construct system with mode `dipole_large_S`."
         set_pair_coupling!(sys, (Si, Sj) -> Si'*J*Sj + biquad*(Si'*Sj)^2, bond)
         return
@@ -390,7 +390,7 @@ See also [`set_exchange!`](@ref).
 """
 function set_exchange_at!(sys::System{N}, J, site1::Site, site2::Site; biquad=nothing, large_S=nothing, offset=nothing) where N
     if !isnothing(biquad)
-        @warn "The `biquad` argument to `set_exchange_at!` will soon be removed! Use `set_pair_coupling_at!` instead."
+        @warn "The `biquad` argument to `set_exchange_at!` is deprecated! Use `set_pair_coupling_at!` instead."
         !isnothing(large_S) && @error "The `large_S` argument is no longer supported. Instead construct system with mode `dipole_large_S`."
         set_pair_coupling_at!(sys, (Si, Sj) -> Si'*J*Sj + biquad*(Si'*Sj)^2, site1, site2; offset)
         return

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,5 +1,5 @@
 Base.@deprecate spin_matrices(; N::Int) let
-    @warn "`spin_matrices(; N)` will soon be removed! Use `spin_matrices((N-1)/2)` instead."
+    @warn "`spin_matrices(; N)` is deprecated! Use `spin_matrices((N-1)/2)` instead."
     spin_matrices((N-1)/2)
 end
 
@@ -7,11 +7,11 @@ Base.@deprecate_binding large_S_spin_operators spin_matrices(Inf)
 Base.@deprecate_binding large_S_stevens_operators stevens_matrices(Inf)
 
 Base.@deprecate spin_operators(sys::System, i::Int) let
-    @warn "`spin_operators` will soon be removed! Use `spin_matrices(spin_label(sys, i))` instead."
+    @warn "`spin_operators` is deprecated! Use `spin_matrices(spin_label(sys, i))` instead."
     spin_matrices(spin_label(sys, i))
 end
 Base.@deprecate stevens_operators(sys::System, i::Int) let
-    @warn "`stevens_operators` will soon be removed! Use `stevens_matrices(spin_label(sys, i))` instead."
+    @warn "`stevens_operators` is deprecated! Use `stevens_matrices(spin_label(sys, i))` instead."
     stevens_matrices(spin_label(sys, i))
 end
 
@@ -19,8 +19,28 @@ Base.@deprecate suggest_magnetic_supercell(qs, latsize) suggest_magnetic_superce
 Base.@deprecate offline_viewers() ()
 
 function Base.copy(dyn::Langevin)
-    @warn "Base.copy(dyn::Langevin) will soon be removed! Use `Langevin(dyn.Δt; dyn.damping, dyn.kT)` instead."
-    Langevin(dyn.Δt; dyn.damping, dyn.kT)
+    @warn "Base.copy(dyn::Langevin) will break in Sunny v0.6! Use `Langevin(dyn.dt; dyn.damping, dyn.kT)` instead."
+    Langevin(dyn.dt; dyn.damping, dyn.kT)
 end
 
+function Base.getproperty(value::Langevin, name::Symbol)
+    if name == :Δt
+        @warn "`Δt` field is deprecated! Use `dt` instead."
+        name = :dt
+    end
+    return getfield(value, name)
+end
+function Base.setproperty!(value::Langevin, name::Symbol, x)
+    if name == :Δt
+        @warn "`Δt` field is deprecated! Use `dt` instead."
+        name = :dt
+    end
+    return setfield!(value, name, convert(fieldtype(Langevin, name), x))
+end
+
+
+# REMEMBER TO ALSO DELETE:
+
 # view_crystal(cryst, max_dist)
+# Special handling of λ in Langevin constructor
+# Special handling of Δt in dynamical_correlations

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -19,8 +19,8 @@ Base.@deprecate suggest_magnetic_supercell(qs, latsize) suggest_magnetic_superce
 Base.@deprecate offline_viewers() ()
 
 function Base.copy(dyn::Langevin)
-    @warn "Base.copy(dyn::Langevin) will soon be removed! Use `Langevin(dyn.Δt; dyn.λ, dyn.kT)` instead."
-    Langevin(dyn.Δt; dyn.λ, dyn.kT)
+    @warn "Base.copy(dyn::Langevin) will soon be removed! Use `Langevin(dyn.Δt; dyn.damping, dyn.kT)` instead."
+    Langevin(dyn.Δt; dyn.damping, dyn.kT)
 end
 
 # view_crystal(cryst, max_dist)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -42,5 +42,6 @@ end
 # REMEMBER TO ALSO DELETE:
 
 # view_crystal(cryst, max_dist)
-# Special handling of λ in Langevin constructor
-# Special handling of Δt in dynamical_correlations
+# λ argument in Langevin constructor
+# Δt argument in dynamical_correlations
+# biquad argument in set_exchange! and set_exchange_at!

--- a/test/test_binning.jl
+++ b/test/test_binning.jl
@@ -16,7 +16,7 @@
 
     sys = System(Sunny.diamond_crystal(),(4,1,1),[SpinInfo(1,S=1/2,g=2)],:SUN,seed=1)
     randomize_spins!(sys)
-    sc = dynamical_correlations(sys;Δt = 1.,nω=3,ωmax = 1.)
+    sc = dynamical_correlations(sys; dt=1, nω=3, ωmax=1)
     add_sample!(sc, sys)
     @test_nowarn unit_resolution_binning_parameters(sc)
     params = unit_resolution_binning_parameters(sc)

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -19,10 +19,9 @@
     end
 
     function thermalize_simple_model!(sys; kT)
-        Δt = 0.05  # Time step for thermalization
-        λ  = 0.1
-        nsteps = 1000  # Number of steps between MC samples
-        langevin = Langevin(Δt; kT, λ)
+        Δt = 0.05
+        nsteps = 1000
+        langevin = Langevin(Δt; damping=0.1, kT)
         for _ in 1:nsteps
             step!(sys, langevin)
         end
@@ -105,7 +104,7 @@ end
 
     # Set up Langevin sampler.
     Δt_langevin = 0.07 
-    langevin = Langevin(Δt_langevin; kT=0.1723, λ=0.1)
+    langevin = Langevin(Δt_langevin; damping=0.1, kT=0.1723)
 
     sc0 = dynamical_correlations(sys; nω=25, ωmax=5.5, Δt=2Δt_langevin, calculate_errors=true)
     sc1 = dynamical_correlations(sys; nω=25, ωmax=5.5, Δt=2Δt_langevin, calculate_errors=true)
@@ -137,9 +136,9 @@ end
     randomize_spins!(sys)
 
     Δt_langevin = 0.07 
+    damping = 0.1
     kT = 0.1723
-    λ  = 0.1
-    langevin = Langevin(Δt_langevin; kT, λ)
+    langevin = Langevin(Δt_langevin; damping, kT)
 
     # Thermalize
     for _ in 1:4000
@@ -149,7 +148,7 @@ end
     sc = dynamical_correlations(sys; nω=10, ωmax=5.5, Δt=2Δt_langevin)
     add_sample!(sc, sys)
     qs = [[0.0, 0.0, 0.0], [0.2, -0.4, 0.1]]
-    data = intensities_interpolated(sc, qs, intensity_formula(sc,:trace; kT); interpolation=:linear)
+    data = intensities_interpolated(sc, qs, intensity_formula(sc, :trace; kT); interpolation=:linear)
     
     refdata = [1.8923137799435257 -1.5731157122871734e-15 -7.618183477999628e-16 2.4258182290582965e-15 2.663555286833582e-15 -2.378171804276773e-15 1.4269030327057308e-15 -1.997664243521173e-15 -4.756343436779901e-16 -1.819301364566135e-15; 0.033223462988952464 0.0565912610212458 0.1616375644454015 4.211237061899472 3.1064676304451533 5.792222570573932 5.536484159910247 0.551596926234539 0.27194613622683184 0.24232982609989023]
 

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -19,9 +19,9 @@
     end
 
     function thermalize_simple_model!(sys; kT)
-        Δt = 0.05
+        dt = 0.05
         nsteps = 1000
-        langevin = Langevin(Δt; damping=0.1, kT)
+        langevin = Langevin(dt; damping=0.1, kT)
         for _ in 1:nsteps
             step!(sys, langevin)
         end
@@ -33,7 +33,7 @@
     thermalize_simple_model!(sys; kT=0.1)
     S = spin_matrices(1/2)
     observables = Dict(:Sx => S[1], :Sy => S[2], :Sz => S[3])
-    sc = dynamical_correlations(sys; nω=100, ωmax=10.0, Δt=0.1, apply_g=false, observables)
+    sc = dynamical_correlations(sys; nω=100, ωmax=10.0, dt=0.1, apply_g=false, observables)
     add_sample!(sc, sys)
     qgrid = available_wave_vectors(sc)
     formula = intensity_formula(sc,:trace)
@@ -44,7 +44,7 @@
     # Test sum rule with default observables in dipole mode 
     sys = simple_model_fcc(; mode=:dipole)
     thermalize_simple_model!(sys; kT=0.1)
-    sc = dynamical_correlations(sys; Δt=0.1, nω=100, ωmax=10.0, apply_g=false)
+    sc = dynamical_correlations(sys; dt=0.1, nω=100, ωmax=10.0, apply_g=false)
     add_sample!(sc, sys)
     trace_formula = intensity_formula(sc,:trace)
     vals = intensities_interpolated(sc, qgrid, trace_formula; negative_energies=true)
@@ -103,12 +103,12 @@ end
     randomize_spins!(sys)
 
     # Set up Langevin sampler.
-    Δt_langevin = 0.07 
-    langevin = Langevin(Δt_langevin; damping=0.1, kT=0.1723)
+    dt_langevin = 0.07 
+    langevin = Langevin(dt_langevin; damping=0.1, kT=0.1723)
 
-    sc0 = dynamical_correlations(sys; nω=25, ωmax=5.5, Δt=2Δt_langevin, calculate_errors=true)
-    sc1 = dynamical_correlations(sys; nω=25, ωmax=5.5, Δt=2Δt_langevin, calculate_errors=true)
-    sc2 = dynamical_correlations(sys; nω=25, ωmax=5.5, Δt=2Δt_langevin, calculate_errors=true)
+    sc0 = dynamical_correlations(sys; nω=25, ωmax=5.5, dt=2dt_langevin, calculate_errors=true)
+    sc1 = dynamical_correlations(sys; nω=25, ωmax=5.5, dt=2dt_langevin, calculate_errors=true)
+    sc2 = dynamical_correlations(sys; nω=25, ωmax=5.5, dt=2dt_langevin, calculate_errors=true)
 
     for _ in 1:4_000
         step!(sys, langevin)
@@ -135,17 +135,17 @@ end
     set_exchange!(sys, 0.6498, Bond(1, 3, [0,0,0]))
     randomize_spins!(sys)
 
-    Δt_langevin = 0.07 
+    dt_langevin = 0.07 
     damping = 0.1
     kT = 0.1723
-    langevin = Langevin(Δt_langevin; damping, kT)
+    langevin = Langevin(dt_langevin; damping, kT)
 
     # Thermalize
     for _ in 1:4000
         step!(sys, langevin)
     end
 
-    sc = dynamical_correlations(sys; nω=10, ωmax=5.5, Δt=2Δt_langevin)
+    sc = dynamical_correlations(sys; nω=10, ωmax=5.5, dt=2dt_langevin)
     add_sample!(sc, sys)
     qs = [[0.0, 0.0, 0.0], [0.2, -0.4, 0.1]]
     data = intensities_interpolated(sc, qs, intensity_formula(sc, :trace; kT); interpolation=:linear)

--- a/test/test_energy_consistency.jl
+++ b/test/test_energy_consistency.jl
@@ -38,10 +38,10 @@
     # Tests that SphericalMidpoint conserves energy to a certain tolerance.
     function test_conservation(sys)
         NITERS = 3_000
-        Δt     = 0.002
+        dt     = 0.002
         energies = Float64[]
 
-        integrator = ImplicitMidpoint(Δt)
+        integrator = ImplicitMidpoint(dt)
         for _ in 1:NITERS
             step!(sys, integrator)
             push!(energies, energy(sys))

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -16,7 +16,7 @@
         sampler = LocalSampler(kT=0.2; propose)
         @test_opt step!(sys, sampler)
 
-        langevin = Langevin(0.01; kT=0.2, λ=0.1)
+        langevin = Langevin(0.01; damping=0.1, kT=0.2)
         @test_opt step!(sys, langevin)
 
         integrator = ImplicitMidpoint(0.01)
@@ -50,7 +50,7 @@ end
             step!(sys, sampler)
             @test iszero(@allocated step!(sys, sampler))
 
-            langevin = Langevin(0.01; kT=0.2, λ=0.1)
+            langevin = Langevin(0.01; damping=0.1, kT=0.2)
             step!(sys, langevin)
             @test iszero(@allocated step!(sys, langevin))
 

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -32,8 +32,8 @@ end
     sys_sun = simple_sys(; mode=:SUN, seed, S)
 
     # Thermalize near ground state
-    Δt = 0.05
-    integrator = Langevin(Δt; damping=0.1, kT=0.1)
+    dt = 0.05
+    integrator = Langevin(dt; damping=0.1, kT=0.1)
     for _ in 1:1000
         step!(sys_dip, integrator)
         step!(sys_sun, integrator)

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -33,7 +33,7 @@ end
 
     # Thermalize near ground state
     Δt = 0.05
-    integrator = Langevin(Δt; λ=0.1, kT=0.1)
+    integrator = Langevin(Δt; damping=0.1, kT=0.1)
     for _ in 1:1000
         step!(sys_dip, integrator)
         step!(sys_sun, integrator)

--- a/test/test_rescaling.jl
+++ b/test/test_rescaling.jl
@@ -7,8 +7,8 @@
         cryst = Sunny.diamond_crystal()
         damping = 0.1
         kT = 0.1
-        Δt = 0.01
-        integrators = (Langevin(Δt; damping, kT), ImplicitMidpoint(Δt; damping, kT))
+        dt = 0.01
+        integrators = (Langevin(dt; damping, kT), ImplicitMidpoint(dt; damping, kT))
 
         for integrator in integrators
             for mode in (:SUN, :dipole)
@@ -61,13 +61,13 @@
 
     # Check that a scaling of κ corresponds to an appropriate rescaling of dynamical time
     let
-        function gen_trajectory(κ, Δt, adder, mode)
+        function gen_trajectory(κ, dt, adder, mode)
             cryst = Sunny.diamond_crystal()
             sys = System(cryst, (4,3,2), [SpinInfo(1, S=5/2, g=2)], mode; seed=0)
             adder(sys, mode)
             sys.κs .= κ
             randomize_spins!(sys)
-            integrator = ImplicitMidpoint(Δt)
+            integrator = ImplicitMidpoint(dt)
             for _ in 1:100
                 step!(sys, integrator)
             end
@@ -75,18 +75,18 @@
         end
     
         κ = 2.0
-        Δt = 0.005
+        dt = 0.005
         for mode in (:SUN, :dipole)
-            s1 = gen_trajectory(1, Δt, add_linear_interactions!, mode)
-            s2 = gen_trajectory(κ, Δt, add_linear_interactions!, mode)
+            s1 = gen_trajectory(1, dt, add_linear_interactions!, mode)
+            s2 = gen_trajectory(κ, dt, add_linear_interactions!, mode)
             @test s1 ≈ s2/κ
 
-            s1 = gen_trajectory(1, Δt, add_quadratic_interactions!, mode)
-            s2 = gen_trajectory(κ, Δt/κ, add_quadratic_interactions!, mode)
+            s1 = gen_trajectory(1, dt, add_quadratic_interactions!, mode)
+            s2 = gen_trajectory(κ, dt/κ, add_quadratic_interactions!, mode)
             @test s1 ≈ s2/κ
 
-            s1 = gen_trajectory(1, Δt, add_quartic_interactions!, mode)
-            s2 = gen_trajectory(κ, Δt/κ^3, add_quartic_interactions!, mode)
+            s1 = gen_trajectory(1, dt, add_quartic_interactions!, mode)
+            s2 = gen_trajectory(κ, dt/κ^3, add_quartic_interactions!, mode)
             @test s1 ≈ s2/κ
         end
     end

--- a/test/test_rescaling.jl
+++ b/test/test_rescaling.jl
@@ -5,10 +5,10 @@
     # invariant under the dynamics
     let
         cryst = Sunny.diamond_crystal()
+        damping = 0.1
         kT = 0.1
-        λ  = 0.1
         Δt = 0.01
-        integrators = (Langevin(Δt; kT, λ), ImplicitMidpoint(Δt))
+        integrators = (Langevin(Δt; damping, kT), ImplicitMidpoint(Δt; damping, kT))
 
         for integrator in integrators
             for mode in (:SUN, :dipole)

--- a/test/test_samplers.jl
+++ b/test/test_samplers.jl
@@ -65,15 +65,15 @@
     function test_su3_anisotropy_energy()
         D = 1.0
         L = 20   # number of (non-interacting) sites
-        λ = 1.0
+        damping = 1.0
         Δt = 0.01
         kTs = [0.125, 0.5]
         thermalize_dur = 10.0
         collect_dur = 100.0
 
         sys = su3_anisotropy_model(; D, L, seed=0)
-        heun = Langevin(Δt; kT=0, λ)
-        midpoint = Sunny.ImplicitMidpoint(Δt; kT=0, λ)
+        heun = Langevin(Δt; damping, kT=0)
+        midpoint = Sunny.ImplicitMidpoint(Δt; damping, kT=0)
 
         for integrator in [heun, midpoint]
             for kT in kTs
@@ -92,15 +92,15 @@
     function test_su5_anisotropy_energy()
         D = 1.0
         L = 20   # number of (non-interacting) sites
-        λ = 0.1
+        damping = 0.1
         Δt = 0.01
         kTs = [0.125, 0.5]
         thermalize_dur = 10.0
         collect_dur = 200.0
 
         sys = su5_anisotropy_model(; D, L, seed=0)
-        heun = Langevin(Δt; kT=0, λ)
-        midpoint = Sunny.ImplicitMidpoint(Δt; kT=0, λ)
+        heun = Langevin(Δt; damping, kT=0)
+        midpoint = Sunny.ImplicitMidpoint(Δt; damping, kT=0)
 
         for integrator in [heun, midpoint]
             for kT ∈ kTs
@@ -187,11 +187,11 @@ end
         for mode in (:SUN, :dipole)
             sys = two_site_spin_chain(; mode, seed=0)
 
-            λ = 0.1
+            damping = 0.1
             kT = 0.1
             Δt = 0.02
-            heun = Langevin(Δt; kT, λ)
-            midpoint = Sunny.ImplicitMidpoint(Δt; kT, λ)
+            heun = Langevin(Δt; damping, kT)
+            midpoint = Sunny.ImplicitMidpoint(Δt; damping, kT)
 
             n_equilib = 1000
             n_samples = 2000

--- a/test/test_samplers.jl
+++ b/test/test_samplers.jl
@@ -45,15 +45,14 @@
     end
 
     function thermalize!(sys, integrator, dur)
-        Δt = integrator.Δt
-        numsteps = round(Int, dur/Δt)
+        numsteps = round(Int, dur/integrator.dt)
         for _ in 1:numsteps
             step!(sys, integrator)
         end
     end
 
     function calc_mean_energy(sys, integrator, dur)
-        numsteps = round(Int, dur/integrator.Δt)
+        numsteps = round(Int, dur/integrator.dt)
         Es = zeros(numsteps)
         for i in 1:numsteps
             step!(sys, integrator)
@@ -66,14 +65,14 @@
         D = 1.0
         L = 20   # number of (non-interacting) sites
         damping = 1.0
-        Δt = 0.01
+        dt = 0.01
         kTs = [0.125, 0.5]
         thermalize_dur = 10.0
         collect_dur = 100.0
 
         sys = su3_anisotropy_model(; D, L, seed=0)
-        heun = Langevin(Δt; damping, kT=0)
-        midpoint = Sunny.ImplicitMidpoint(Δt; damping, kT=0)
+        heun = Langevin(dt; damping, kT=0)
+        midpoint = Sunny.ImplicitMidpoint(dt; damping, kT=0)
 
         for integrator in [heun, midpoint]
             for kT in kTs
@@ -93,14 +92,14 @@
         D = 1.0
         L = 20   # number of (non-interacting) sites
         damping = 0.1
-        Δt = 0.01
+        dt = 0.01
         kTs = [0.125, 0.5]
         thermalize_dur = 10.0
         collect_dur = 200.0
 
         sys = su5_anisotropy_model(; D, L, seed=0)
-        heun = Langevin(Δt; damping, kT=0)
-        midpoint = Sunny.ImplicitMidpoint(Δt; damping, kT=0)
+        heun = Langevin(dt; damping, kT=0)
+        midpoint = Sunny.ImplicitMidpoint(dt; damping, kT=0)
 
         for integrator in [heun, midpoint]
             for kT ∈ kTs
@@ -189,9 +188,9 @@ end
 
             damping = 0.1
             kT = 0.1
-            Δt = 0.02
-            heun = Langevin(Δt; damping, kT)
-            midpoint = Sunny.ImplicitMidpoint(Δt; damping, kT)
+            dt = 0.02
+            heun = Langevin(dt; damping, kT)
+            midpoint = Sunny.ImplicitMidpoint(dt; damping, kT)
 
             n_equilib = 1000
             n_samples = 2000


### PR DESCRIPTION
Replace keyword arguments:
 * `Δt` with `dt`
 * `λ` with `damping`

Using the old symbols will emit a deprecation warning, and will break in 0.6.