### PR TITLE
Add non-local observables

### DIFF
--- a/src/Operators/Observables.jl
+++ b/src/Operators/Observables.jl
@@ -1,8 +1,12 @@
 
+struct NonLocalObservableOperator
+  localize :: Function # A function of System, returning an ObservableOperator which is *not* a NonLocalObservableOperator
+end
+
 # An observable is either an operator, or a field of operators.
 # If it's a field of operators, then it's defined with reference
 # to some System that users of this type are responsible for keeping track of.
-ObservableOperator = Union{LinearMap, Array{LinearMap,4}}
+ObservableOperator = Union{LinearMap, Array{LinearMap,4}, NonLocalObservableOperator}
 
 observable_at_site(op::LinearMap,site) = op
 observable_at_site(op::Array{LinearMap,4},site) = op[site]
@@ -58,6 +62,8 @@ function magnetization_observables(g,N)
 end
 
 spin_observables(N) = magnetization_observables([I(3)],N)
+
+energy_gradient_dipole_observable(i) = NonLocalObservableOperator(sys -> map(x -> x[i],sys.dipoles .× Sunny.energy_grad_dipoles(sys) .× sys.dipoles ./ norm.(sys.dipoles) .^ 2))
 
 # TODO: Add/unify docs about allowed list of observables. See comment here:
 # https://github.com/SunnySuite/Sunny.jl/pull/167#issuecomment-1724751213

--- a/src/SampledCorrelations/CorrelationSampling.jl
+++ b/src/SampledCorrelations/CorrelationSampling.jl
@@ -1,18 +1,26 @@
 function observable_values!(buf, sys::System{N}, ops) where N
     if N == 0
         for (i, op) in enumerate(ops)
-            for site in eachsite(sys)
-                A = observable_at_site(op,site)
-                dipole = sys.dipoles[site]
-                buf[i,site] = A * dipole
+            if op isa NonLocalObservableOperator
+                buf[i,:] .= op.localize(sys)
+            else
+                for site in eachsite(sys)
+                    A = observable_at_site(op,site)
+                    dipole = sys.dipoles[site]
+                    buf[i,site] = (A * dipole)[1]
+                end
             end
         end
     else
         Zs = sys.coherents
         for (i, op) in enumerate(ops)
-            for site in eachsite(sys)
-                A = observable_at_site(op,site)
-                buf[i,site] = dot(Zs[site], A, Zs[site])
+            if op isa NonLocalObservableOperator
+                buf[i,:] .= op.localize(sys)
+            else
+                for site in eachsite(sys)
+                    A = observable_at_site(op,site)
+                    buf[i,site] = dot(Zs[site], A, Zs[site])
+                end
             end
         end
     end

--- a/src/SampledCorrelations/CorrelationSampling.jl
+++ b/src/SampledCorrelations/CorrelationSampling.jl
@@ -2,7 +2,7 @@ function observable_values!(buf, sys::System{N}, ops) where N
     if N == 0
         for (i, op) in enumerate(ops)
             if op isa NonLocalObservableOperator
-                buf[i,:] .= op.localize(sys)
+                buf[i,:,:,:,:] .= op.localize(sys)
             else
                 for site in eachsite(sys)
                     A = observable_at_site(op,site)
@@ -15,7 +15,7 @@ function observable_values!(buf, sys::System{N}, ops) where N
         Zs = sys.coherents
         for (i, op) in enumerate(ops)
             if op isa NonLocalObservableOperator
-                buf[i,:] .= op.localize(sys)
+                buf[i,:,:,:,:] .= op.localize(sys)
             else
                 for site in eachsite(sys)
                     A = observable_at_site(op,site)


### PR DESCRIPTION
This PR adds support for a new type of observable to be used with `SampledCorrelations`: a `NonLocalObservableOperator`. There should probably be error handling and/or support added for the spin wave theory case, where I'm not sure that this type of observable can be used. (This PR implements the functionality only)

The reason for this is to support computing correlations of the form `<s_i(t) energy_grad_j(t')>` where `energy_grad` is the gradient of the Hamiltonian with respect to the spins (component index `j`). This observable is non-site-local because it depends on exchanges with distant sites along bonds. This type of correlation is important for computing classical response functions.

For such non-local observable, the (only) fast way to generally support it is to let the observable be a callback which computes the value on every site at once.

Currently, the `NonLocalObservableOperator` constructor and `energy_gradient_dipole_observable` are not exported, but it can be used like this:

```julia
observables = [
  :Sx => [1. 0 0], 
  :Sy => [0. 1 0], 
  :Sz => [0. 0 1],
  :A => Sunny.energy_gradient_dipole_observable(1),
  :B => Sunny.energy_gradient_dipole_observable(2),
  :C => Sunny.energy_gradient_dipole_observable(3),
  :dipoleNorm => Sunny.NonLocalObservableOperator(sys -> norm.(sys.dipoles))]

dsc = dynamical_correlations(sys;Δt = 0.05, nω = 600, ωmax = 1.0, observables)
```
which results in the usual x,y,z spin (not magnetization) observables, plus the three components of the energy gradient, plus the dipole sector norm being available to compute correlations between.