### PR TITLE
Bugfix: typo in `Element` contractor

### DIFF
--- a/src/Intensities/ElementContraction.jl
+++ b/src/Intensities/ElementContraction.jl
@@ -172,9 +172,9 @@ function intensity_formula(swt::SpinWaveTheory, contractor::Contraction{T}; kwar
     end
 end
 
-function intensity_formula(sc::SampledCorrelations, elem::Tuple{Symbol,Symbol}; kwargs...)
-    string_formula = "S{$(elem[1]),$(elem[2])}[ix_q,ix_ω]"
-    intensity_formula(sc,Element(sc, elem); string_formula, kwargs...)
+function intensity_formula(source, elem::Tuple{Symbol,Symbol}; kwargs...)
+    string_formula = "S{$(elem[1]),$(elem[2])}"
+    intensity_formula(source,Element(source.observables, elem); string_formula, kwargs...)
 end
 
 function intensity_formula(sc::SampledCorrelations, mode::Symbol; kwargs...)

--- a/test/test_intensities_setup.jl
+++ b/test/test_intensities_setup.jl
@@ -1,3 +1,20 @@
+@testitem "Contractors" begin
+    using LinearAlgebra
+    cryst = Crystal(I(3), [[0.,0,0]], 1)
+    sys = System(cryst, (1,1,1), [SpinInfo(1,S=1,g=2)], :SUN)
+    sc = instant_correlations(sys)
+    @test_nowarn intensity_formula(sc,(:Sx,:Sz))
+    @test_nowarn intensity_formula(sc,:trace)
+    @test_nowarn intensity_formula(sc,:perp)
+    @test_nowarn intensity_formula(sc,:full)
+    swt = SpinWaveTheory(sys)
+    @test_nowarn intensity_formula(swt,(:Sx,:Sz); kernel = delta_function_kernel)
+    @test_nowarn intensity_formula(swt,:trace; kernel = delta_function_kernel)
+    @test_nowarn intensity_formula(swt,:perp; kernel = delta_function_kernel)
+    @test_nowarn intensity_formula(swt,:full; kernel = delta_function_kernel)
+
+end
+
 @testitem "Dipole Factor Ordering" begin
     using LinearAlgebra
     obs = Sunny.parse_observables(3; observables=nothing, correlations=nothing, g=nothing)


### PR DESCRIPTION
Also now enables element contractor for spin wave theory, and brings the formatting in line with the other contractors