### PR TITLE
Scalar biquadratic support for `:dipole_large_S`

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -2,17 +2,20 @@
 
 ## v0.5.9
 
-* Enhancements to [`view_crystal`](@ref). If a [`System`](@ref) is supplied, the
-  exchange interactions will be depicted graphically.
 * **Correctness fixes**: Structure factor conventions are now uniform across
   modes and [precisely specified](@ref "Structure Factor Conventions"). The
   g-tensor is applied by default (disable with `apply_g = false`). The intensity
   is additive with increasing number of magnetic ions in the chemical cell,
   consistent with SpinW. [Issue
   #235](https://github.com/SunnySuite/Sunny.jl/issues/235).
+* Enhancements to [`view_crystal`](@ref). If a bond allows a DM interaction, its
+  orientation will be shown visually. If a [`System`](@ref) argument is
+  supplied, its exchange interactions will be shown..
 * New function [`suggest_timestep`](@ref) to assist in performing accurate and
   efficient simulation of classical spin dynamics. [Issue
   #149](https://github.com/SunnySuite/Sunny.jl/issues/149).
+* Scalar biquadratic interactions can again be set in `:dipole_large_S` mode via
+  the keyword argument `biquad` of [`set_exchange!`](@ref).
 * Significantly speed up [`dynamical_correlations`](@ref) for crystals with many
   atoms in the unit cell. [Issue
   #204](https://github.com/SunnySuite/Sunny.jl/issues/204).

--- a/ext/PlottingExt.jl
+++ b/ext/PlottingExt.jl
@@ -358,7 +358,7 @@ function reference_bonds_upto(cryst, nbonds, dims)
 end
 
 function propagate_reference_bond_for_cell(cryst, b_ref)
-    symops = Sunny.canonical_group_order(cryst.symops; atol=cryst.symprec)
+    symops = Sunny.canonical_group_order(cryst.symops)
 
     found = map(_ -> Bond[], cryst.positions)
     for s in symops

--- a/src/System/OnsiteCoupling.jl
+++ b/src/System/OnsiteCoupling.jl
@@ -7,9 +7,8 @@ function onsite_coupling(sys, site, matrep::AbstractMatrix)
         return Hermitian(matrep)
     elseif sys.mode == :dipole
         S = spin_label(sys, to_atom(site))
-        λ = anisotropy_renormalization(S)
         c = matrix_to_stevens_coefficients(hermitianpart(matrep))
-        return StevensExpansion(λ .* c)
+        return StevensExpansion(rcs_factors(S) .* c)
     elseif sys.mode == :dipole_large_S
         error("System with mode `:dipole_large_S` requires a symbolic operator.")
     end
@@ -31,7 +30,7 @@ end
 
 # k-dependent renormalization of Stevens operators O[k,q] as derived in
 # https://arxiv.org/abs/2304.03874.
-function anisotropy_renormalization(S)
+function rcs_factors(S)
     λ = [1,                                                                  # k=0
          1,                                                                  # k=1
          1 - (1/2)/S,                                                        # k=2

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -44,4 +44,4 @@ end
 # view_crystal(cryst, max_dist)
 # λ argument in Langevin constructor
 # Δt argument in dynamical_correlations
-# biquad argument in set_exchange! and set_exchange_at!
+# large_S and biquad arguments in set_exchange! and set_exchange_at!


### PR DESCRIPTION
Support a `biquad` parameter in `set_exchange!` to allow scalar biquadratic interactions for the special case of mode `:dipole_large_S`. The original plan was to avoid this, and instead use DynamicPolynomials to represent arbitrary biquadratic couplings symbolically. It's not clear whether the complexity of a full symbolic treatment justifies the benefit. We should be guiding people towards `:dipole` mode instead, which performs physically correct renormalizations. Nonetheless, scalar biquadratic interactions in `:dipole_large_S` can still be important for reproducing SpinW studies.

Resolves https://github.com/SunnySuite/Sunny.jl/issues/251.