### PR TITLE
Support varying spin-S in dipole mode

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,6 +3,9 @@
 ## v0.5.10
 (In development)
 
+* In dipole mode, fix bugs to support the case that spin-``S`` varies between
+  sites. In SU(``N``) mode, however, there is still no support for varying
+  spin-``S``.
 * [`view_crystal`](@ref) called on a [`System`](@ref) now optionally shows
   spin or magnetic dipoles.
 * Interactions for [`enable_dipole_dipole!`](@ref) are now supported in linear

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -11,6 +11,8 @@
   will accept a real-space cutoff.
 * Long-range dipole-dipole was previously broken for systems with multiple
   cells, but is now fixed.
+* General biquadratic interactions (beyond scalar) in dipole mode are fixed in
+  linear spin wave theory.
 
 
 ## v0.5.9

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -5,7 +5,7 @@
 
 * In dipole mode, fix bugs to support the case that spin-``S`` varies between
   sites. In SU(``N``) mode, however, there is still no support for varying
-  spin-``S``.
+  the Hilbert space dimension ``N`` between sites.
 * [`view_crystal`](@ref) called on a [`System`](@ref) now optionally shows
   spin or magnetic dipoles.
 * Interactions for [`enable_dipole_dipole!`](@ref) are now supported in linear

--- a/src/MathBasics.jl
+++ b/src/MathBasics.jl
@@ -50,3 +50,8 @@ end
 # Avoid linter false positives per
 # https://github.com/julia-vscode/julia-vscode/issues/1497
 kron(a...) = Base.kron(a...)
+
+function tracelesspart(A)
+    @assert allequal(size(A))
+    return A - tr(A) * I / size(A,1)
+end

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -68,29 +68,29 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
             # Biquadratic exchange
             if !iszero(coupling.biquad)
                 K = coupling.biquad  # Transformed quadrupole exchange matrix
-                @assert sqrtS[i] ≈ sqrtS[j] "Biquadratic interactions currently require fixed S"
-                FIXME = Sij^3
 
-                H11[i, i] += -6 * FIXME * K[3, 3]
-                H11[j, j] += -6 * FIXME * K[3, 3]
-                H22[i, i] += -6 * FIXME * K[3, 3]
-                H22[j, j] += -6 * FIXME * K[3, 3]
-                H21[i, i] += 2 * FIXME * (K[1, 3] - im*K[5, 3])
-                H12[i, i] += 2 * FIXME * (K[1, 3] + im*K[5, 3])
-                H21[j, j] += 2 * FIXME * (K[3, 1] - im*K[3, 5])
-                H12[j, j] += 2 * FIXME * (K[3, 1] + im*K[3, 5])
+                Sj2Si = Sj^2 * Si
+                Si2Sj = Si^2 * Sj
+                H11[i, i] += -6 * Sj2Si * K[3, 3]
+                H22[i, i] += -6 * Sj2Si * K[3, 3]
+                H11[j, j] += -6 * Si2Sj * K[3, 3]
+                H22[j, j] += -6 * Si2Sj * K[3, 3]
+                H21[i, i] += 2 * Sj2Si * (K[1, 3] - im*K[5, 3])
+                H12[i, i] += 2 * Sj2Si * (K[1, 3] + im*K[5, 3])
+                H21[j, j] += 2 * Si2Sj * (K[3, 1] - im*K[3, 5])
+                H12[j, j] += 2 * Si2Sj * (K[3, 1] + im*K[3, 5])
 
-                Q = 0.25 * FIXME * ( K[4, 4]+K[2, 2] - im*(-K[4, 2]+K[2, 4]))
+                Q = 0.25 * Sij^3 * ( K[4, 4]+K[2, 2] - im*(-K[4, 2]+K[2, 4]))
                 H11[i, j] += Q * phase
-                H11[j, i] += conj(Q) * conj(phase)
+                H11[j, i] += conj(Q * phase)
                 H22[i, j] += conj(Q) * phase
                 H22[j, i] += Q  * conj(phase)
 
-                P = 0.25 * FIXME * (-K[4, 4]+K[2, 2] - im*( K[4, 2]+K[2, 4]))
+                P = 0.25 * Sij^3 * (-K[4, 4]+K[2, 2] - im*( K[4, 2]+K[2, 4]))
                 H21[i, j] += P * phase
+                H12[j, i] += conj(P * phase)
                 H21[j, i] += P * conj(phase)
                 H12[i, j] += conj(P) * phase
-                H12[j, i] += conj(P) * conj(phase)
             end
         end
     end
@@ -247,31 +247,32 @@ function multiply_by_hamiltonian_dipole!(y::Array{ComplexF64, 2}, x::Array{Compl
             if !iszero(coupling.biquad)
                 J = coupling.biquad  # Transformed quadrupole exchange matrix
 
-                FIXME = Sij^3
-                P = 0.25 * FIXME * (-J[4, 4]+J[2, 2] - im*( J[4, 2]+J[2, 4]))
-                Q = 0.25 * FIXME * ( J[4, 4]+J[2, 2] - im*(-J[4, 2]+J[2, 4]))
+                Sj2Si = Sj^2 * Si
+                Si2Sj = Si^2 * Sj
+                Q = 0.25 * Sij^3 * ( J[4, 4]+J[2, 2] - im*(-J[4, 2]+J[2, 4]))
+                P = 0.25 * Sij^3 * (-J[4, 4]+J[2, 2] - im*( J[4, 2]+J[2, 4]))
 
                 @inbounds for q in 1:Nq
-                    Y[q, i, 1] += -6 * FIXME * J[3, 3] * X[q, i, 1]
-                    Y[q, i, 1] += 12 * FIXME * (J[1, 3] + im*J[5, 3]) * X[q, i, 2]
+                    Y[q, i, 1] += -6 * Sj2Si * J[3, 3] * X[q, i, 1]
+                    Y[q, i, 1] += 12 * Sj2Si * (J[1, 3] + im*J[5, 3]) * X[q, i, 2]
                     Y[q, i, 1] += Q * phases[q] * X[q, j, 1]
                     Y[q, i, 1] += conj(P) * phases[q] * X[q, j, 2]
                 end
                 @inbounds for q in 1:Nq
-                    Y[q, i, 2] += -6 * FIXME * J[3, 3] * X[q, i, 2]
-                    Y[q, i, 2] += 12 * FIXME * (J[1, 3] - im*J[5, 3]) * X[q, i, 1]
+                    Y[q, i, 2] += -6 * Sj2Si * J[3, 3] * X[q, i, 2]
+                    Y[q, i, 2] += 12 * Sj2Si * (J[1, 3] - im*J[5, 3]) * X[q, i, 1]
                     Y[q, i, 2] += conj(Q) * phases[q] * X[q, j, 2]
                     Y[q, i, 2] += P * phases[q] * X[q, j, 1]
                 end
                 @inbounds for q in 1:Nq
-                    Y[q, j, 1] += -6 * FIXME * J[3, 3] * X[q, j, 1]
-                    Y[q, j, 1] += 12 * FIXME * (J[3, 1] + im*J[3, 5]) * X[q, j, 2]
+                    Y[q, j, 1] += -6 * Si2Sj * J[3, 3] * X[q, j, 1]
+                    Y[q, j, 1] += 12 * Si2Sj * (J[3, 1] + im*J[3, 5]) * X[q, j, 2]
                     Y[q, j, 1] += conj(Q) * conj(phases[q]) * X[q, i, 1]
                     Y[q, j, 1] += conj(P) * conj(phases[q]) * X[q, i, 2]
                 end
                 @inbounds for q in 1:Nq
-                    Y[q, j, 2] += -6 * FIXME * J[3, 3] * X[q, j, 2]
-                    Y[q, j, 2] += 12 * FIXME * (J[3, 1] - im*J[3, 5]) * X[q, j, 1]
+                    Y[q, j, 2] += -6 * Si2Sj * J[3, 3] * X[q, j, 2]
+                    Y[q, j, 2] += 12 * Si2Sj * (J[3, 1] - im*J[3, 5]) * X[q, j, 1]
                     Y[q, j, 2] += Q * conj(phases[q]) * X[q, i, 2]
                     Y[q, j, 2] += P * conj(phases[q]) * X[q, i, 1]
                 end

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -70,10 +70,10 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
                 H11[j, j] += -6J[3, 3]
                 H22[i, i] += -6J[3, 3]
                 H22[j, j] += -6J[3, 3]
-                H21[i, i] += 12*(J[1, 3] - im*J[5, 3])
-                H12[i, i] += 12*(J[1, 3] + im*J[5, 3])
-                H21[j, j] += 12*(J[3, 1] - im*J[3, 5])
-                H12[j, j] += 12*(J[3, 1] + im*J[3, 5])
+                H21[i, i] += 2*(J[1, 3] - im*J[5, 3])
+                H12[i, i] += 2*(J[1, 3] + im*J[5, 3])
+                H21[j, j] += 2*(J[3, 1] - im*J[3, 5])
+                H12[j, j] += 2*(J[3, 1] + im*J[3, 5])
 
                 Q = 0.25 * ( J[4, 4]+J[2, 2] - im*(-J[4, 2]+J[2, 4]))
                 H11[i, j] += Q * phase
@@ -247,25 +247,25 @@ function multiply_by_hamiltonian_dipole!(y::Array{ComplexF64, 2}, x::Array{Compl
 
                 @inbounds for q in 1:Nq
                     Y[q, i, 1] += -6J[3, 3] * X[q, i, 1]
-                    Y[q, i, 1] += 12*(J[1, 3] + im*J[5, 3]) * X[q, i, 2]
+                    Y[q, i, 1] += 2*(J[1, 3] + im*J[5, 3]) * X[q, i, 2]
                     Y[q, i, 1] += Q * phases[q] * X[q, j, 1]
                     Y[q, i, 1] += conj(P) * phases[q] * X[q, j, 2]
                 end
                 @inbounds for q in 1:Nq
                     Y[q, i, 2] += -6J[3, 3] * X[q, i, 2]
-                    Y[q, i, 2] += 12*(J[1, 3] - im*J[5, 3]) * X[q, i, 1]
+                    Y[q, i, 2] += 2*(J[1, 3] - im*J[5, 3]) * X[q, i, 1]
                     Y[q, i, 2] += conj(Q) * phases[q] * X[q, j, 2]
                     Y[q, i, 2] += P * phases[q] * X[q, j, 1]
                 end
                 @inbounds for q in 1:Nq
                     Y[q, j, 1] += -6J[3, 3] * X[q, j, 1]
-                    Y[q, j, 1] += 12*(J[3, 1] + im*J[3, 5]) * X[q, j, 2]
+                    Y[q, j, 1] += 2*(J[3, 1] + im*J[3, 5]) * X[q, j, 2]
                     Y[q, j, 1] += conj(Q) * conj(phases[q]) * X[q, i, 1]
                     Y[q, j, 1] += conj(P) * conj(phases[q]) * X[q, i, 2]
                 end
                 @inbounds for q in 1:Nq
                     Y[q, j, 2] += -6J[3, 3] * X[q, j, 2]
-                    Y[q, j, 2] += 12*(J[3, 1] - im*J[3, 5]) * X[q, j, 1]
+                    Y[q, j, 2] += 2*(J[3, 1] - im*J[3, 5]) * X[q, j, 1]
                     Y[q, j, 2] += Q * conj(phases[q]) * X[q, i, 2]
                     Y[q, j, 2] += P * conj(phases[q]) * X[q, i, 1]
                 end

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -254,25 +254,25 @@ function multiply_by_hamiltonian_dipole!(y::Array{ComplexF64, 2}, x::Array{Compl
 
                 @inbounds for q in 1:Nq
                     Y[q, i, 1] += -6 * Sj2Si * J[3, 3] * X[q, i, 1]
-                    Y[q, i, 1] += 12 * Sj2Si * (J[1, 3] + im*J[5, 3]) * X[q, i, 2]
+                    Y[q, i, 1] += 2 * Sj2Si * (J[1, 3] + im*J[5, 3]) * X[q, i, 2]
                     Y[q, i, 1] += Q * phases[q] * X[q, j, 1]
                     Y[q, i, 1] += conj(P) * phases[q] * X[q, j, 2]
                 end
                 @inbounds for q in 1:Nq
                     Y[q, i, 2] += -6 * Sj2Si * J[3, 3] * X[q, i, 2]
-                    Y[q, i, 2] += 12 * Sj2Si * (J[1, 3] - im*J[5, 3]) * X[q, i, 1]
+                    Y[q, i, 2] += 2 * Sj2Si * (J[1, 3] - im*J[5, 3]) * X[q, i, 1]
                     Y[q, i, 2] += conj(Q) * phases[q] * X[q, j, 2]
                     Y[q, i, 2] += P * phases[q] * X[q, j, 1]
                 end
                 @inbounds for q in 1:Nq
                     Y[q, j, 1] += -6 * Si2Sj * J[3, 3] * X[q, j, 1]
-                    Y[q, j, 1] += 12 * Si2Sj * (J[3, 1] + im*J[3, 5]) * X[q, j, 2]
+                    Y[q, j, 1] += 2 * Si2Sj * (J[3, 1] + im*J[3, 5]) * X[q, j, 2]
                     Y[q, j, 1] += conj(Q) * conj(phases[q]) * X[q, i, 1]
                     Y[q, j, 1] += conj(P) * conj(phases[q]) * X[q, i, 2]
                 end
                 @inbounds for q in 1:Nq
                     Y[q, j, 2] += -6 * Si2Sj * J[3, 3] * X[q, j, 2]
-                    Y[q, j, 2] += 12 * Si2Sj * (J[3, 1] - im*J[3, 5]) * X[q, j, 1]
+                    Y[q, j, 2] += 2 * Si2Sj * (J[3, 1] - im*J[3, 5]) * X[q, j, 1]
                     Y[q, j, 2] += Q * conj(phases[q]) * X[q, i, 2]
                     Y[q, j, 2] += P * conj(phases[q]) * X[q, i, 1]
                 end

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -1,13 +1,14 @@
 struct SWTDataDipole
-    local_rotations       :: Vector{Mat3}
-    stevens_coefs         :: Vector{StevensExpansion}
-    observables_localized :: Array{ComplexF64, 4}  # Observables in local frame (for intensity calcs)
+    local_rotations       :: Vector{Mat3}             # Rotations from global to local frame
+    observables_localized :: Array{ComplexF64, 4}     # Observables in local frame
+    stevens_coefs         :: Vector{StevensExpansion} # Rotated onsite coupling as Steven expansion
+    sqrtS                 :: Vector{Float64}          # Square root of spin magnitudes
 end
 
 struct SWTDataSUN
-    local_unitaries       :: Array{ComplexF64, 3}  # Aligns to quantization axis on each site
-    spins_localized       :: Array{ComplexF64, 4}  # Spins in local frame
-    observables_localized :: Array{ComplexF64, 4}  # Observables in local frame (for intensity calcs)
+    local_unitaries       :: Array{ComplexF64, 3}     # Aligns to quantization axis on each site
+    spins_localized       :: Array{ComplexF64, 4}     # Spins in local frame
+    observables_localized :: Array{ComplexF64, 4}     # Observables in local frame
 end
 
 """
@@ -188,7 +189,6 @@ function swt_data_dipole(sys::System{0}, obs)
 
     n_magnetic_atoms = natoms(sys.crystal)
     observables_localized = zeros(ComplexF64, 1, 3, num_observables(obs), n_magnetic_atoms)
-    S = [(N-1)/2 for N in sys.Ns]
 
     for atom in 1:n_magnetic_atoms
         # Direction n of dipole will define rotation R that aligns the
@@ -230,13 +230,13 @@ function swt_data_dipole(sys::System{0}, obs)
 
             if !iszero(bilin)  # Leave zero if already zero
                 J = Mat3(bilin*I)
-                bilin = sqrt(S[i]*S[j]) * Rs[i]' * J * Rs[j]
+                bilin = Rs[i]' * J * Rs[j]
             end
 
             if !iszero(biquad)
                 J = biquad
                 J = Mat5(J isa Number ? J * diagm(scalar_biquad_metric) : J)
-                biquad = sqrt(S[i]*S[j])^3 * Vs[i]' * J * Vs[j]
+                biquad = Vs[i]' * J * Vs[j]
             end
 
             @assert isempty(general.data)
@@ -245,5 +245,6 @@ function swt_data_dipole(sys::System{0}, obs)
         end
     end
 
-    return SWTDataDipole(Rs, cs, observables_localized)
+    sqrtS = [sqrt((N-1)/2) for N in vec(sys.Ns)]
+    return SWTDataDipole(Rs, observables_localized, cs, sqrtS)
 end

--- a/src/System/OnsiteCoupling.jl
+++ b/src/System/OnsiteCoupling.jl
@@ -1,7 +1,7 @@
 function onsite_coupling(sys, site, matrep::AbstractMatrix)
     N = sys.Ns[site]
     size(matrep) == (N, N) || error("Invalid matrix size.")
-    matrep ≈ matrep' || error("Requires Hermitian operator")
+    matrep ≈ matrep' || error("Operator is not Hermitian")
 
     if sys.mode == :SUN
         return Hermitian(matrep)

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -208,7 +208,9 @@ function spin_label(sys::System, i::Int)
         return Inf
     else
         @assert sys.mode in (:dipole, :SUN)
-        return (sys.Ns[i]-1)/2
+        N = unique(sys.Ns[:,:,:,i])
+        length(N) > 1 && error("Spin varies between chemical cells")
+        return (only(N)-1)/2
     end
 end
 
@@ -530,13 +532,15 @@ function polarize_spins!(sys::System{N}, dir) where N
 end
 
 """
-    set_spin_rescaling!(sys, κ)
+    set_spin_rescaling!(sys, α)
 
-Renormalize all expected magnetic moments (e.g., dipoles) by `κ`.
+In dipole mode, rescale all spin magnitudes ``S → α S``. In SU(N) mode, rescale
+all SU(N) coherent states ``Z → √α Z`` such that every expectation value
+rescales like ``⟨A⟩ → α ⟨A⟩``.
 """
-function set_spin_rescaling!(sys::System{0}, κ)
+function set_spin_rescaling!(sys::System{0}, α)
     for site in eachsite(sys)
-        sys.κs[site] = κ * (sys.Ns[2]-1)/2
+        sys.κs[site] = α * (sys.Ns[site]-1)/2
         set_dipole!(sys, sys.dipoles[site], site)
     end
 end

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -208,9 +208,8 @@ function spin_label(sys::System, i::Int)
         return Inf
     else
         @assert sys.mode in (:dipole, :SUN)
-        N = unique(sys.Ns[:,:,:,i])
-        length(N) > 1 && error("Spin varies between chemical cells")
-        return (only(N)-1)/2
+        allequal(sys.Ns[:,:,:,i]) || error("Spin varies between chemical cells")
+        return (sys.Ns[1,1,1,i]-1)/2
     end
 end
 


### PR DESCRIPTION
This fixes two bugs:

1. Indexing in `spin_label` was previously incorrect.
2. LSWT in dipole mode was using the first spin as representative of all spins.