### PR TITLE
Undeprecate `biquad` argument in `set_exchange!`

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -55,5 +55,5 @@ end
 # view_crystal(cryst, max_dist)
 # λ argument in Langevin constructor
 # Δt argument in dynamical_correlations
-# large_S and biquad arguments in set_exchange! and set_exchange_at!
+# large_S argument in set_exchange! and set_exchange_at!
 # Argument `q` in set_spiral_order*


### PR DESCRIPTION
Since scalar-biquadratic is such a common use case, this PR uniformly supports again it with the `biquad` argument to `set_exchange!`, regardless of mode.

I was originally hoping we could entirely remove the `biquad` argument, and instead direct people to the more general `set_pair_coupling!` function. That idea hit a snag with `mode = :dipole_large_S`. In particular, Sunny doesn't have a way to represent symbolic spin operators ($S \to \infty$) in the tensor product space along a bond. It would be complicated to implement, and there is not a strong motivation, especially since we are de-emphasizing `:dipole_large_S`.

Fixes #276.