### PR TITLE
Error message when calling intensities on a SC with `kT=0`

### DIFF
--- a/examples/04_GSD_FeI2.jl
+++ b/examples/04_GSD_FeI2.jl
@@ -218,7 +218,7 @@ points = [[0,   0, 0],  # List of wave vectors that define a path
 qpath = q_space_path(cryst, points, 500)
 formfactors = [FormFactor("Fe2"; g_lande=3/2)]
 res = intensities(sc, qpath; kT, energies, formfactors)
-plot_intensities(res; colormap=:viridis, colorrange=(0.0, 1.0))
+plot_intensities(res; colorrange=(0.0, 1.0))
 
 # On can also view the intensity along a ``𝐪``-space slice at a fixed energy
 # value.


### PR DESCRIPTION
Adds an error message when a user sets `kT=0` when calling `intensities` on a `SampledCorrelations`. Somewhat simplifies the set of conditionals that check whether an `intensities` call is valid for a given `SampledCorrelations`.