### PR TITLE
Move `formfactors` into `measure`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,7 +36,7 @@ function build_examples(example_sources, destdir)
         # which is set up by `Documenter.deploydocs`.
         function preprocess(str)
             """
-            # Download this example as [Jupyter notebook]($assetsdir/notebooks/$name.ipynb) or [Julia script]($assetsdir/scripts/$name.jl).
+            # Download this example as [Julia file]($assetsdir/scripts/$name.jl) or [Jupyter notebook]($assetsdir/notebooks/$name.ipynb).
 
             """ * str
         end
@@ -114,16 +114,14 @@ Documenter.makedocs(;
         "index.md",
         "Examples" => [
             example_mds...,
-            "SpinW tutorials" => spinw_mds,
             # "Contributed" => contributed_mds,
-            "Advanced" => [
-                "parallelism.md",                        
-                # "writevtk.md",
-            ],
+            "SpinW ports" => spinw_mds,
         ],
-        "Modeling Guides" => [
+        "Guides" => [
             "structure-factor.md",
+            "parallelism.md",                        
             "renormalization.md",
+            # "writevtk.md",
         ],
         "library.md",
         "versions.md",

--- a/docs/src/renormalization.md
+++ b/docs/src/renormalization.md
@@ -1,4 +1,4 @@
-# Interaction Strength Renormalization
+# Interaction Renormalization
 
 A unique feature of Sunny is its support for building classical models where
 quantum spin is represented as an $N$-level system, rather than just an expected

--- a/docs/src/structure-factor.md
+++ b/docs/src/structure-factor.md
@@ -1,4 +1,4 @@
-# Structure Factor Calculations
+# Structure Factor Conventions
 
 ## Dynamical correlations
 

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,7 +3,7 @@
 ## v0.7.0
 (In development)
 
-This **major release** introduces several breaking changes:
+This **major release** introduces breaking interface changes.
 
 * The interface for calculating intensities has been revised to unify
   functionality across backends. The functions [`intensities_bands`](@ref),
@@ -24,8 +24,8 @@ This **major release** introduces several breaking changes:
 * New convenience functions [`powder_average`](@ref) and
   [`domain_average`](@ref), which wrap [`intensities`](@ref).
 * [`System`](@ref) now expects supercell dimensions as a `dims` keyword
-  argument. Lower-case `s` now labels quantum spin. For example, use
-  `:dipole_large_s` instead of `:dipole_large_S`.
+  argument. [`Moment`](@ref) replaces `SpinInfo`. Lower-case `s` now labels
+  quantum spin. For example, use `:dipole_large_s` instead of `:dipole_large_S`.
 * In [`view_crystal`](@ref) and [`plot_spins`](@ref) use `ndims` instead of
   `dims` for the number of spatial dimensions.
 * Binning features have been removed. Some functionality may be added back in a
@@ -106,7 +106,7 @@ This **major release** introduces several breaking changes:
 (Mar 25, 2024)
 
 * **Correctness fixes**: Structure factor conventions are now uniform across
-  modes and [precisely specified](@ref "Structure Factor Calculations"). The
+  modes and [precisely specified](@ref "Structure Factor Conventions"). The
   g-tensor is applied by default (disable with `apply_g = false`). The intensity
   is additive with increasing number of magnetic ions in the chemical cell,
   consistent with SpinW. [Issue

--- a/examples/01_LSWT_CoRh2O4.jl
+++ b/examples/01_LSWT_CoRh2O4.jl
@@ -128,11 +128,17 @@ plot_spins(sys_prim; color=[S[3] for S in sys_prim.dipoles])
 # With this primitive cell, we will perform a [`SpinWaveTheory`](@ref)
 # calculation of the structure factor ``\mathcal{S}(𝐪,ω)``. The measurement
 # [`ssf_perp`](@ref) indicates projection of the spin structure factor
-# perpendicular to the direction of momentum transfer. This measurement is
-# appropriate for unpolarized neutron scattering.
+# ``\mathcal{S}(𝐪,ω)`` perpendicular to the direction of momentum transfer, as
+# appropriate for unpolarized neutron scattering. The isotropic
+# [`FormFactor`](@ref) for Co²⁺ dampens intensities at large ``𝐪``.
 
 measure = ssf_perp(sys_prim; formfactors=[1 => "Co2"])
 swt = SpinWaveTheory(sys_prim; measure)
+
+# Select [`lorentzian`](@ref) broadening with a full-width at half-maximum
+# (FWHM) of 0.8 meV. 
+
+kernel = lorentzian(fwhm=0.8)
 
 # Define a [`q_space_path`](@ref) that connects high-symmetry points in
 # reciprocal space. The ``𝐪``-points are given in reciprocal lattice units
@@ -143,19 +149,12 @@ swt = SpinWaveTheory(sys_prim; measure)
 qs = [[0, 0, 0], [1/2, 0, 0], [1/2, 1/2, 0], [0, 0, 0]]
 path = q_space_path(cryst, qs, 500)
 
-# Select [`lorentzian`](@ref) broadening with a full-width at half-maximum
-# (FWHM) of 0.8 meV. The isotropic [`FormFactor`](@ref) for Co²⁺ dampens
-# intensities at large ``𝐪``.
-
-kernel = lorentzian(fwhm=0.8)
-formfactors = [FormFactor("Co2")];
-
 # Calculate the single-crystal scattering [`intensities`](@ref)` along the path,
 # for 300 energy points between 0 and 6 meV. Use [`plot_intensities`](@ref) to
 # visualize the result.
 
 energies = range(0, 6, 300)
-res = intensities(swt, path; energies, kernel, formfactors)
+res = intensities(swt, path; energies, kernel)
 plot_intensities(res; units)
 
 # To directly compare with the available experimental data, perform a
@@ -167,7 +166,7 @@ plot_intensities(res; units)
 
 radii = range(0, 3, 200) # (1/Å)
 res = powder_average(cryst, radii, 2000) do qs
-    intensities(swt, qs; energies, kernel, formfactors)
+    intensities(swt, qs; energies, kernel)
 end
 plot_intensities(res; units, saturation=1.0)
 

--- a/examples/01_LSWT_CoRh2O4.jl
+++ b/examples/01_LSWT_CoRh2O4.jl
@@ -131,7 +131,8 @@ plot_spins(sys_prim; color=[S[3] for S in sys_prim.dipoles])
 # perpendicular to the direction of momentum transfer. This measurement is
 # appropriate for unpolarized neutron scattering.
 
-swt = SpinWaveTheory(sys_prim; measure=ssf_perp(sys_prim))
+measure = ssf_perp(sys_prim; formfactors=[1 => "Co2"])
+swt = SpinWaveTheory(sys_prim; measure)
 
 # Define a [`q_space_path`](@ref) that connects high-symmetry points in
 # reciprocal space. The ``𝐪``-points are given in reciprocal lattice units

--- a/examples/01_LSWT_CoRh2O4.jl
+++ b/examples/01_LSWT_CoRh2O4.jl
@@ -132,7 +132,8 @@ plot_spins(sys_prim; color=[S[3] for S in sys_prim.dipoles])
 # appropriate for unpolarized neutron scattering. The isotropic
 # [`FormFactor`](@ref) for Co²⁺ dampens intensities at large ``𝐪``.
 
-measure = ssf_perp(sys_prim; formfactors=[1 => "Co2"])
+formfactors = [1 => FormFactor("Co2")]
+measure = ssf_perp(sys_prim; formfactors)
 swt = SpinWaveTheory(sys_prim; measure)
 
 # Select [`lorentzian`](@ref) broadening with a full-width at half-maximum

--- a/examples/02_LLD_CoRh2O4.jl
+++ b/examples/02_LLD_CoRh2O4.jl
@@ -91,7 +91,8 @@ plot_spins(sys; color=[S'*S0 for S in sys.dipoles])
 # configurations in classical thermal equilibrium. Each call to
 # [`add_sample!`](@ref) will accumulate data for the current spin snapshot.
 
-measure = ssf_perp(sys; formfactors=[1 => "Co2"])
+formfactors = [1 => FormFactor("Co2")]
+measure = ssf_perp(sys; formfactors)
 sc = SampledCorrelationsStatic(sys; measure)
 add_sample!(sc, sys)    # Accumulate the newly sampled structure factor into `sf`
 

--- a/examples/02_LLD_CoRh2O4.jl
+++ b/examples/02_LLD_CoRh2O4.jl
@@ -91,7 +91,8 @@ plot_spins(sys; color=[S'*S0 for S in sys.dipoles])
 # configurations in classical thermal equilibrium. Each call to
 # [`add_sample!`](@ref) will accumulate data for the current spin snapshot.
 
-sc = SampledCorrelationsStatic(sys; measure=ssf_perp(sys))
+measure = ssf_perp(sys; formfactors=[1 => "Co2"])
+sc = SampledCorrelationsStatic(sys; measure)
 add_sample!(sc, sys)    # Accumulate the newly sampled structure factor into `sf`
 
 # Collect 20 additional samples. Perform 100 Langevin time-steps between

--- a/examples/02_LLD_CoRh2O4.jl
+++ b/examples/02_LLD_CoRh2O4.jl
@@ -117,8 +117,7 @@ grid = q_space_grid(cryst, [1, 0, 0], range(-10, 10, 200), [0, 1, 0], (-10, 10))
 # saturation point to the maximum intensity value. This is reasonable because we
 # are above the ordering temperature, and do not have sharp Bragg peaks.
 
-formfactors = [FormFactor("Co2")]
-res = intensities_static(sc, grid; formfactors)
+res = intensities_static(sc, grid)
 plot_intensities(res; saturation=1.0)
 
 # ### Dynamical structure factor
@@ -174,6 +173,6 @@ plot_intensities(res; units)
 
 radii = range(0, 3.5, 200) # (1/Å)
 res = powder_average(cryst, radii, 350) do qs
-    intensities(sc, qs; energies, formfactors, langevin.kT)
+    intensities(sc, qs; energies, langevin.kT)
 end
 plot_intensities(res; units)

--- a/examples/04_GSD_FeI2.jl
+++ b/examples/04_GSD_FeI2.jl
@@ -153,8 +153,7 @@ end
 # `kT`. The large statistical noise could be reduced by averaging over more
 # thermal samples.
 
-formfactors = [FormFactor("Fe2"; g_lande=3/2)]
-res = intensities(sc, [[0, 0, 0], [0.5, 0.5, 0.5]]; energies, formfactors, langevin.kT)
+res = intensities(sc, [[0, 0, 0], [0.5, 0.5, 0.5]]; energies, langevin.kT)
 fig = lines(res.energies, res.data[:, 1]; axis=(xlabel="meV", ylabel="Intensity"), label="(0,0,0)")
 lines!(res.energies, res.data[:, 2]; label="(π,π,π)")
 axislegend()
@@ -173,7 +172,7 @@ qs = [[0,   0, 0],  # List of wave vectors that define a path
       [0,   1, 0],
       [0,   0, 0]] 
 qpath = q_space_path(cryst, qs, 500)
-res = intensities(sc, qpath; energies, formfactors, langevin.kT)
+res = intensities(sc, qpath; energies, langevin.kT)
 plot_intensities(res; colorrange=(0.0, 1.0))
 
 # One can also view the intensity along a [`q_space_grid`](@ref) for a fixed
@@ -181,5 +180,5 @@ plot_intensities(res; colorrange=(0.0, 1.0))
 # over all available energies.
 
 grid = q_space_grid(cryst, [1, 0, 0], range(-1.5, 1.5, 300), [0, 1, 0], (-1.5, 1.5); orthogonalize=true)
-res = intensities(sc, grid; energies=[3.88], formfactors, langevin.kT)
+res = intensities(sc, grid; energies=[3.88], langevin.kT)
 plot_intensities(res)

--- a/examples/04_GSD_FeI2.jl
+++ b/examples/04_GSD_FeI2.jl
@@ -123,11 +123,13 @@ langevin.dt = 0.040;
 # dynamics for SU(_N_) coherent states](https://arxiv.org/abs/2204.07563).
 # Normal modes appearing in the classical dynamics can be quantized to yield
 # magnetic excitations. The associated structure factor intensities
-# ``S^{αβ}(q,ω)`` can be compared with inelastic neutron scattering data .
+# ``S^{αβ}(q,ω)`` can be compared with inelastic neutron scattering data.
+# Incorporate the [`FormFactor`](@ref) appropriate to Fe²⁺. 
 
 dt = 2*langevin.dt
 energies = range(0, 7.5, 120)
-sc = SampledCorrelations(sys; dt, energies, measure=ssf_perp(sys))
+formfactors = [1 => FormFactor("Fe2"; g_lande=3/2)]
+sc = SampledCorrelations(sys; dt, energies, measure=ssf_perp(sys; formfactors))
 
 # The function [`add_sample!`](@ref) will collect data by running a dynamical
 # trajectory starting from the current system configuration. 
@@ -146,11 +148,10 @@ for _ in 1:2
 end
 
 # Measure intensities along a path connecting high-symmetry ``𝐪``-points,
-# specified in reciprocal lattice units (RLU). Incorporate the
-# [`FormFactor`](@ref) appropriate to Fe²⁺. A classical-to-quantum rescaling of
-# normal mode occupations will be performed according to the temperature `kT`.
-# The large statistical noise could be reduced by averaging over more thermal
-# samples.
+# specified in reciprocal lattice units (RLU). A classical-to-quantum rescaling
+# of normal mode occupations will be performed according to the temperature
+# `kT`. The large statistical noise could be reduced by averaging over more
+# thermal samples.
 
 formfactors = [FormFactor("Fe2"; g_lande=3/2)]
 res = intensities(sc, [[0, 0, 0], [0.5, 0.5, 0.5]]; energies, formfactors, langevin.kT)

--- a/examples/08_Momentum_Conventions.jl
+++ b/examples/08_Momentum_Conventions.jl
@@ -2,7 +2,7 @@
 #
 # This example illustrates Sunny's conventions for dynamical structure factor
 # intensities, ``\mathcal{S}(𝐪,ω)``, as documented in the page [Structure
-# Factor Calculations](@ref). In the neutron scattering context, the variables
+# Factor Conventions](@ref). In the neutron scattering context, the variables
 # ``𝐪`` and ``ω`` describe momentum and energy transfer _to_ the sample.
 #
 # For systems without inversion-symmetry, the structure factor intensities at

--- a/examples/spinw_tutorials/SW12_Triangular_easy_plane.jl
+++ b/examples/spinw_tutorials/SW12_Triangular_easy_plane.jl
@@ -26,12 +26,12 @@ set_exchange!(sys, J1, Bond(1, 1, [1, 0, 0]))
 # [`set_onsite_coupling!`](@ref). **Important note**: When introducing a
 # single-ion anisotropy in `:dipole` mode, Sunny will automatically include a
 # classical-to-quantum correction factor, as described in the document
-# [Interaction Strength Renormalization](@ref). The present single-ion
-# anisotropy is quadratic in the spin operators, so the prescription is to
-# rescale the interaction strength as ``D → (1 - 1/2s) D``. For purposes of this
-# tutorial, our aim is to reproduce the SpinW result, which requires to "undo"
-# Sunny's classical-to-quantum rescaling factor. Another way to achieve the same
-# thing is to select system mode `:dipole_large_s` instead of `:dipole`.
+# [Interaction Renormalization](@ref). For an anisotropy operator that is
+# quadratic in the spin operators, Sunny will automatically renormalize the
+# interaction strength as ``D → (1 - 1/2s) D``. We must "undo" Sunny's
+# classical-to-quantum rescaling factor to reproduce the SpinW calculation.
+# Alternatively, renormalization can be disabled by selecting the system mode
+# `:dipole_large_s` instead of `:dipole`.
 
 undo_classical_to_quantum_rescaling = 1 / (1 - 1/2s)
 D = 0.2 * undo_classical_to_quantum_rescaling

--- a/examples/spinw_tutorials/SW13_LiNiPO4.jl
+++ b/examples/spinw_tutorials/SW13_LiNiPO4.jl
@@ -25,7 +25,7 @@ view_crystal(cryst)
 # **79**, 092413 (2009)](https://doi.org/10.1103/PhysRevB.79.092413). The
 # corrected anisotropy values are taken from the thesis of T. Jensen. The mode
 # `:dipole_large_s` avoids a [classical-to-quantum rescaling factor](@ref
-# "Interaction Strength Renormalization") of anisotropy strengths, as needed for
+# "Interaction Renormalization") of anisotropy strengths, as needed for
 # consistency with the original fits.
 
 S = 3/2

--- a/examples/spinw_tutorials/SW14_YVO3.jl
+++ b/examples/spinw_tutorials/SW14_YVO3.jl
@@ -26,7 +26,7 @@ cryst = Crystal(latvecs, positions, 1; types)
 # Create a system following the model of [C. Ulrich, et al. PRL **91**, 257202
 # (2003)](https://doi.org/10.1103/PhysRevLett.91.257202). The mode
 # `:dipole_large_s` avoids a [classical-to-quantum rescaling factor](@ref
-# "Interaction Strength Renormalization") of anisotropy strengths, as needed for
+# "Interaction Renormalization") of anisotropy strengths, as needed for
 # consistency with the original fits.
 
 sys = System(cryst, [1 => Moment(s=1/2, g=2), 2 => Moment(s=1/2, g=2)], :dipole_large_s; dims=(2,2,1))

--- a/examples/spinw_tutorials/SW19_Different_Ions.jl
+++ b/examples/spinw_tutorials/SW19_Different_Ions.jl
@@ -44,7 +44,7 @@ path = q_space_path(cryst, qs, 400)
 
 fig = Figure(size=(768,600))
 
-formfactors = [1 => "Cu2", 2 => "Fe2"]
+formfactors = [1 => FormFactor("Cu2"), 2 => FormFactor("Fe2")]
 swt = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
 res = intensities_bands(swt, path)
 plot_intensities!(fig[1, 1], res; units, axisopts=(; title="All correlations"))

--- a/examples/spinw_tutorials/SW19_Different_Ions.jl
+++ b/examples/spinw_tutorials/SW19_Different_Ions.jl
@@ -37,7 +37,6 @@ plot_spins(sys)
 
 # Configure spin wave calculation
 
-swt = SpinWaveTheory(sys; measure=ssf_perp(sys))
 qs = [[0,0,0], [1,0,0]]
 path = q_space_path(cryst, qs, 400)
 
@@ -45,13 +44,19 @@ path = q_space_path(cryst, qs, 400)
 
 fig = Figure(size=(768,600))
 
-res = intensities_bands(swt, path)
+formfactors = [1 => "Cu2", 2 => "Fe2"]
+swt = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
+res = intensities_bands(swt, path; formfactors=[FormFactor("Cu2"), FormFactor("Fe2")])
 plot_intensities!(fig[1, 1], res; units, axisopts=(; title="All correlations"))
 
+formfactors = [1 => FormFactor("Cu2"), 2 => zero(FormFactor)]
+swt = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
 formfactors = [FormFactor("Cu2"), zero(FormFactor)]
 res = intensities_bands(swt, path; formfactors)
 plot_intensities!(fig[1, 2], res; units, axisopts=(; title="Cu-Cu correlations"))
 
+formfactors = [1 => zero(FormFactor), 2 => FormFactor("Fe2")]
+swt = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
 formfactors = [zero(FormFactor), FormFactor("Fe2")]
 res = intensities_bands(swt, path; formfactors)
 plot_intensities!(fig[2, 2], res; units, axisopts=(; title="Fe-Fe correlations"))

--- a/examples/spinw_tutorials/SW19_Different_Ions.jl
+++ b/examples/spinw_tutorials/SW19_Different_Ions.jl
@@ -46,19 +46,17 @@ fig = Figure(size=(768,600))
 
 formfactors = [1 => "Cu2", 2 => "Fe2"]
 swt = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
-res = intensities_bands(swt, path; formfactors=[FormFactor("Cu2"), FormFactor("Fe2")])
+res = intensities_bands(swt, path)
 plot_intensities!(fig[1, 1], res; units, axisopts=(; title="All correlations"))
 
 formfactors = [1 => FormFactor("Cu2"), 2 => zero(FormFactor)]
 swt = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
-formfactors = [FormFactor("Cu2"), zero(FormFactor)]
-res = intensities_bands(swt, path; formfactors)
+res = intensities_bands(swt, path)
 plot_intensities!(fig[1, 2], res; units, axisopts=(; title="Cu-Cu correlations"))
 
 formfactors = [1 => zero(FormFactor), 2 => FormFactor("Fe2")]
 swt = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
-formfactors = [zero(FormFactor), FormFactor("Fe2")]
-res = intensities_bands(swt, path; formfactors)
+res = intensities_bands(swt, path)
 plot_intensities!(fig[2, 2], res; units, axisopts=(; title="Fe-Fe correlations"))
 
 fig

--- a/src/FormFactor.jl
+++ b/src/FormFactor.jl
@@ -152,20 +152,6 @@ function compute_form_factor(form_factor::FormFactor, q2_absolute::Float64)
     end
 end
 
-# Given a form factor for each "symmetry class" of sites, return a form factor
-# for each atom in the crystal.
-function propagate_form_factors_to_atoms(ffs, cryst::Crystal)
-    isnothing(ffs) && return fill(one(FormFactor), natoms(cryst))
-    
-    ref_classes = unique(cryst.classes)
-    if length(ffs) != length(ref_classes)
-        error("""Received $(length(ffs)) form factors, but $(length(ref_classes)) are
-                 required, one for each symmetry-distinct site in the crystal.""")
-    end
-
-    return [ffs[findfirst(==(c), ref_classes)] for c in cryst.classes]
-end
-
 
 const radial_integral_coefficients = Dict(
     # 3d electrons of transition atoms and ions (P. J. Brown)

--- a/src/FormFactor.jl
+++ b/src/FormFactor.jl
@@ -127,6 +127,9 @@ function FormFactor(ion::String; g_lande=2)
     FormFactor(j0, j2, config, g_lande)
 end
 
+function Base.convert(::Type{FormFactor}, x::String)
+    return FormFactor(x)
+end
 
 function compute_gaussian_expansion(j::ExpandedBesselIntegral, s2)
     (; A, a, B, b, C, c, D, d, E) = j

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -82,9 +82,6 @@ function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::
     corrbuf = zeros(ComplexF64, Ncorr)
     moments = ElasticArray{ComplexF64}(undef, Ncorr, 0)
 
-    # Repeat formfactors data on dims of sys prior to SWT flattening
-    ffs = propagate_form_factors_for_swt(measure)
-
     u = zeros(ComplexF64, Nobs, 2L)
     α0 = zeros(ComplexF64, Nobs, 2L)
     α1 = zeros(ComplexF64, Nobs, 2L)
@@ -99,8 +96,9 @@ function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::
 
         for i in 1:Na
             r = sys.crystal.positions[i]
+            ff = get_swt_formfactor(measure, 1, i)
             Avec_pref[i] = exp(2π*im * dot(q_reshaped, r))
-            Avec_pref[i] *= compute_form_factor(ffs[1, i], norm2(q_global))
+            Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
         end
 
         if sys.mode == :SUN

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -60,7 +60,7 @@ function set_moments!(moments, measure, u, α)
 end
 
 
-function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::AbstractBroadening, formfactors=nothing, kT=0.0)
+function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::AbstractBroadening, kT=0.0)
     qpts = convert(AbstractQPoints, qpts)
 
     (; swt, resolution, screening_factor) = swt_kpm
@@ -82,9 +82,8 @@ function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::
     corrbuf = zeros(ComplexF64, Ncorr)
     moments = ElasticArray{ComplexF64}(undef, Ncorr, 0)
 
-    # Expand formfactors for symmetry classes to formfactors for all atoms in
-    # crystal
-    ff_atoms = propagate_form_factors_to_atoms(formfactors, sys.crystal)
+    # Repeat formfactors data on dims of sys prior to SWT flattening
+    ffs = propagate_form_factors_for_swt(measure)
 
     u = zeros(ComplexF64, Nobs, 2L)
     α0 = zeros(ComplexF64, Nobs, 2L)
@@ -101,7 +100,7 @@ function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::
         for i in 1:Na
             r = sys.crystal.positions[i]
             Avec_pref[i] = exp(2π*im * dot(q_reshaped, r))
-            Avec_pref[i] *= compute_form_factor(ff_atoms[i], norm2(q_global))
+            Avec_pref[i] *= compute_form_factor(ffs[1, i], norm2(q_global))
         end
 
         if sys.mode == :SUN
@@ -169,8 +168,8 @@ function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::
     return Intensities(cryst, qpts, collect(energies), data)
 end
 
-function intensities(swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::AbstractBroadening, formfactors=nothing, kT=0.0)
+function intensities(swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::AbstractBroadening, kT=0.0)
     qpts = convert(AbstractQPoints, qpts)
     data = zeros(eltype(swt_kpm.swt.measure), length(energies), length(qpts.qs))
-    return intensities!(data, swt_kpm, qpts; energies, kernel, formfactors, kT)
+    return intensities!(data, swt_kpm, qpts; energies, kernel, kT)
 end

--- a/src/Measurements/MeasureSpec.jl
+++ b/src/Measurements/MeasureSpec.jl
@@ -83,8 +83,7 @@ measure = ssf_custom((q, ssf) -> ssf, sys)
 measure = ssf_custom((q, ssf) -> real(sum(ssf)), sys)
 ```
 
-See also the Sunny documentation on [Structure Factor Calculations](@ref) for
-more details.
+See also the Sunny documentation on [Structure Factor Conventions](@ref).
 """
 function ssf_custom(f, sys::System; apply_g=true)
     observables = all_dipole_observables(sys; apply_g)

--- a/src/Measurements/MeasureSpec.jl
+++ b/src/Measurements/MeasureSpec.jl
@@ -121,7 +121,7 @@ operators.
 
 The optional `formfactors` comprise a list of pairs `[i1 => ff1, i2 => ...]`,
 where `i1, i2, ...` are a complete set of symmetry-distinct atoms, and `ff1,
-ff2, ...` convert to [`FormFactor`](@ref)s.
+ff2, ...` are [`FormFactor`](@ref)s or strings that convert to `FormFactor`s.
 
 Intended for use with [`SpinWaveTheory`](@ref) and instances of
 [`SampledCorrelations`](@ref).

--- a/src/Measurements/RotationalAverages.jl
+++ b/src/Measurements/RotationalAverages.jl
@@ -34,7 +34,7 @@ units of inverse length, define spherical shells in reciprocal space. The
 sphere, with quasi-uniformity. Sample points on different shells are
 decorrelated through random rotations. A consistent random number `seed` will
 yield reproducible results. The function `f` should accept a list of q-points
-and call a variant of [`intensities`](@ref).
+and call [`intensities`](@ref).
 
 # Example
 ```julia

--- a/src/Operators/Spin.jl
+++ b/src/Operators/Spin.jl
@@ -23,8 +23,7 @@ generators of SU(2) in the spin-`s` representation.
 If `s == Inf`, then the return values are abstract symbols denoting
 infinite-dimensional matrices that commute. These can be useful for repeating
 historical studies, or modeling micromagnetic systems. A technical discussion
-appears in the Sunny documentation page: [Interaction Strength
-Renormalization](@ref).
+appears in the Sunny documentation page: [Interaction Renormalization](@ref).
 
 # Example
 ```julia

--- a/src/Operators/Stevens.jl
+++ b/src/Operators/Stevens.jl
@@ -246,8 +246,7 @@ B = S[1]^4 + S[2]^4 + S[3]^4
 @assert A ≈ B
 ```
 
-See also [`spin_matrices`](@ref) and [Interaction Strength
-Renormalization](@ref).
+See also [`spin_matrices`](@ref) and [Interaction Renormalization](@ref).
 """
 function stevens_matrices(s)
     if isfinite(s) && !isinteger(2s+1)

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -170,13 +170,9 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
     intensity = zeros(eltype(measure), L, Nq)
 
     # Temporary storage for pair correlations
+    Nobs = size(measure.observables, 1)
     Ncorr = length(measure.corr_pairs)
     corrbuf = zeros(ComplexF64, Ncorr)
-
-    Nobs = size(measure.observables, 1)
-
-    # Repeat formfactors data on dims of sys prior to SWT flattening
-    ffs = propagate_form_factors_for_swt(measure)
 
     for (iq, q) in enumerate(qpts.qs)
         q_global = cryst.recipvecs * q
@@ -184,8 +180,9 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
 
         for i in 1:Na
             r_global = global_position(sys, (1,1,1,i))
+            ff = get_swt_formfactor(measure, 1, i)
             Avec_pref[i] = exp(- im * dot(q_global, r_global))
-            Avec_pref[i] *= compute_form_factor(ffs[1, i], norm2(q_global))
+            Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
         end
 
         Avec = zeros(ComplexF64, Nobs)

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -138,13 +138,13 @@ function dispersion(swt::SpinWaveTheory, qpts)
 end
 
 """
-    intensities_bands(swt::SpinWaveTheory, qpts; formfactors=nothing, kT=0)
+    intensities_bands(swt::SpinWaveTheory, qpts; kT=0)
 
 Calculate spin wave excitation bands for a set of q-points in reciprocal space.
 This calculation is analogous to [`intensities`](@ref), but does not perform
 line broadening of the bands.
 """
-function intensities_bands(swt::SpinWaveTheory, qpts; formfactors=nothing, kT=0, with_negative=false)
+function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
     (; sys, measure) = swt
     isempty(measure.observables) && error("No observables! Construct SpinWaveTheory with a `measure` argument.")
     with_negative && error("Option `with_negative=true` not yet supported.")
@@ -175,14 +175,8 @@ function intensities_bands(swt::SpinWaveTheory, qpts; formfactors=nothing, kT=0,
 
     Nobs = size(measure.observables, 1)
 
-    # Expand formfactors for symmetry classes to formfactors for all atoms in
-    # crystal
-    ff_atoms = propagate_form_factors_to_atoms(formfactors, sys.crystal)
-
     # Repeat formfactors data on dims of sys prior to SWT flattening
     ffs = propagate_form_factors_for_swt(measure)
-    @assert ff_atoms == ffs[1, :]
-
 
     for (iq, q) in enumerate(qpts.qs)
         q_global = cryst.recipvecs * q
@@ -237,23 +231,23 @@ function intensities_bands(swt::SpinWaveTheory, qpts; formfactors=nothing, kT=0,
 end
 
 """
-    intensities!(data, swt::SpinWaveTheory, qpts; energies, kernel, formfactors=nothing, kT=0)
-    intensities!(data, swt::SampledCorrelations, qpts; energies, kernel=nothing, formfactors=nothing, kT=0)
+    intensities!(data, swt::SpinWaveTheory, qpts; energies, kernel, kT=0)
+    intensities!(data, swt::SampledCorrelations, qpts; energies, kernel=nothing, kT=0)
 
 Like [`intensities`](@ref), but makes use of storage space `data` to avoid
 allocation costs.
 """
-function intensities!(data, swt::AbstractSpinWaveTheory, qpts; energies, kernel::AbstractBroadening, formfactors=nothing, kT=0)
+function intensities!(data, swt::AbstractSpinWaveTheory, qpts; energies, kernel::AbstractBroadening, kT=0)
     @assert size(data) == (length(energies), size(qpts.qs)...)
-    bands = intensities_bands(swt, qpts; formfactors, kT)
+    bands = intensities_bands(swt, qpts; kT)
     @assert eltype(bands) == eltype(data)
     broaden!(data, bands; energies, kernel)
     return Intensities(bands.crystal, bands.qpts, collect(Float64, energies), data)
 end
 
 """
-    intensities(swt::SpinWaveTheory, qpts; energies, kernel, formfactors=nothing, kT=0)
-    intensities(swt::SampledCorrelations, qpts; energies, kernel=nothing, formfactors=nothing, kT)
+    intensities(swt::SpinWaveTheory, qpts; energies, kernel, kT=0)
+    intensities(swt::SampledCorrelations, qpts; energies, kernel=nothing, kT)
 
 Calculates pair correlation intensities for a set of ``𝐪``-points in reciprocal
 space.
@@ -278,14 +272,14 @@ occupation factor. The special choice `kT = nothing` will suppress the
 classical-to-quantum correction factor, and yield statistics consistent with the
 classical Boltzmann distribution.
 """
-function intensities(swt::AbstractSpinWaveTheory, qpts; energies, kernel::AbstractBroadening, formfactors=nothing, kT=0)
-    return broaden(intensities_bands(swt, qpts; formfactors, kT); energies, kernel)
+function intensities(swt::AbstractSpinWaveTheory, qpts; energies, kernel::AbstractBroadening, kT=0)
+    return broaden(intensities_bands(swt, qpts; kT); energies, kernel)
 end
 
 """
-    intensities_static(sc::SpinWaveTheory, qpts; bounds=(-Inf, Inf), formfactors=nothing, kT=0)
-    intensities_static(sc::SampledCorrelations, qpts; bounds=(-Inf, Inf), formfactors=nothing, kT)
-    intensities_static(sc::SampledCorrelationsStatic, qpts; formfactors=nothing)
+    intensities_static(sc::SpinWaveTheory, qpts; bounds=(-Inf, Inf), kT=0)
+    intensities_static(sc::SampledCorrelations, qpts; bounds=(-Inf, Inf), kT)
+    intensities_static(sc::SampledCorrelationsStatic, qpts)
 
 Like [`intensities`](@ref), but integrates the dynamical correlations
 ``\\mathcal{S}(𝐪, ω)`` over a range of energies ``ω``. By default, the
@@ -303,8 +297,8 @@ The parameter `kT` can be used to account for the quantum thermal occupation of
 excitations at finite temperature. For details, see the documentation in
 [`intensities`](@ref).
 """
-function intensities_static(swt::AbstractSpinWaveTheory, qpts; bounds=(-Inf, Inf), formfactors=nothing, kT=0)
-    res = intensities_bands(swt, qpts; formfactors, kT)  # TODO: with_negative=true
+function intensities_static(swt::AbstractSpinWaveTheory, qpts; bounds=(-Inf, Inf), kT=0)
+    res = intensities_bands(swt, qpts; kT)  # TODO: with_negative=true
     data_reduced = zeros(eltype(res.data), size(res.data)[2:end])
     for ib in axes(res.data, 1), iq in CartesianIndices(data_reduced)
         if bounds[1] <= res.disp[ib, iq] < bounds[2]

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -179,6 +179,11 @@ function intensities_bands(swt::SpinWaveTheory, qpts; formfactors=nothing, kT=0,
     # crystal
     ff_atoms = propagate_form_factors_to_atoms(formfactors, sys.crystal)
 
+    # Repeat formfactors data on dims of sys prior to SWT flattening
+    ffs = propagate_form_factors_for_swt(measure)
+    @assert ff_atoms == ffs[1, :]
+
+
     for (iq, q) in enumerate(qpts.qs)
         q_global = cryst.recipvecs * q
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)
@@ -186,7 +191,7 @@ function intensities_bands(swt::SpinWaveTheory, qpts; formfactors=nothing, kT=0,
         for i in 1:Na
             r_global = global_position(sys, (1,1,1,i))
             Avec_pref[i] = exp(- im * dot(q_global, r_global))
-            Avec_pref[i] *= compute_form_factor(ff_atoms[i], norm2(q_global))
+            Avec_pref[i] *= compute_form_factor(ffs[1, i], norm2(q_global))
         end
 
         Avec = zeros(ComplexF64, Nobs)

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -290,3 +290,11 @@ function swt_data(sys::System{0}, measure)
 
     return SWTDataDipole(Rs, obs_localized, cs, sqrtS)
 end
+
+function propagate_form_factors_for_swt(measure)
+    Nobs = size(measure.observables, 1)
+    Ndims = size(measure.observables)[2:4]
+    ffs = reshape(measure.formfactors, Nobs, 1, 1, 1, :)
+    ffs = repeat(ffs, inner=(1, Ndims..., 1))
+    return reshape(ffs, Nobs, :)
+end

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -291,10 +291,10 @@ function swt_data(sys::System{0}, measure)
     return SWTDataDipole(Rs, obs_localized, cs, sqrtS)
 end
 
-function propagate_form_factors_for_swt(measure)
-    Nobs = size(measure.observables, 1)
-    Ndims = size(measure.observables)[2:4]
-    ffs = reshape(measure.formfactors, Nobs, 1, 1, 1, :)
-    ffs = repeat(ffs, inner=(1, Ndims..., 1))
-    return reshape(ffs, Nobs, :)
+# i is an "atom" index for the flattened swt.sys. However, `measure` was
+# originally constructed for a system with some crystal containing natoms. Use
+# mod1(i, natoms) to index into measure.formfactors.
+function get_swt_formfactor(measure, μ, i)
+    natoms = size(measure.observables, 5)
+    measure.formfactors[μ, mod1(i, natoms)]
 end

--- a/src/Spiral/SpiralSWT.jl
+++ b/src/Spiral/SpiralSWT.jl
@@ -176,7 +176,7 @@ function gs_as_scalar(swt::SpinWaveTheory, measure::MeasureSpec)
 end
 
 
-function intensities_bands(sswt::SpiralSpinWaveTheory, qpts; formfactors=nothing, kT=0) # TODO: branch=nothing
+function intensities_bands(sswt::SpiralSpinWaveTheory, qpts; kT=0) # TODO: branch=nothing
     (; swt, axis) = sswt
     (; sys, data, measure) = swt
     isempty(measure.observables) && error("No observables! Construct SpinWaveTheorySpiral with a `measure` argument.")
@@ -219,9 +219,8 @@ function intensities_bands(sswt::SpiralSpinWaveTheory, qpts; formfactors=nothing
     intensity_flat = reshape(intensity, 3L, Nq)
     S = zeros(ComplexF64, 3, 3, L, 3)
 
-    # Expand formfactors for symmetry classes to formfactors for all atoms in
-    # crystal
-    ff_atoms = propagate_form_factors_to_atoms(formfactors, sys.crystal)
+    # Repeat formfactors data on dims of sys prior to SWT flattening
+    ffs = propagate_form_factors_for_swt(measure)
     c = zeros(ComplexF64, Na)
 
     # If g-tensors are included in observables, they must be scalar. Precompute.
@@ -238,7 +237,7 @@ function intensities_bands(sswt::SpiralSpinWaveTheory, qpts; formfactors=nothing
         end
 
         for i in 1:Na
-            c[i] = data.sqrtS[i] * gs[i] * compute_form_factor(ff_atoms[i], norm2(q_global))
+            c[i] = data.sqrtS[i] * gs[i] * compute_form_factor(ffs[1, i], norm2(q_global))
         end
 
         for i in 1:L, j in 1:L

--- a/src/Spiral/SpiralSWT.jl
+++ b/src/Spiral/SpiralSWT.jl
@@ -219,8 +219,7 @@ function intensities_bands(sswt::SpiralSpinWaveTheory, qpts; kT=0) # TODO: branc
     intensity_flat = reshape(intensity, 3L, Nq)
     S = zeros(ComplexF64, 3, 3, L, 3)
 
-    # Repeat formfactors data on dims of sys prior to SWT flattening
-    ffs = propagate_form_factors_for_swt(measure)
+    # Like Avec_pref
     c = zeros(ComplexF64, Na)
 
     # If g-tensors are included in observables, they must be scalar. Precompute.
@@ -237,7 +236,8 @@ function intensities_bands(sswt::SpiralSpinWaveTheory, qpts; kT=0) # TODO: branc
         end
 
         for i in 1:Na
-            c[i] = data.sqrtS[i] * gs[i] * compute_form_factor(ffs[1, i], norm2(q_global))
+            ff = get_swt_formfactor(measure, 1, i)
+            c[i] = data.sqrtS[i] * gs[i] * compute_form_factor(ff, norm2(q_global))
         end
 
         for i in 1:L, j in 1:L

--- a/src/System/Moment.jl
+++ b/src/System/Moment.jl
@@ -1,14 +1,13 @@
 """
-    Moment(; s, g, ff=nothing)
+    Moment(; s, g)
 
 Characterizes a effective spin magnetic moment on an atom. Quantum spin-`s` is a
 multiple of 1/2 in units of ħ. The `g`-factor or tensor defines the
-[`magnetic_moment`](@ref) ``μ = - g 𝐒`` in units of the Bohr magneton. The
-optional parameter `ff` is a string representation of the [`FormFactor`](@ref).
+[`magnetic_moment`](@ref) ``μ = - g 𝐒`` in units of the Bohr magneton.
 
 # Example
 ```julia
-Moment(s=3/2, g=2, ff="Fe2")
+Moment(s=3/2, g=2)
 ```
 """
 struct Moment
@@ -30,17 +29,19 @@ end
 function propagate_moments(cryst::Crystal, moments::Vector{Pair{Int, Moment}})
     # Verify that all g tensors are consistent with the the site symmetries
     for (i, m) in moments
+        1 <= i <= natoms(cryst) || error("Atom $i outside the valid range 1:$(natoms(cryst))")
         if !is_coupling_valid(cryst, Bond(i, i, [0,0,0]), m.g)
             error("g-tensor $(m.g) is inconsistent with the site symmetry of atom $(m.atom).")
         end
     end
 
-    ref_classes = cryst.classes[first.(moments)]
+    ref_atoms = [i for (i, _) in moments]
+    ref_classes = cryst.classes[ref_atoms]
 
     return map(enumerate(cryst.classes)) do (i, c)
         js = findall(==(c), ref_classes)
         isempty(js) && error("Not all sites are specified; consider including atom $i.")
-        length(js) > 1 && error("Atoms $(js) are symmetry equivalent.")
+        length(js) > 1 && error("Atoms $(ref_atoms[js]) are symmetry equivalent.")
         (j, m) = moments[only(js)]
         g = transform_coupling_for_bonds(cryst, Bond(i, i, [0,0,0]), Bond(j, j, [0,0,0]), m.g)
         Moment(; m.s, g)

--- a/src/System/PairExchange.jl
+++ b/src/System/PairExchange.jl
@@ -330,7 +330,7 @@ antisymmetric part of the exchange, where `D` is the Dzyaloshinskii-Moriya
 pseudo-vector. The resulting interaction will be ``𝐃⋅(𝐒_i×𝐒_j)``.
 
 The optional numeric parameter `biquad` multiplies a scalar biquadratic
-interaction, ``(𝐒_i⋅𝐒_j)^2``, with appropriate [Interaction Strength
+interaction, ``(𝐒_i⋅𝐒_j)^2``, with appropriate [Interaction
 Renormalization](@ref). For more general interactions, use
 [`set_pair_coupling!`](@ref) instead.
 

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -7,9 +7,9 @@ specification of the spin `moments` symmetry-distinct sites, and a calculation
 [`set_exchange!`](@ref). The default supercell dimensions are 1×1×1 chemical
 cells, but this can be changed with `dims`.
 
-Spin `moments` should be given as a list of pairs, `[i => Moment(...), j =>
-Moment(...)]`, where `i, j, ...` are a complete set of symmetry-distinct atoms.
-Each [`Moment`](@ref) contains spin and ``g``-factor information.
+Spin `moments` comprise a list of pairs, `[i1 => Moment(...), i2 => ...]`, where
+`i1, i2, ...` are a complete set of symmetry-distinct atoms. Each
+[`Moment`](@ref) contains spin and ``g``-factor information.
 
 The two primary options for `mode` are `:SUN` and `:dipole`. In the former, each
 spin-``s`` degree of freedom is described as an SU(_N_) coherent state, i.e. a

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -9,8 +9,7 @@ cells, but this can be changed with `dims`.
 
 Spin `moments` should be given as a list of pairs, `[i => Moment(...), j =>
 Moment(...)]`, where `i, j, ...` are a complete set of symmetry-distinct atoms.
-Each [`Moment`](@ref) contains spin, ``g``-factor, and optionally form factor
-information.
+Each [`Moment`](@ref) contains spin and ``g``-factor information.
 
 The two primary options for `mode` are `:SUN` and `:dipole`. In the former, each
 spin-``s`` degree of freedom is described as an SU(_N_) coherent state, i.e. a
@@ -22,7 +21,7 @@ dipoles. In practice this means that Sunny will simulate Landau-Lifshitz
 dynamics, but single-ion anisotropy and biquadratic exchange interactions will
 be renormalized to improve accuracy. To disable this renormalization, use the
 mode `:dipole_large_s` which applies the ``s → ∞`` classical limit. For details,
-see the documentation page: [Interaction Strength Renormalization](@ref).
+see the documentation page: [Interaction Renormalization](@ref).
 
 An integer `seed` for the random number generator can optionally be specified to
 enable reproducible calculations.

--- a/test/test_chirality.jl
+++ b/test/test_chirality.jl
@@ -68,24 +68,21 @@ end
     # Check SpiralSpinWaveTheory
 
     qs = [[0,0,-1/3], [0,0,1/3]]
-    swt = SpiralSpinWaveTheory(sys; measure=ssf_trace(sys; apply_g=false), k, axis)
+    formfactors = [1 => "Fe2"]
+    swt = SpiralSpinWaveTheory(sys; measure=ssf_trace(sys; apply_g=false, formfactors), k, axis)
     res = intensities_bands(swt, qs)
-    disp_ref = [3.0133249314 2.5980762316 0.6479760935
-                 3.0133249314 2.5980762316 0.6479760935]
-    intens_ref = [0.0292617379 0.4330127014 0.8804147011
-                   0.5292617379 0.4330127014 0.3804147011]
-    @test res.disp ≈ disp_ref'
-    @test res.data ≈ intens_ref'
+    disp_ref = [3.0133249314050294 3.013324931405025; 2.598076231555311 2.5980762315553187; 0.6479760935008405 0.6479760935008452]
+    intens_ref = [0.017051546888468827 0.3084140583919762; 0.2523273363813809 0.252327336381381; 0.5130396769375238 0.22167716543401594]
+    @test res.disp ≈ disp_ref
+    @test res.data ≈ intens_ref
 
     # Check supercell equivalent
 
     sys_enlarged = repeat_periodically_as_spiral(sys, (1, 1, 4); k, axis)
-    swt = SpinWaveTheory(sys_enlarged; measure=ssf_trace(sys_enlarged; apply_g=false))
+    swt = SpinWaveTheory(sys_enlarged; measure=ssf_trace(sys_enlarged; apply_g=false, formfactors))
     res = intensities_bands(swt, qs)
-    disp2_ref = [3.0133249314 2.5980762316 1.3228756763 0.6479760935
-                 3.0133249314 2.5980762316 1.3228756763 0.6479760935]
-    intens2_ref = [0.0292617379 0.4330127014 0.0 0.8804147011
-                   0.5292617379 0.4330127014 0.0 0.3804147011]
-    @test res.disp ≈ disp2_ref'
-    @test res.data ≈ intens2_ref'
+    disp2_ref = [3.013324931405024 3.0133249314050277; 2.5980762315553148 2.598076231555316; 1.3228756763031237 1.3228756763031235; 0.647976093500838 0.6479760935008375]
+    intens2_ref = [0.01705154688846884 0.30841405839197655; 0.2523273363813807 0.25232733638138083; 0 0; 0.5130396769375255 0.2216771654340186]
+    @test res.disp ≈ disp2_ref
+    @test res.data ≈ intens2_ref
 end

--- a/test/test_chirality.jl
+++ b/test/test_chirality.jl
@@ -68,7 +68,7 @@ end
     # Check SpiralSpinWaveTheory
 
     qs = [[0,0,-1/3], [0,0,1/3]]
-    formfactors = [1 => "Fe2"]
+    formfactors = [1 => FormFactor("Fe2")]
     swt = SpiralSpinWaveTheory(sys; measure=ssf_trace(sys; apply_g=false, formfactors), k, axis)
     res = intensities_bands(swt, qs)
     disp_ref = [3.0133249314050294 3.013324931405025; 2.598076231555311 2.5980762315553187; 0.6479760935008405 0.6479760935008452]

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -72,12 +72,13 @@
 
     # Test form factor correction works and is doing something.
     sc.measure = ssf_trace(sys; apply_g=false, formfactors=[1 => "Fe2"])
-    is = intensities(sc, qgrid; energies=:available_with_negative, kT=nothing, formfactors=[FormFactor("Fe2")])
+    is = intensities(sc, qgrid; energies=:available_with_negative, kT=nothing)
     total_intensity_ff = sum(is.data)
     @test total_intensity_ff != total_intensity_trace
 
 
     # Test static from dynamic intensities working
+    sc.measure = ssf_trace(sys; apply_g=false)
     is_static = intensities_static(sc, qgrid; kT=nothing)
     total_intensity_static = sum(is_static.data)
     @test isapprox(total_intensity_static, total_intensity_trace * sc.Δω; atol=1e-9)  # Order of summation can lead to very small discrepancies
@@ -87,7 +88,7 @@
     total_intensity_static_c2q = sum(is_static_c2q.data)
     @test total_intensity_static_c2q > total_intensity_static 
 
-    # Test instant intensities working
+    # Test static intensities working
     sys = simple_model_fcc(; mode=:dipole)
     thermalize_simple_model!(sys; kT=0.1)
     ic = SampledCorrelationsStatic(sys; measure=ssf_trace(sys; apply_g=false))

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -71,9 +71,8 @@
 
 
     # Test form factor correction works and is doing something.
-    formfactors = [FormFactor("Fe2")]
-    sc.measure = ssf_trace(sys; apply_g=false)
-    is = intensities(sc, qgrid; energies=:available_with_negative, kT=nothing, formfactors)
+    sc.measure = ssf_trace(sys; apply_g=false, formfactors=[1 => "Fe2"])
+    is = intensities(sc, qgrid; energies=:available_with_negative, kT=nothing, formfactors=[FormFactor("Fe2")])
     total_intensity_ff = sum(is.data)
     @test total_intensity_ff != total_intensity_trace
 

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -71,7 +71,8 @@
 
 
     # Test form factor correction works and is doing something.
-    sc.measure = ssf_trace(sys; apply_g=false, formfactors=[1 => "Fe2"])
+    formfactors = [1 => FormFactor("Fe2")]
+    sc.measure = ssf_trace(sys; apply_g=false, formfactors)
     is = intensities(sc, qgrid; energies=:available_with_negative, kT=nothing)
     total_intensity_ff = sum(is.data)
     @test total_intensity_ff != total_intensity_trace

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -57,7 +57,7 @@ end
         bounds = Sunny.eigbounds(swt, q_reshaped, 50; extend=0.0)
         @test all(extrema(energies) .≈ bounds)
 
-        measure = ssf_perp(sys)
+        measure = ssf_perp(sys; formfactors=[1 => "Fe2"])
         σ = 0.05
         swt = SpinWaveTheory(sys; measure)
         swt_kpm = SpinWaveTheoryKPM(sys; measure, resolution=0.005, screening_factor=10)

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -57,7 +57,8 @@ end
         bounds = Sunny.eigbounds(swt, q_reshaped, 50; extend=0.0)
         @test all(extrema(energies) .≈ bounds)
 
-        measure = ssf_perp(sys; formfactors=[1 => "Fe2"])
+        formfactors = [1 => FormFactor("Fe2")]
+        measure = ssf_perp(sys; formfactors)
         σ = 0.05
         swt = SpinWaveTheory(sys; measure)
         swt_kpm = SpinWaveTheoryKPM(sys; measure, resolution=0.005, screening_factor=10)

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -65,10 +65,8 @@ end
         energies = range(0, 6, 100)
         kT = 0.2
         kernel = lorentzian(fwhm=2σ)
-        formfactors = [FormFactor("Fe2")]
-
-        res1 = intensities(swt, [q]; energies, formfactors, kernel, kT)
-        res2 = intensities(swt_kpm, [q]; energies, formfactors, kernel, kT)
+        res1 = intensities(swt, [q]; energies, kernel, kT)
+        res2 = intensities(swt_kpm, [q]; energies, kernel, kT)
 
         @test isapprox(res1.data, res2.data, atol=1e-3)
     end

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -58,7 +58,8 @@
     @test isapprox(res.data, data_golden'; atol=1e-9)
 
     # Test first 5 output matrices
-    measure = ssf_custom((q, ssf) -> ssf, sys; apply_g=false, formfactors=[1 => "Fe2"])
+    formfactors = [1 => FormFactor("Fe2")]
+    measure = ssf_custom((q, ssf) -> ssf, sys; apply_g=false, formfactors)
     swt = SpinWaveTheory(sys; measure)
     res = intensities_bands(swt, qs)
     data_flat = reinterpret(ComplexF64, res.data[1:5])
@@ -415,7 +416,8 @@ end
     q2 = [0.2360,0.7492,0.9596]
     q3 = [0.1131,0.7654,0.2810]
     q = [q1,q2,q3]
-    measure = ssf_custom((q, ssf) -> ssf, sys; formfactors=[1 => "Cr4"])
+    formfactors = [1 => FormFactor("Cr4")]
+    measure = ssf_custom((q, ssf) -> ssf, sys; formfactors)
     swt = SpinWaveTheory(sys; measure)
     res = intensities_bands(swt, q)
     disp_inds = [107, 89, 118, 140, 112, 16, 103, 75, 142, 18]
@@ -444,7 +446,7 @@ end
     @test energy_per_site(sys_prim) ≈ -2s^2
     
     # Both systems should produce the same intensities
-    formfactors = [1 => "Co2"]
+    formfactors = [1 => FormFactor("Co2")]
     swt1 = SpinWaveTheory(sys_prim; measure=ssf_perp(sys_prim; formfactors))
     swt2 = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
     kernel = lorentzian(fwhm=0.8)

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -58,7 +58,7 @@
     @test isapprox(res.data, data_golden'; atol=1e-9)
 
     # Test first 5 output matrices
-    measure = ssf_custom((q, ssf) -> ssf, sys; apply_g=false)
+    measure = ssf_custom((q, ssf) -> ssf, sys; apply_g=false, formfactors=[1 => "Fe2"])
     swt = SpinWaveTheory(sys; measure)
     formfactors=[FormFactor("Fe2")]
     res = intensities_bands(swt, qs; formfactors)
@@ -416,7 +416,7 @@ end
     q2 = [0.2360,0.7492,0.9596]
     q3 = [0.1131,0.7654,0.2810]
     q = [q1,q2,q3]
-    measure = ssf_custom((q, ssf) -> ssf, sys)
+    measure = ssf_custom((q, ssf) -> ssf, sys; formfactors=[1 => "Cr4"])
     swt = SpinWaveTheory(sys; measure)
     formfactors = [FormFactor("Cr4")]
     res = intensities_bands(swt, q; formfactors)
@@ -446,8 +446,9 @@ end
     @test energy_per_site(sys_prim) ≈ -2s^2
     
     # Both systems should produce the same intensities
-    swt1 = SpinWaveTheory(sys_prim; measure=ssf_perp(sys_prim))
-    swt2 = SpinWaveTheory(sys; measure=ssf_perp(sys))
+    formfactors = [1 => "Co2"]
+    swt1 = SpinWaveTheory(sys_prim; measure=ssf_perp(sys_prim; formfactors))
+    swt2 = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
     kernel = lorentzian(fwhm=0.8)
     formfactors = [FormFactor("Co2")]
     q = randn(3)
@@ -622,8 +623,8 @@ end
     observables = repeat(observables0, 1, size(eachsite(sys))...)
     corr_pairs = [(3,3), (2,2), (1,1)]
     combiner = (_, data) -> real(sum(data))
-    measure = Sunny.MeasureSpec(observables, corr_pairs, combiner)
-    
+    measure = Sunny.MeasureSpec(observables, corr_pairs, combiner, [one(FormFactor)])
+
     # Set up SpinWaveTheory
     randomize_spins!(sys)
     minimize_energy!(sys)

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -60,8 +60,7 @@
     # Test first 5 output matrices
     measure = ssf_custom((q, ssf) -> ssf, sys; apply_g=false, formfactors=[1 => "Fe2"])
     swt = SpinWaveTheory(sys; measure)
-    formfactors=[FormFactor("Fe2")]
-    res = intensities_bands(swt, qs; formfactors)
+    res = intensities_bands(swt, qs)
     data_flat = reinterpret(ComplexF64, res.data[1:5])
     # println(round.(data_flat; digits=12))
     data_golden = natoms * ComplexF64[0.000768755803 + 0.0im, 0.000453313199 - 4.8935387e-5im, 0.000468535469 + 8.5812793e-5im, 0.000453313199 + 4.8935387e-5im, 0.00027042076 + 0.0im, 0.000270819458 + 8.0426107e-5im, 0.000468535469 - 8.5812793e-5im, 0.000270819458 - 8.0426107e-5im, 0.000295138353 + 0.0im, 0.0 + 0.0im, 0.0 - 0.0im, 0.0 + 0.0im, 0.0 + 0.0im, 0.0 + 0.0im, 0.0 + 0.0im, 0.0 - 0.0im, 0.0 - 0.0im, 0.0 + 0.0im, 0.00021794048 + 0.0im, -0.000114399503 - 0.000211293782im, -0.000126018935 + 0.000199895684im, -0.000114399503 + 0.000211293782im, 0.000264899429 + 0.0im, -0.000127650501 - 0.000227103219im, -0.000126018935 - 0.000199895684im, -0.000127650501 + 0.000227103219im, 0.000256212415 + 0.0im, 0.0 + 0.0im, -0.0 - 0.0im, -0.0 + 0.0im, -0.0 + 0.0im, 0.0 + 0.0im, -0.0 - 0.0im, -0.0 - 0.0im, -0.0 + 0.0im, 0.0 + 0.0im, 7.5017149e-5 + 0.0im, 0.000206625046 + 0.000158601356im, 0.000240055385 - 0.00011016714im, 0.000206625046 - 0.000158601356im, 0.000904437194 + 0.0im, 0.000428286033 - 0.000810966567im, 0.000240055385 + 0.00011016714im, 0.000428286033 + 0.000810966567im, 0.000929965845 + 0.0im]
@@ -418,8 +417,7 @@ end
     q = [q1,q2,q3]
     measure = ssf_custom((q, ssf) -> ssf, sys; formfactors=[1 => "Cr4"])
     swt = SpinWaveTheory(sys; measure)
-    formfactors = [FormFactor("Cr4")]
-    res = intensities_bands(swt, q; formfactors)
+    res = intensities_bands(swt, q)
     disp_inds = [107, 89, 118, 140, 112, 16, 103, 75, 142, 18]
     int_inds = [9, 147, 131, 41, 15, 96, 48, 105, 129, 17]
     disp_ref = [8.464621970889235,2.965829202488746,6.539681848582543,2.524276472373584,7.536305768861917,7.21157510322424,9.267100207705882,5.603801899767303,2.2012141464553636,6.933800585478572]
@@ -450,11 +448,10 @@ end
     swt1 = SpinWaveTheory(sys_prim; measure=ssf_perp(sys_prim; formfactors))
     swt2 = SpinWaveTheory(sys; measure=ssf_perp(sys; formfactors))
     kernel = lorentzian(fwhm=0.8)
-    formfactors = [FormFactor("Co2")]
     q = randn(3)
     energies = 0:0.01:6
-    res1 = intensities(swt1, [q]; energies, kernel, formfactors)
-    res2 = intensities(swt2, [q]; energies, kernel, formfactors)
+    res1 = intensities(swt1, [q]; energies, kernel)
+    res2 = intensities(swt2, [q]; energies, kernel)
     @test res1.data ≈ res2.data
 end
 

--- a/test/test_rescaling.jl
+++ b/test/test_rescaling.jl
@@ -105,7 +105,7 @@ end
             return energy(sys)
         end
         @test E1 ≈ λ[k] * E2
-    end    
+    end
 end
 
 


### PR DESCRIPTION
The new syntax is:

```julia
formfactors = [1 => FormFactor("Fe2"), 2 => FormFactor("Cu2")]
measure = ssf_perp(sys; formfactors)
```

Including explicit atom indices is required to eventually support non-isotropic form factors. Also, this PR lays the foundations for observable-dependent form factors. For example, with an appropriate superposition of pair measurements, it should eventually be possible to allow form factors to vary correctly in an inhomogeneous system.
