### PR TITLE
Fix test for repeated wave vectors in SampledCorrelations

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -1,5 +1,11 @@
 # Version History
 
+## v0.7.2
+(In development)
+
+* Fix error in `SampledCorrelations` with a coarse ``𝐪``-grid. ([PR
+  #314](https://github.com/SunnySuite/Sunny.jl/pull/314))
+
 ## v0.7.1
 (Sep 3, 2024)
 

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -14,10 +14,9 @@ function pruned_wave_vector_info(sc::SampledCorrelations, qs)
     # Convert to absolute units (for form factors)
     qabs_rounded = map(m -> sc.crystal.recipvecs * (m ./ sc.sys_dims), ms)
 
-    # List of "starting" pointers i where qabs_rounded[i-1] != qabs_rounded[i]
-    # WARNING: This test cannot be done on idcs, since they wrap and a
-    # distinction must be made between wave vectors in different Brillouin
-    # zones which nonetheless index the same underlying data.
+    # List of "starting" pointers i where qabs_rounded[i-1] != qabs_rounded[i],
+    # i.e., indices where the desired wave vector is distinct from the previous
+    # one.
     starts = findall(i -> i == 1 || !isapprox(qabs_rounded[i-1], qabs_rounded[i]), eachindex(qabs_rounded))
 
     # Length of each run of repeated values

--- a/src/SampledCorrelations/DataRetrieval.jl
+++ b/src/SampledCorrelations/DataRetrieval.jl
@@ -14,8 +14,11 @@ function pruned_wave_vector_info(sc::SampledCorrelations, qs)
     # Convert to absolute units (for form factors)
     qabs_rounded = map(m -> sc.crystal.recipvecs * (m ./ sc.sys_dims), ms)
 
-    # List of "starting" pointers i where idcs[i-1] != idcs[i]
-    starts = findall(i -> i == 1 || idcs[i-1] != idcs[i], eachindex(idcs))
+    # List of "starting" pointers i where qabs_rounded[i-1] != qabs_rounded[i]
+    # WARNING: This test cannot be done on idcs, since they wrap and a
+    # distinction must be made between wave vectors in different Brillouin
+    # zones which nonetheless index the same underlying data.
+    starts = findall(i -> i == 1 || !isapprox(qabs_rounded[i-1], qabs_rounded[i]), eachindex(qabs_rounded))
 
     # Length of each run of repeated values
     counts = starts[2:end] - starts[1:end-1]

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -94,9 +94,8 @@
     true_static_total = sum(true_static_vals.data)
     @test isapprox(true_static_total / prod(sys.dims), 1.0; atol=1e-12)
 
-    # Test the case in which a list of wave vectors contains succesive elements
-    # that rely on the same underlying data point (same index into sc.data) but
-    # require different treatment w.r.t. phase averaging and/or form factors.
+    # Test whether two distinct wave vectors referencing the same underlying
+    # data point in sc.data are in fact treated differently.
     formfactors = [1 => FormFactor("Fe2")]
     sc.measure = ssf_trace(sys; apply_g=false, formfactors)
     res = intensities_static(sc, [[0, 0, 1/2], [1, 0, 1/2]]; kT=nothing)

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -93,6 +93,14 @@
     true_static_vals = intensities_static(res, qgrid)
     true_static_total = sum(true_static_vals.data)
     @test isapprox(true_static_total / prod(sys.dims), 1.0; atol=1e-12)
+
+    # Make sure a list that contains successive wave vectors that rely on the
+    # same underlying data point (but require different treatment w.r.t. phase
+    # averaging and form factors) do not produce the same output.
+    formfactors = [1 => FormFactor("Fe2")]
+    sc.measure = ssf_trace(sys; apply_g=false, formfactors)
+    res = intensities_static(sc, [[0, 0, 1/2], [1, 0, 1/2]]; kT=nothing)
+    @test res.data[1] != res.data[2]
 end
 
 @testitem "Merge correlations" begin

--- a/test/test_correlation_sampling.jl
+++ b/test/test_correlation_sampling.jl
@@ -94,9 +94,9 @@
     true_static_total = sum(true_static_vals.data)
     @test isapprox(true_static_total / prod(sys.dims), 1.0; atol=1e-12)
 
-    # Make sure a list that contains successive wave vectors that rely on the
-    # same underlying data point (but require different treatment w.r.t. phase
-    # averaging and form factors) do not produce the same output.
+    # Test the case in which a list of wave vectors contains succesive elements
+    # that rely on the same underlying data point (same index into sc.data) but
+    # require different treatment w.r.t. phase averaging and/or form factors.
     formfactors = [1 => FormFactor("Fe2")]
     sc.measure = ssf_trace(sys; apply_g=false, formfactors)
     res = intensities_static(sc, [[0, 0, 1/2], [1, 0, 1/2]]; kT=nothing)


### PR DESCRIPTION
Fixes the bug reported by Yishu Wang which is triggered when the requesting intensities at successive q points that reference the same underlying data in the `data` field of `SampledCorrelations`.

Previously, wave vectors such as `[0, 0, 1/2]` and `[1, 0, 1/2]` were falsely identified when they appeared successively. This led to incorrect treatment of phase averaging and form factors.