### PR TITLE
Make Colorbar more reliable

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -4,12 +4,14 @@
 (In development)
 
 * Fix error in `SampledCorrelations` with a coarse ``𝐪``-grid. ([PR
-  #314](https://github.com/SunnySuite/Sunny.jl/pull/314))
+  #314](https://github.com/SunnySuite/Sunny.jl/pull/314)).
+* Fix colorbar in `plot_intensities!` when all data is uniform ([PR
+  #315](https://github.com/SunnySuite/Sunny.jl/pull/315)).
+
 
 ## v0.7.1
 (Sep 3, 2024)
 
-* Fix crash in `plot_intensities!` when all data is uniform.
 * Correctness fix for scalar biquadratic interactions specified with option
   `biquad` to [`set_exchange!`](@ref).
 * Prototype implementation of entangled units.

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -8,7 +8,6 @@
 * Fix colorbar in `plot_intensities!` when all data is uniform ([PR
   #315](https://github.com/SunnySuite/Sunny.jl/pull/315)).
 
-
 ## v0.7.1
 (Sep 3, 2024)
 


### PR DESCRIPTION
Fix subtle problems associated with the Colorbar used in `plot_intensities`. These problems arose primarily when all intensities were very close to zero, with small numerical roundoff, such that the suggested `colorrange` pair was non-ascending. This PR adds logic to ensure that the suggested `colorrange` is always strictly ascending. For the special case of uniformly zero intensity, the selected color will correspond to the low end of the `colorrange`.
