### PR TITLE
Stabilize KPM

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -5,6 +5,8 @@
 
 * Fix error in `print_symmetry_table` for slightly-distorted crystal cells ([PR
   #317](https://github.com/SunnySuite/Sunny.jl/pull/317)).
+* Stabilize [`SpinWaveTheoryKPM`](@ref). It now automatically selects the
+  polynomial order according to an error tolerance.
 
 ## v0.7.2
 (Sep 11, 2024)

--- a/examples/01_LSWT_CoRh2O4.jl
+++ b/examples/01_LSWT_CoRh2O4.jl
@@ -23,11 +23,11 @@ using Sunny, GLMakie
 # GLMakie from the [built-in package
 # manager](https://github.com/SunnySuite/Sunny.jl/wiki/Getting-started-with-Julia#the-built-in-julia-package-manager).
 
-# ### Units
+# ### Units system
 
-# The [`Units`](@ref Sunny.Units) object selects reference energy and length
-# scales, and uses these to provide physical constants. For example, `units.K`
-# returns one kelvin as 0.086 meV, where the Boltzmann constant is implicit.
+# The [`Units`](@ref Units) object selects reference energy and length scales,
+# and uses these to provide physical constants. For example, `units.K` returns
+# one kelvin as 0.086 meV, where the Boltzmann constant is implicit.
 
 units = Units(:meV, :angstrom);
 

--- a/examples/09_Disorder_KPM.jl
+++ b/examples/09_Disorder_KPM.jl
@@ -66,21 +66,25 @@ plot_spins(sys_inhom; color=[s[3] for s in sys_inhom.dipoles], ndims=2)
 # [`SpinWaveTheoryKPM`](@ref) in place of the traditional
 # [`SpinWaveTheory`](@ref). Using KPM, the cost of an [`intensities`](@ref)
 # calculation becomes linear in system size and scales inversely with the width
-# of the line broadening `kernel`. Error is controllable through the
-# dimensionless `tol` parameter. A relatively small value is needed to resolve
-# the large intensities near the Goldstone mode.
+# of the line broadening `kernel`. Error tolerance is controlled through the
+# dimensionless `tol` parameter. A relatively small value, `tol = 0.01`, helps
+# to resolve the large intensities near the Goldstone mode. Had we selected
+# instead `tol = 0.1`, the calculation would be twice faster but significant
+# numerical artifacts would become apparent.
 #
 # Observe that disorder in the nearest-neighbor exchange serves to broaden the
 # discrete excitation bands into a continuum.
 
-swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.0001)
+swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.01)
 res = intensities(swt, path; energies, kernel)
 plot_intensities(res)
 
 # Now apply a magnetic field of magnitude 7.5 (energy units) along the global
-# ``ẑ`` axis. This is sufficiently strong to fully polarize the spins. The new
-# spin wave spectrum shows a sharp mode at the zone center that broadens into a
-# continuum at the zone boundary.
+# ``ẑ`` axis. This field fully polarizes the spins. Because gap opens, a larger
+# tolerance of `tol = 0.1` can be used to accelerate the KPM calculation without
+# sacrificing much accuracy. The resulting spin wave spectrum shows a sharp mode
+# at the Γ-point (zone center) that broadens into a continuum along the K and M
+# points (zone boundary).
 
 set_field!(sys_inhom, [0, 0, 7.5])
 randomize_spins!(sys_inhom)

--- a/examples/09_Disorder_KPM.jl
+++ b/examples/09_Disorder_KPM.jl
@@ -30,7 +30,7 @@ plot_spins(sys; color=[s[3] for s in sys.dipoles], ndims=2)
 qs = [[0, 0, 0], [1/3, 1/3, 0], [1/2, 0, 0], [0, 0, 0]]
 labels = ["Γ", "K", "M", "Γ"]
 path = q_space_path(cryst, qs, 150; labels)
-kernel = gaussian(fwhm=0.4);
+kernel = lorentzian(fwhm=0.4);
 
 # Perform a traditional spin wave calculation. The spectrum shows sharp modes
 # associated with coherent excitations about the K-point ordering wavevector,

--- a/examples/09_Disorder_KPM.jl
+++ b/examples/09_Disorder_KPM.jl
@@ -23,7 +23,7 @@ set_exchange!(sys, +1.0, Bond(1, 1, [1,0,0]))
 
 randomize_spins!(sys)
 minimize_energy!(sys)
-plot_spins(sys; color=[s[3] for s in sys.dipoles], ndims=2)
+plot_spins(sys; color=[S[3] for S in sys.dipoles], ndims=2)
 
 # Select a ``𝐪``-space path for the spin wave calculations.
 
@@ -58,7 +58,7 @@ for (site1, site2, offset) in symmetry_equivalent_bonds(sys_inhom, Bond(1,1,[1,0
 end
 
 minimize_energy!(sys_inhom, maxiters=5_000)
-plot_spins(sys_inhom; color=[s[3] for s in sys_inhom.dipoles], ndims=2)
+plot_spins(sys_inhom; color=[S[3] for S in sys_inhom.dipoles], ndims=2)
 
 # Traditional spin wave theory calculations become impractical for large system
 # sizes. Significant acceleration is possible with the [kernel polynomial

--- a/examples/09_Disorder_KPM.jl
+++ b/examples/09_Disorder_KPM.jl
@@ -1,14 +1,14 @@
-# # 9. Disordered spectrum with KPM
+# # 9. Disordered system with KPM
 #
 # This example uses the kernel polynomial method (KPM) to efficiently calculate
 # the neutron scattering spectrum of a disordered triangular antiferromagnet.
-# Our simple model is inspired by YbMgGaO4, as studied in [Paddison et al,
-# Nature Phys., **13**, 117–122 (2017)](https://doi.org/10.1038/nphys3971) and
-# [Zhu et al, Phys. Rev. Lett. **119**, 157201
-# (2017)](https://doi.org/10.1103/PhysRevLett.119.157201). The presence of
-# non-magnetic disorder of the the Mg/Ga occupancy can be modeled as a
-# stochastic distribution of exchange constants and ``g``-factors. Including
-# this randomness introduces broadening of the spin wave spectrum.
+# The model is inspired by YbMgGaO4, as studied in [Paddison et al, Nature
+# Phys., **13**, 117–122 (2017)](https://doi.org/10.1038/nphys3971) and [Zhu et
+# al, Phys. Rev. Lett. **119**, 157201
+# (2017)](https://doi.org/10.1103/PhysRevLett.119.157201). Disordered occupancy
+# of non-magnetic Mg/Ga sites can be modeled as a stochastic distribution of
+# exchange constants and ``g``-factors. Including this disorder introduces
+# broadening of the spin wave spectrum.
 
 using Sunny, GLMakie
 
@@ -30,7 +30,7 @@ plot_spins(sys; color=[s[3] for s in sys.dipoles], ndims=2)
 qs = [[0, 0, 0], [1/3, 1/3, 0], [1/2, 0, 0], [0, 0, 0]]
 labels = ["Γ", "K", "M", "Γ"]
 path = q_space_path(cryst, qs, 150; labels)
-kernel = lorentzian(fwhm=0.4);
+kernel = gaussian(fwhm=0.4);
 
 # Perform a traditional spin wave calculation. The spectrum shows sharp modes
 # associated with coherent excitations about the K-point ordering wavevector,
@@ -73,7 +73,7 @@ plot_spins(sys_inhom; color=[s[3] for s in sys_inhom.dipoles], ndims=2)
 # Observe that disorder in the nearest-neighbor exchange serves to broaden the
 # discrete excitation bands into a continuum.
 
-swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.01)
+swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.0001)
 res = intensities(swt, path; energies, kernel)
 plot_intensities(res)
 

--- a/examples/09_Disorder_KPM.jl
+++ b/examples/09_Disorder_KPM.jl
@@ -68,7 +68,7 @@ plot_spins(sys_inhom; color=[s[3] for s in sys_inhom.dipoles], ndims=2)
 # calculation becomes linear in system size and scales inversely with the width
 # of the line broadening `kernel`. Error tolerance is controlled through the
 # dimensionless `tol` parameter. A relatively small value, `tol = 0.01`, helps
-# to resolve the large intensities near the Goldstone mode. The alternative
+# to resolve the large intensities near the ordering wavevector. The alternative
 # choice `tol = 0.1` would be twice faster, but would introduce significant
 # numerical artifacts.
 #

--- a/examples/09_Disorder_KPM.jl
+++ b/examples/09_Disorder_KPM.jl
@@ -68,12 +68,12 @@ plot_spins(sys_inhom; color=[s[3] for s in sys_inhom.dipoles], ndims=2)
 # calculation becomes linear in system size and scales inversely with the width
 # of the line broadening `kernel`. Error tolerance is controlled through the
 # dimensionless `tol` parameter. A relatively small value, `tol = 0.01`, helps
-# to resolve the large intensities near the Goldstone mode. Had we selected
-# instead `tol = 0.1`, the calculation would be twice faster but significant
-# numerical artifacts would become apparent.
+# to resolve the large intensities near the Goldstone mode. The alternative
+# choice `tol = 0.1` would be twice faster, but would introduce significant
+# numerical artifacts.
 #
-# Observe that disorder in the nearest-neighbor exchange serves to broaden the
-# discrete excitation bands into a continuum.
+# Observe from the KPM calculation that disorder in the nearest-neighbor
+# exchange serves to broaden the discrete excitation bands into a continuum.
 
 swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.01)
 res = intensities(swt, path; energies, kernel)

--- a/examples/09_Disordered_spectrum.jl
+++ b/examples/09_Disordered_spectrum.jl
@@ -30,7 +30,7 @@ plot_spins(sys; color=[s[3] for s in sys.dipoles], ndims=2)
 qs = [[0, 0, 0], [1/3, 1/3, 0], [1/2, 0, 0], [0, 0, 0]]
 labels = ["Γ", "K", "M", "Γ"]
 path = q_space_path(cryst, qs, 150; labels)
-kernel = gaussian(fwhm=0.4);
+kernel = lorentzian(fwhm=0.4);
 
 # Perform a traditional spin wave calculation. The spectrum shows sharp modes
 # associated with coherent excitations about the K-point ordering wavevector,
@@ -67,13 +67,13 @@ plot_spins(sys_inhom; color=[s[3] for s in sys_inhom.dipoles], ndims=2)
 # [`SpinWaveTheory`](@ref). Using KPM, the cost of an [`intensities`](@ref)
 # calculation becomes linear in system size and scales inversely with the width
 # of the line broadening `kernel`. Error is controllable through the
-# dimensionless `tol` parameter. Reasonable choices are 0.1 (faster) or 0.01
-# (more accurate).
+# dimensionless `tol` parameter. A relatively small value is needed to resolve
+# the large intensities near the Goldstone mode.
 #
 # Observe that disorder in the nearest-neighbor exchange serves to broaden the
 # discrete excitation bands into a continuum.
 
-swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.1)
+swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.01)
 res = intensities(swt, path; energies, kernel)
 plot_intensities(res)
 

--- a/examples/09_Disordered_spectrum.jl
+++ b/examples/09_Disordered_spectrum.jl
@@ -1,0 +1,120 @@
+# # 9. Disordered spectrum with KPM
+#
+# This example uses the kernel polynomial method (KPM) to efficiently calculate
+# the neutron scattering spectrum of a disordered triangular antiferromagnet.
+# Our simple model is inspired by YbMgGaO4, which was previously studied in
+# [Paddison et al, Nature Phys., **13**, 117–122
+# (2017)](https://doi.org/10.1038/nphys3971) and [Zhu et al, Phys. Rev. Lett.
+# **119**, 157201 (2017)](https://doi.org/10.1103/PhysRevLett.119.157201). The
+# presence of non-magnetic disorder of the the Mg/Ga occupancy can be modeled as
+# a stochastic distribution of exchange constants and ``g``-factors. Including
+# this randomness introduces broadening of the spin wave spectrum.
+
+using Sunny, GLMakie
+
+# Set up minimal triangular lattice system. Include antiferromagnetic exchange
+# interactions between nearest neighbor bonds.
+
+units = Units(:meV, :angstrom)
+latvecs = lattice_vectors(1, 1, 10, 90, 90, 120)
+cryst = Crystal(latvecs, [[0, 0, 0]])
+sys = System(cryst, [1 => Moment(s=1/2, g=1)], :dipole; dims=(3, 3, 1))
+J1 = 1.0 # meV
+set_exchange!(sys, J1, Bond(1, 1, [1,0,0]))
+
+# Energy minimization yields the magnetic ground state with 120° angles between
+# spins.
+
+randomize_spins!(sys)
+minimize_energy!(sys)
+plot_spins(sys; color=[s[3] for s in sys.dipoles], ndims=2)
+
+# Select a ``𝐪``-space path for the spin wave calculations.
+
+qs = [[0, 0, 0], [1/3, 1/3, 0], [1/2, 0, 0], [0, 0, 0]]
+labels = ["Γ", "K", "M", "Γ"]
+path = q_space_path(cryst, qs, 150; labels)
+kernel = lorentzian(fwhm=0.4)
+
+# Perform a traditional spin wave calculation. The spectrum shows sharp modes
+# associated with coherent excitations about the K-point ordering wavevector,
+# ``𝐪 = [1/3, 1/3, 0]``.
+
+energies = range(0.0, 3.0, 150)
+swt = SpinWaveTheory(sys; measure=ssf_perp(sys))
+res = intensities(swt, path; energies, kernel)
+plot_intensities(res)
+
+# Use [`repeat_periodically`](@ref) to enlarge the system by a factor of 10 in
+# each dimension. Use [`to_inhomogeneous`](@ref) to disable symmetry
+# constraints, and allow for the addition of disordered interactions.
+
+sys_inhom = to_inhomogeneous(repeat_periodically(sys, (10, 10, 1)))
+
+# Use [`symmetry_equivalent_bonds`](@ref) to iterate over all nearest neighbor
+# bonds of the inhomogeneous system. Modulate the AFM exchange with a noise term
+# that has variance of 1/3. The newly minimized energy configuration allows for
+# long wavelength modulations on top of the original 120° order.
+
+for (site1, site2, offset) in symmetry_equivalent_bonds(sys_inhom, Bond(1,1,[1,0,0]))
+    noise = randn()/3
+    set_exchange_at!(sys_inhom, J1 * (1 + noise), site1, site2; offset)
+end
+
+minimize_energy!(sys_inhom, maxiters=5_000)
+plot_spins(sys_inhom; color=[s[3] for s in sys_inhom.dipoles], ndims=2)
+
+# Traditional spin wave theory calculations become impractical for large system
+# sizes. Significant acceleration is possible with the [kernel polynomial
+# method](https://arxiv.org/abs/2312.08349). Enable this calculation method by
+# selecting [`SpinWaveTheoryKPM`](@ref) in place of the traditional
+# [`SpinWaveTheory`](@ref). Using KPM, the cost of an [`intensities`](@ref)
+# calculation becomes linear in system size and scales inversely with the width
+# of the line broadening `kernel`. Error is controllable through the
+# dimensionless `tol` parameter. Reasonable choices are 0.1 (faster) or 0.01
+# (more accurate).
+#
+# Observe that disorder in the nearest-neighbor exchange serves to broaden the
+# discrete excitation bands into a continuum.
+
+swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.1)
+res = intensities(swt, path; energies, kernel)
+plot_intensities(res)
+
+# Now apply a magnetic field of magnitude ``B / μ_B = 7.5`` (meV) along the
+# global ``ẑ`` axis. This is sufficiently strong to fully polarize the spins. 
+
+set_field!(sys_inhom, [0, 0, 7.5])
+randomize_spins!(sys_inhom)
+minimize_energy!(sys_inhom)
+
+# The recalculated spin wave spectrum shows a sharp mode which disperse from the
+# zone center but which broadens into a continuum at the zone boundary.
+
+energies = range(0.0, 9.0, 150)
+swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.1)
+res = intensities(swt, path; energies, kernel)
+plot_intensities(res)
+
+# Now add disorder to the ``z``-component of each magnetic moment ``g``-tensor.
+# The resulting spectrum exhibits even greater broadening, now across the whole
+# path.
+
+for site in eachsite(sys_inhom)
+    noise = randn()/6
+    sys_inhom.gs[site] = [1 0 0; 0 1 0; 0 0 1+noise]
+end
+
+swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.1)
+res = intensities(swt, path; energies, kernel)
+plot_intensities(res)
+
+# For reference, the equivalent non-disordered system shows a single coherent
+# mode.
+
+set_field!(sys, [0, 0, 7.5])
+randomize_spins!(sys)
+minimize_energy!(sys)
+swt = SpinWaveTheory(sys; measure=ssf_perp(sys))
+res = intensities(swt, path; energies, kernel)
+plot_intensities(res)

--- a/examples/spinw_tutorials/SW02_AFM_Heisenberg_chain.jl
+++ b/examples/spinw_tutorials/SW02_AFM_Heisenberg_chain.jl
@@ -37,7 +37,7 @@ plot_spins(sys; ndims=2, ghost_radius=8)
 
 swt = SpinWaveTheory(sys; measure=ssf_perp(sys))
 qs = [[0,0,0], [1,0,0]]
-path = q_space_path(cryst, qs, 400)
+path = q_space_path(cryst, qs, 401)
 res = intensities_bands(swt, path)
 plot_intensities(res; units)
 

--- a/examples/spinw_tutorials/SW03_Frustrated_chain.jl
+++ b/examples/spinw_tutorials/SW03_Frustrated_chain.jl
@@ -53,6 +53,6 @@ plot_spins(sys_enlarged; ndims=2)
 
 swt = SpinWaveTheorySpiral(sys; measure=ssf_perp(sys), k, axis)
 qs = [[0,0,0], [1,0,0]]
-path = q_space_path(cryst, qs, 400)
+path = q_space_path(cryst, qs, 401)
 res = intensities_bands(swt, path)
 plot_intensities(res; units)

--- a/examples/spinw_tutorials/SW04_Frustrated_square.jl
+++ b/examples/spinw_tutorials/SW04_Frustrated_square.jl
@@ -34,6 +34,6 @@ plot_spins(sys)
 
 swt = SpinWaveTheory(sys; measure=ssf_perp(sys))
 qs = [[0, 0, 0], [1/2, 0, 0], [1/2, 1/2, 0], [0, 0, 0]]
-path = q_space_path(cryst, qs, 400);
+path = q_space_path(cryst, qs, 400)
 res = intensities_bands(swt, path)
 plot_intensities(res; units)

--- a/src/KPM/Chebyshev.jl
+++ b/src/KPM/Chebyshev.jl
@@ -58,8 +58,10 @@ function cheb_eval(x, bounds, coefs)
 end
 
 """
-    Transform Chebyshev expansion moments μ_m to densities ρ_n for discrete
-    points x_n = cos[(π/N)(n+1/2)], where n = 0 … N-1.
+    cheb_moments_to_density(μs, N; γ=1)
+
+Transform Chebyshev expansion moments μ_m to densities ρ_n for discrete points
+x_n = cos[(π/N)(n+1/2)], where n = 0 … N-1. ⟦UNTESTED⟧.
 """
 function cheb_moments_to_density(μs, N; γ=1)
     M = length(μs)

--- a/src/KPM/Lanczos.jl
+++ b/src/KPM/Lanczos.jl
@@ -1,69 +1,3 @@
-#=
-
-function lanczos(swt, q_reshaped, niters)
-    L = nbands(swt)
-
-    function inner_product(w, v)
-        return @views real(dot(w[1:L], v[1:L]) - dot(w[L+1:2L], v[L+1:2L]))
-    end
-
-    function mat_vec_mul!(w, v, q_reshaped)
-        mul_dynamical_matrix!(swt, reshape(w, 1, :), reshape(v, 1, :), [q_reshaped])
-        view(w, L+1:2L) .*= -1
-    end
-
-    αs = zeros(Float64, niters)   # Diagonal part
-    βs = zeros(Float64, niters-1) # Off-diagonal part
-
-    vprev = randn(ComplexF64, 2L)
-    v = zeros(ComplexF64, 2L)
-    w = zeros(ComplexF64, 2L)
-
-    mat_vec_mul!(w, vprev, q_reshaped)
-    b0 = sqrt(inner_product(vprev, w))
-    vprev = vprev / b0
-    w = w / b0
-    αs[1] = inner_product(w, w)
-    @. w = w - αs[1]*vprev
-    for j in 2:niters
-        @. v = w
-        mat_vec_mul!(w, v, q_reshaped)
-        βs[j-1] = sqrt(inner_product(v, w)) # maybe v?
-        if abs(βs[j-1]) < 1e-12
-            # TODO: Terminate early if all β are small
-            βs[j-1] = 0
-            @. v = w = 0
-        else
-            @. v = v / βs[j-1]
-            @. w = w / βs[j-1]
-        end
-        αs[j] = inner_product(w, w)
-        @. w = w - αs[j]*v - βs[j-1]*vprev
-        v, vprev = vprev, v
-    end
-
-    return SymTridiagonal(αs, βs)
-end
-
-
-"""
-    eigbounds(A, niters; extend=0.0)
-
-Returns estimates of the extremal eigenvalues of Hermitian matrix `A` using the
-Lanczos algorithm. `niters` should be given a value smaller than the dimension
-of `A`. `extend` specifies how much to shift the upper and lower bounds as a
-percentage of the total scale of the estimated eigenvalues.
-"""
-function eigbounds(swt, q_reshaped, niters; extend)
-    tridiag = lanczos(swt, Vec3(q_reshaped), niters)
-    lo, hi = extrema(eigvals!(tridiag)) # TODO: pass irange=1 and irange=2L
-    slack = extend*(hi-lo)
-    return lo-slack, hi+slack
-end
-
-=#
-
-
 # Reference implementation, without consideration of speed.
 function lanczos_ref(A, S, v; niters)
     αs = Float64[]
@@ -110,7 +44,7 @@ end
 # https://doi.org/10.1090/s0025-5718-1982-0669648-0
 # 3. M. Grüning, A. Marini, X. Gonze, Comput. Mater. Sci. 50, 2148-2156 (2011),
 # https://doi.org/10.1016/j.commatsci.2011.02.021.
-function lanczos3(mulA!, mulS!, v; niters)
+function lanczos(mulA!, mulS!, v; niters)
     αs = Float64[]
     βs = Float64[]
 
@@ -150,31 +84,29 @@ end
 
 
 """
-    eigbounds(swt, niters; extend=0.0)
+    eigbounds(swt, niters)
 
 Returns estimates of the extremal eigenvalues of the matrix (Ĩ D)^2 using the
 Lanczos algorithm. Here Ĩ is the Bogoliubov identity and D is the dynamical
 matrix from LSWT for the wavevector q_reshaped. `niters` should be given a value
-smaller than the dimension of `A`. `extend` specifies how much to shift the
-upper and lower bounds as a percentage of the total scale of the estimated
-eigenvalues.
+smaller than the dimension of `A`.
 """
-function eigbounds(swt, q_reshaped, niters; extend)
+function eigbounds(swt, q_reshaped, niters)
     q_reshaped = Vec3(q_reshaped)
     L = nbands(swt)
 
+    # w = Ĩ v
     function mulA!(w, v)
         @views w[1:L]    = +v[1:L]
         @views w[L+1:2L] = -v[L+1:2L]
     end
 
+    # w = D v
     function mulS!(w, v)
         mul_dynamical_matrix!(swt, reshape(w, 1, :), reshape(v, 1, :), [q_reshaped])
     end
 
     v = randn(ComplexF64, 2L)
-    tridiag = lanczos3(mulA!, mulS!, v; niters)
-    lo, hi = extrema(eigvals!(tridiag)) # TODO: pass irange=1 and irange=2L
-    slack = extend*(hi-lo)
-    return lo-slack, hi+slack
+    tridiag = lanczos(mulA!, mulS!, v; niters)
+    return eigmin(tridiag), eigmax(tridiag)
 end

--- a/src/KPM/Lanczos.jl
+++ b/src/KPM/Lanczos.jl
@@ -1,21 +1,4 @@
-
-"""
-    parallel_lanczos!(buf1, buf2, buf3; niters, mat_vec_mul!, inner_product!)
-
-Parallelized Lanczos. Takes functions for matrix-vector multiplication and inner
-products. Returns a list of tridiagonal matrices. `niters` sets the number of
-iterations used by the Lanczos algorithm.
-
-References:
-- [H. A. van der Vorst, Math. Comp. 39, 559-561
-  (1982)](https://doi.org/10.1090/s0025-5718-1982-0669648-0).
-- [M. Grüning, A. Marini, X. Gonze, Comput. Mater. Sci. 50, 2148-2156
-  (2011)](https://doi.org/10.1016/j.commatsci.2011.02.021).
-"""
-function parallel_lanczos!(vprev, v, w;  niters, mat_vec_mul!, inner_product)
-    # ...
-end
-
+#=
 
 function lanczos(swt, q_reshaped, niters)
     L = nbands(swt)
@@ -73,6 +56,124 @@ percentage of the total scale of the estimated eigenvalues.
 """
 function eigbounds(swt, q_reshaped, niters; extend)
     tridiag = lanczos(swt, Vec3(q_reshaped), niters)
+    lo, hi = extrema(eigvals!(tridiag)) # TODO: pass irange=1 and irange=2L
+    slack = extend*(hi-lo)
+    return lo-slack, hi+slack
+end
+
+=#
+
+
+# Reference implementation, without consideration of speed.
+function lanczos_ref(A, S, v; niters)
+    αs = Float64[]
+    βs = Float64[]
+
+    v /= sqrt(real(dot(v, S, v)))
+    w = A * S * v
+    α = real(dot(w, S, v))
+    w = w - α * v
+    push!(αs, α)
+
+    for _ in 2:niters
+        β = sqrt(real(dot(w, S, w)))
+        iszero(β) && break
+        vp = w / β
+        w = A * S * vp
+        α = real(dot(w, S, vp))
+        w = w - α * vp - β * v
+        v = vp
+        push!(αs, α)
+        push!(βs, β)
+    end
+
+    return SymTridiagonal(αs, βs)
+end
+
+
+
+# Use Lanczos iterations to find a truncated tridiagonal representation of A S,
+# up to similarity transformation. Here, A is any Hermitian matrix, while S is
+# both Hermitian and positive definite. Traditional Lanczos uses the identity
+# matrix, S = I. The extension to non-identity matrices S is as follows: Each
+# matrix-vector product A v becomes A S v, and each vector inner product w† v
+# becomes w† S v. The implementation below follows the notation of Wikipedia,
+# and is the most stable of the four variants considered by Paige [1]. Each
+# Lanczos iteration requires only one matrix-vector multiplication for A and S,
+# respectively.
+
+# Similar generalizations of Lanczos have been considered in [2] and [3].
+#
+# 1. C. C. Paige, IMA J. Appl. Math., 373-381 (1972),
+# https://doi.org/10.1093%2Fimamat%2F10.3.373.
+# 2. H. A. van der Vorst, Math. Comp. 39, 559-561 (1982),
+# https://doi.org/10.1090/s0025-5718-1982-0669648-0
+# 3. M. Grüning, A. Marini, X. Gonze, Comput. Mater. Sci. 50, 2148-2156 (2011),
+# https://doi.org/10.1016/j.commatsci.2011.02.021.
+function lanczos3(mulA!, mulS!, v; niters)
+    αs = Float64[]
+    βs = Float64[]
+
+    vp  = zero(v)
+    Sv  = zero(v)
+    Svp = zero(v)
+    w   = zero(v)
+    Sw  = zero(v)
+
+    mulS!(Sv, v)
+    c = sqrt(real(dot(v, Sv)))
+    @. v /= c
+    @. Sv /= c
+
+    mulA!(w, Sv)
+    α = real(dot(w, Sv))
+    @. w = w - α * v
+    mulS!(Sw, w)
+    push!(αs, α)
+
+    for _ in 2:niters
+        β = sqrt(real(dot(w, Sw)))
+        iszero(β) && break
+        @. vp = w / β
+        @. Svp = Sw / β
+        mulA!(w, Svp)
+        α = real(dot(w, Svp))
+        @. w = w - α * vp - β * v
+        mulS!(Sw, w)
+        @. v = vp
+        push!(αs, α)
+        push!(βs, β)
+    end
+
+    return SymTridiagonal(αs, βs)
+end
+
+
+"""
+    eigbounds(swt, niters; extend=0.0)
+
+Returns estimates of the extremal eigenvalues of the matrix (Ĩ D)^2 using the
+Lanczos algorithm. Here Ĩ is the Bogoliubov identity and D is the dynamical
+matrix from LSWT for the wavevector q_reshaped. `niters` should be given a value
+smaller than the dimension of `A`. `extend` specifies how much to shift the
+upper and lower bounds as a percentage of the total scale of the estimated
+eigenvalues.
+"""
+function eigbounds(swt, q_reshaped, niters; extend)
+    q_reshaped = Vec3(q_reshaped)
+    L = nbands(swt)
+
+    function mulA!(w, v)
+        @views w[1:L]    = +v[1:L]
+        @views w[L+1:2L] = -v[L+1:2L]
+    end
+
+    function mulS!(w, v)
+        mul_dynamical_matrix!(swt, reshape(w, 1, :), reshape(v, 1, :), [q_reshaped])
+    end
+
+    v = randn(ComplexF64, 2L)
+    tridiag = lanczos3(mulA!, mulS!, v; niters)
     lo, hi = extrema(eigvals!(tridiag)) # TODO: pass irange=1 and irange=2L
     slack = extend*(hi-lo)
     return lo-slack, hi+slack

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -124,7 +124,7 @@ function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::
         lo, hi = eigbounds(swt, q_reshaped, lanczos_iters)
         γ = 1.1 * max(abs(lo), hi)
         accuracy_factor = max(-3*log10(tol), 1)
-        M = round(Int, accuracy_factor * 2γ / kernel.fwhm)
+        M = round(Int, accuracy_factor * max(2γ / kernel.fwhm, 3))
         resize!(moments, Ncorr, M)
 
         if verbose

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -161,8 +161,8 @@ function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::
             # the polynomial resolution scale times a prefactor that grows like
             # sqrt(accuracy) to reduce lingering ringing artifacts. See "AFM
             # KPM" for a test case where the smoothing degrades accuracy, and
-            # "Disordered spectrum with KPM" for an illustration of how
-            # smoothing affects intensities near the Goldstone mode.
+            # "Disordered system with KPM" for an illustration of how smoothing
+            # affects intensities near the Goldstone mode.
             σ = sqrt(accuracy_factor) * (γ / M)
             thermal_prefactor_zero(x) = (tanh(x / σ) + 1) / 2
             f(x) = kernel(x, ω) * thermal_prefactor_zero(x)

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -16,6 +16,12 @@ resolution of the broadening kernel, times the negative logarithm of `tol`.
 The error tolerance `tol` should be tuned empirically for each calculation.
 Reasonable starting points are `1e-1` (more speed) or `1e-2` (more accuracy).
 
+!!! warning "Missing intensity at small quasi-particle energy"
+
+    The KPM calculation may mask intensities at small energies ``ω``. In
+    particular, such artifacts may arise near the Goldstone modes of an
+    ordered state with continuous symmetry.
+
 References:
 
  1. H. Lane et al., Kernel Polynomial Method for Linear Spin Wave Theory (2023)

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -162,7 +162,7 @@ function intensities!(data, swt_kpm::SpinWaveTheoryKPM, qpts; energies, kernel::
             # sqrt(accuracy) to reduce lingering ringing artifacts. See "AFM
             # KPM" for a test case where the smoothing degrades accuracy, and
             # "Disordered system with KPM" for an illustration of how smoothing
-            # affects intensities near the Goldstone mode.
+            # affects intensities at small ω.
             σ = sqrt(accuracy_factor) * (γ / M)
             thermal_prefactor_zero(x) = (tanh(x / σ) + 1) / 2
             f(x) = kernel(x, ω) * thermal_prefactor_zero(x)

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -227,7 +227,7 @@ end
 
 """
     intensities!(data, swt::SpinWaveTheory, qpts; energies, kernel, kT=0)
-    intensities!(data, swt::SampledCorrelations, qpts; energies, kernel=nothing, kT=0)
+    intensities!(data, sc::SampledCorrelations, qpts; energies, kernel=nothing, kT=0)
 
 Like [`intensities`](@ref), but makes use of storage space `data` to avoid
 allocation costs.
@@ -242,37 +242,36 @@ end
 
 """
     intensities(swt::SpinWaveTheory, qpts; energies, kernel, kT=0)
-    intensities(swt::SampledCorrelations, qpts; energies, kernel=nothing, kT)
+    intensities(sc::SampledCorrelations, qpts; energies, kernel=nothing, kT)
 
-Calculates pair correlation intensities for a set of ``𝐪``-points in reciprocal
-space.
+Calculates dynamical pair correlation intensities for a set of ``𝐪``-points in
+reciprocal space.
 
-Traditional spin wave theory calculations are performed with an instance of
-[`SpinWaveTheory`](@ref). One can alternatively use
-[`SpinWaveTheorySpiral`](@ref) to study generalized spiral orders with a single,
-incommensurate-``𝐤`` ordering wavevector. Another alternative is
-[`SpinWaveTheoryKPM`](@ref), which may be faster than `SpinWaveTheory` for
-calculations on large magnetic cells (e.g., to study systems with disorder). In
-spin wave theory, a nonzero temperature `kT` will scale intensities by the
-quantum thermal occupation factor ``|1 + n_B(ω)|`` where ``n_B(ω) = 1 / (exp(βω)
-- 1)`` is the Bose function.
+Linear spin wave theory calculations are performed with an instance of
+[`SpinWaveTheory`](@ref). The alternative [`SpinWaveTheorySpiral`](@ref) allows
+to study generalized spiral orders with a single, incommensurate-``𝐤`` ordering
+wavevector. Another alternative [`SpinWaveTheoryKPM`](@ref) is favorable for
+calculations on large magnetic cells, and allows to study systems with disorder.
+An optional nonzero temperature `kT` will scale intensities by the quantum
+thermal occupation factor ``|1 + n_B(ω)|`` where ``n_B(ω) = 1/(exp(βω)-1)`` is
+the Bose function.
 
 Intensities can also be calculated for `SampledCorrelations` associated with
 classical spin dynamics. In this case, thermal broadening will already be
-present, and the line-broadening `kernel` becomes an optional argument.
-Conversely, the parameter `kT` becomes required. If positive, it will introduce
-an intensity correction factor ``|βω [1 + n_B(ω)]|`` that undoes the occupation
-factor for the classical Boltzmann distribution, and applies the quantum thermal
-occupation factor. The special choice `kT = nothing` will suppress the
-classical-to-quantum correction factor, and yield statistics consistent with the
-classical Boltzmann distribution.
+present, and the line-broadening `kernel` becomes optional. Conversely, the
+parameter `kT` becomes required. If positive, it will introduce an intensity
+correction factor ``|βω [1 + n_B(ω)]|`` that undoes the occupation factor for
+the classical Boltzmann distribution and applies the quantum thermal occupation
+factor. The special choice `kT = nothing` will suppress the classical-to-quantum
+correction factor, and yield statistics consistent with the classical Boltzmann
+distribution.
 """
 function intensities(swt::AbstractSpinWaveTheory, qpts; energies, kernel::AbstractBroadening, kT=0)
     return broaden(intensities_bands(swt, qpts; kT); energies, kernel)
 end
 
 """
-    intensities_static(sc::SpinWaveTheory, qpts; bounds=(-Inf, Inf), kT=0)
+    intensities_static(swt::SpinWaveTheory, qpts; bounds=(-Inf, Inf), kT=0)
     intensities_static(sc::SampledCorrelations, qpts; bounds=(-Inf, Inf), kT)
     intensities_static(sc::SampledCorrelationsStatic, qpts)
 
@@ -281,16 +280,19 @@ Like [`intensities`](@ref), but integrates the dynamical correlations
 integration `bounds` are ``(-∞, ∞)``, yielding the instantaneous (equal-time)
 correlations.
 
-In [`SpinWaveTheory`](@ref) the integral will be realized as a sum over discrete
-bands. A [`SampledCorrelations`](@ref) object will have a finite grid of
-available `energies`, which will constrain the domain of integration. A
-[`SampledCorrelationsStatic`](@ref) object stores no dynamical data; here, the
-return value represents instantaneous correlations for the _classical_ Boltzmann
-distribution.
+In [`SpinWaveTheory`](@ref), the integral will be realized as a sum over
+discrete bands. Alternative calculation methods are
+[`SpinWaveTheorySpiral`](@ref) and [`SpinWaveTheoryKPM`](@ref).
 
-The parameter `kT` can be used to account for the quantum thermal occupation of
-excitations at finite temperature. For details, see the documentation in
+Classical dynamics data in [`SampledCorrelations`](@ref) can also be used to
+calculate static intensities. In this case, the domain of integration will be a
+finite grid of available `energies`. Here, the parameter `kT` will be used to
+account for the quantum thermal occupation of excitations, as documented in
 [`intensities`](@ref).
+
+Static intensities calculated from [`SampledCorrelationsStatic`](@ref) are
+dynamics-independent. Instead, instantaneous correlations sampled from the
+classical Boltzmann distribution will be reported.
 """
 function intensities_static(swt::AbstractSpinWaveTheory, qpts; bounds=(-Inf, Inf), kT=0)
     res = intensities_bands(swt, qpts; kT)  # TODO: with_negative=true

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -57,12 +57,9 @@ end
 
 # Returns |1 + nB(ω)| where nB(ω) = 1 / (exp(βω) - 1) is the Bose function.
 function thermal_prefactor(ω; kT)
-    if iszero(kT)
-        return iszero(ω) ? 1/2 : (ω > 0 ? 1 : 0)
-    else
-        @assert kT > 0
-        return abs(1 / (1 - exp(-ω/kT)))
-    end
+    @assert kT >= 0
+    iszero(ω) && return Inf
+    return abs(1 / (1 - exp(-ω/kT)))
 end
 
 

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -253,14 +253,14 @@ to study generalized spiral orders with a single, incommensurate-``𝐤`` orderi
 wavevector. Another alternative [`SpinWaveTheoryKPM`](@ref) is favorable for
 calculations on large magnetic cells, and allows to study systems with disorder.
 An optional nonzero temperature `kT` will scale intensities by the quantum
-thermal occupation factor ``|1 + n_B(ω)|`` where ``n_B(ω) = 1/(exp(βω)-1)`` is
+thermal occupation factor ``|1 + n_B(ω)|`` where ``n_B(ω) = 1/(e^{βω}-1)`` is
 the Bose function.
 
 Intensities can also be calculated for `SampledCorrelations` associated with
 classical spin dynamics. In this case, thermal broadening will already be
 present, and the line-broadening `kernel` becomes optional. Conversely, the
 parameter `kT` becomes required. If positive, it will introduce an intensity
-correction factor ``|βω [1 + n_B(ω)]|`` that undoes the occupation factor for
+correction factor ``|βω (1 + n_B(ω))|`` that undoes the occupation factor for
 the classical Boltzmann distribution and applies the quantum thermal occupation
 factor. The special choice `kT = nothing` will suppress the classical-to-quantum
 correction factor, and yield statistics consistent with the classical Boltzmann

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -5,7 +5,7 @@ import Statistics
 import StaticArrays: SVector, SMatrix, SArray, MVector, MMatrix, SA, @SVector
 import OffsetArrays: OffsetArray, OffsetMatrix, Origin
 import ElasticArrays: ElasticArray, resize!
-import SpecialFunctions: erfc
+import SpecialFunctions: erf, erfc
 import FFTW
 import DynamicPolynomials as DP
 import Printf: Printf, @printf, @sprintf

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -49,13 +49,12 @@ end
         q = [0.8, 0.6, 0.1]
         res = intensities_bands(swt, [q])
         energies, _ = excitations(swt, q)
-        Sunny.eigbounds(swt, q, 20; extend=0.0)
-        @test all(extrema(energies) .≈ Sunny.eigbounds(swt, q, 30; extend=0.0))
+        @test all(extrema(energies) .≈ Sunny.eigbounds(swt, q, 30))
     end
 
 end
 
-#=
+
 @testitem "AFM KPM" begin
     J, D, h = 1.0, 0.54, 0.76
     s, g = 1, -1.5
@@ -79,24 +78,24 @@ end
 
         swt = SpinWaveTheory(sys; measure=nothing)
         energies, T = excitations(swt, q)
-        extrema(energies)
         q_reshaped = Sunny.to_reshaped_rlu(sys, q)
-        bounds = Sunny.eigbounds(swt, q_reshaped, 50; extend=0.0)
+        bounds = Sunny.eigbounds(swt, q_reshaped, 50)
         @test all(extrema(energies) .≈ bounds)
 
         formfactors = [1 => FormFactor("Fe2")]
         measure = ssf_perp(sys; formfactors)
-        σ = 0.05
         swt = SpinWaveTheory(sys; measure)
-        swt_kpm = SpinWaveTheoryKPM(sys; measure, resolution=0.005, screening_factor=10)
+        swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=1e-6)
 
+        kernel = lorentzian(fwhm=0.1)
         energies = range(0, 6, 100)
         kT = 0.2
-        kernel = lorentzian(fwhm=2σ)
         res1 = intensities(swt, [q]; energies, kernel, kT)
         res2 = intensities(swt_kpm, [q]; energies, kernel, kT)
 
-        @test isapprox(res1.data, res2.data, atol=1e-3)
+        # TODO: Accuracy is very poor with Jackson kernel enabled (decreases
+        # inversely with polynomial order). But it's difficult to handle "Gibbs
+        # ringing" at Goldstone modes with Jackson kernel is disabled.
+        @test isapprox(res1.data, res2.data, rtol=1e-2)
     end
 end
-=#

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -85,17 +85,16 @@ end
         formfactors = [1 => FormFactor("Fe2")]
         measure = ssf_perp(sys; formfactors)
         swt = SpinWaveTheory(sys; measure)
-        swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=1e-6)
+        swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=1e-8)
 
         kernel = lorentzian(fwhm=0.1)
         energies = range(0, 6, 100)
-        kT = 0.2
+        kT = 0.0
         res1 = intensities(swt, [q]; energies, kernel, kT)
-        res2 = intensities(swt_kpm, [q]; energies, kernel, kT, with_jackson=false)
+        res2 = intensities(swt_kpm, [q]; energies, kernel, kT)
 
-        # TODO: Accuracy is very poor with Jackson kernel enabled (decreases
-        # inversely with polynomial order). But it's difficult to disable the
-        # Jackson kernel while avoiding "Gibbs ringing" at Goldstone modes.
+        # Note that KPM accuracy is currently limited by Gibbs ringing
+        # introduced in the thermal occupancy (Heaviside step) function.
         @test isapprox(res1.data, res2.data, rtol=1e-5)
     end
 end

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -13,11 +13,9 @@
     v = randn(N)
     ev1 = eigvals(Sunny.lanczos_ref(A*S*A, S, v; niters=10))
 
-    function mulA!(w, v)
-        w .= A * S * A * v
-    end
+    mulA!(w, v) = (w .= A * S * A * v)
     mulS!(w, v) = mul!(w, S, v)
-    ev2 = eigvals(Sunny.lanczos3(mulA!, mulS!, copy(v); niters=10))
+    ev2 = eigvals(Sunny.lanczos(mulA!, mulS!, copy(v); niters=10))
 
     @test ev1 ≈ ev2
 

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -91,11 +91,11 @@ end
         energies = range(0, 6, 100)
         kT = 0.2
         res1 = intensities(swt, [q]; energies, kernel, kT)
-        res2 = intensities(swt_kpm, [q]; energies, kernel, kT)
+        res2 = intensities(swt_kpm, [q]; energies, kernel, kT, with_jackson=false)
 
         # TODO: Accuracy is very poor with Jackson kernel enabled (decreases
-        # inversely with polynomial order). But it's difficult to handle "Gibbs
-        # ringing" at Goldstone modes with Jackson kernel is disabled.
-        @test isapprox(res1.data, res2.data, rtol=1e-2)
+        # inversely with polynomial order). But it's difficult to disable the
+        # Jackson kernel while avoiding "Gibbs ringing" at Goldstone modes.
+        @test isapprox(res1.data, res2.data, rtol=1e-5)
     end
 end

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -1,3 +1,32 @@
+@testitem "Lanczos" begin
+    using LinearAlgebra
+
+    N = 200
+    A = hermitianpart(randn(N, N))
+    A = diagm(vcat(ones(N÷2), -ones(N÷2)))
+
+    S = randn(N, N)
+    S = S' * S
+    S = S / eigmax(S)
+    S = S + 0.0I
+
+    v = randn(N)
+    ev1 = eigvals(Sunny.lanczos_ref(A*S*A, S, v; niters=10))
+
+    function mulA!(w, v)
+        w .= A * S * A * v
+    end
+    mulS!(w, v) = mul!(w, S, v)
+    ev2 = eigvals(Sunny.lanczos3(mulA!, mulS!, copy(v); niters=10))
+
+    @test ev1 ≈ ev2
+
+    ev3 = extrema(eigvals(Sunny.lanczos_ref(A*S*A, S, v; niters=100)))
+    ev4 = extrema(eigvals((A*S)^2))
+    @test isapprox(collect(ev3), collect(ev4); atol=1e-3)
+end
+
+
 @testitem "FCC KPM" begin
     using LinearAlgebra
 
@@ -28,7 +57,7 @@
 
 end
 
-
+#=
 @testitem "AFM KPM" begin
     J, D, h = 1.0, 0.54, 0.76
     s, g = 1, -1.5
@@ -72,3 +101,4 @@ end
         @test isapprox(res1.data, res2.data, atol=1e-3)
     end
 end
+=#


### PR DESCRIPTION
The new interface automatically selects the polynomial order according to the specified error tolerance. If `tol` is too high, some ringing will become visible. This is a sign that `tol` must be lowered.

In spite of the name "kernel polynomial method" (KPM), this implementation does not employ a Jackson kernel. Instead, we use simple truncation of the Chebyshev series (i.e., the "Dirichlet kernel"). For purposes of approximating relatively _smooth_ functions, this simple truncation provides accuracy that improves exponentially with the number of polynomials, `M ~ -log(tol)`.

The finite temperature Bose occupation factor has been removed for now because I haven't been able to find a good regularization strategy. At $T=0$, the Bose occupation factor becomes a step function at $\omega = 0$, and this is straightforward to regularize as a sigmoid (tanh) function. There is special logic to select a broadening width $\sigma$ that balances between (a) Capturing the large intensity near an ordering wavevector (see the new tutorial 09), but (b) not sacrificing too much accuracy in the truncated Chebyshev approximation to a step function (see the bottom of `test_kpm.jl`). A reasonable heuristic seems to be that $\sigma$ can decrease like `1 / sqrt(-log(tol))` whereas the true KPM resolution for decreases like `1/M ~ -1 / log(tol)`. In this way, decreasing `tol` improves all types of accuracy, including "ringing" artifacts from the step function, while still allowing the step function to be very sharp.

Also in this PR: Broadening kernels now keep track of additional information: the FWHM, the integral function, and a human-readable name. The line broadening integral is now used in `intensities_static` for SWT calculations.

