### PR TITLE
Warn if `set_onsite_coupling!` is called for spin `s=1/2`

### DIFF
--- a/src/System/OnsiteCoupling.jl
+++ b/src/System/OnsiteCoupling.jl
@@ -3,6 +3,11 @@ function onsite_coupling(sys, site, matrep::AbstractMatrix)
     size(matrep) == (N, N) || error("Invalid matrix size.")
     matrep ≈ matrep' || error("Operator is not Hermitian")
 
+    if N == 2 && norm(matrep) > 1e-12 && matrep ≈ matrep[1, 1] * I
+        suggest = sys.mode == :dipole ? " (use :dipole_large_s to reproduce legacy calculations)" : ""
+        @warn "Onsite coupling is always trivial for quantum spin s=1/2" * suggest
+    end
+
     if sys.mode == :SUN
         return Hermitian(matrep)
     elseif sys.mode == :dipole

--- a/src/System/OnsiteCoupling.jl
+++ b/src/System/OnsiteCoupling.jl
@@ -3,7 +3,7 @@ function onsite_coupling(sys, site, matrep::AbstractMatrix)
     size(matrep) == (N, N) || error("Invalid matrix size.")
     matrep ≈ matrep' || error("Operator is not Hermitian")
 
-    if N == 2 && norm(matrep) > 1e-12 && matrep ≈ matrep[1, 1] * I
+    if N == 2 && isapprox(matrep, matrep[1, 1] * I; atol=1e-8)
         suggest = sys.mode == :dipole ? " (use :dipole_large_s to reproduce legacy calculations)" : ""
         @warn "Onsite coupling is always trivial for quantum spin s=1/2" * suggest
     end


### PR DESCRIPTION
Quantum mechanics disallows single-ion anisotropy for quantum spin-1/2. This is because any Pauli matrix squared is the identity matrix. Sunny follows quantum mechanics, but it can be confusing to users who may be thinking of spins as classical dipole vectors. Print an informative error message if this situation is detected, and provide guidance about using `:dipole_large_s` to reproduce legacy calculations.