### PR TITLE
Remove `MVector` from intensities calls for `SampledCorrelations`

### DIFF
--- a/src/SampledCorrelations/PhaseAveraging.jl
+++ b/src/SampledCorrelations/PhaseAveraging.jl
@@ -1,21 +1,3 @@
-function phase_averaged_elements(data, q_absolute::Vec3, crystal::Crystal, ff_atoms, ::Val{NCorr}, ::Val{NAtoms}) where {NCorr, NAtoms}
-    elems = zero(MVector{NCorr,ComplexF64})
-
-    # Form factor
-    ffs = ntuple(i -> compute_form_factor(ff_atoms[i], q_absolute⋅q_absolute), Val{NAtoms}())
-
-    # Overall phase factor for each site
-    q = crystal.recipvecs \ q_absolute
-    r = crystal.positions
-    prefactor = ntuple(i -> ffs[i] * exp(- 2π*im * (q ⋅ r[i])), Val{NAtoms}())
-
-    for j in 1:NAtoms, i in 1:NAtoms
-        elems .+= (prefactor[i] * conj(prefactor[j])) .* view(data, :, i, j)
-    end
-
-    return SVector{NCorr,ComplexF64}(elems)
-end
-
 function prefactors_for_phase_averaging(q_absolute::Vec3, recipvecs, positions, ff_atoms, ::Val{NCorr}, ::Val{NAtoms}) where {NCorr, NAtoms}
     # Form factor
     ffs = ntuple(i -> compute_form_factor(ff_atoms[i], q_absolute⋅q_absolute), Val{NAtoms}())
@@ -38,12 +20,12 @@ end
 # not used, but would be employed in a parallel intensities-like pipeline for
 # error propagation.
 function error_basis_reduction(data, q_absolute::Vec3, _::Crystal, ff_atoms, ::Val{NCorr}, ::Val{NAtoms}) where {NCorr, NAtoms}
-    elems = zero(MVector{NCorr, ComplexF64})
+    elems = zero(SVector{NCorr, ComplexF64})
     ffs = ntuple(i -> compute_form_factor(ff_atoms[i], q_absolute⋅q_absolute), NAtoms)
 
     for j in 1:NAtoms, i in 1:NAtoms
-        elems .+= ffs[i] .* ffs[j] .* view(data, :, i, j)
+        elems += (ffs[i] * ffs[j]) * SVector{NCorr}(view(data, :, i, j))
     end
 
-    return SVector{NCorr,Float64}(elems / (NAtoms*NAtoms))
+    return elems / (NAtoms*NAtoms)
 end


### PR DESCRIPTION
Removed the `MVector` from the phase averaging procedure and replaced with an `SVector`. This explicitly ensures static behavior without relying on compiler optimizations. On a simple example, performance was improved by ~35%.