### PR TITLE
Add Wyckoff inference test

### DIFF
--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -397,7 +397,7 @@ function crystal_from_spacegroup(latvecs::Mat3, positions::Vector{Vec3}, types::
     wyckoffs = find_wyckoff_for_position.(Ref(sg), positions; symprec)
     orbits = crystallographic_orbits_distinct(sg.symops, positions; symprec, wyckoffs)
 
-    # Inferred orbits must match known multiplicities of the Wyckoffs
+    # Symmetry-propagated orbits must match known multiplicities of the Wyckoffs
     foreach(orbits, wyckoffs) do orbit, wyckoff
         @assert wyckoff.multiplicity ≈ length(orbit) / abs(det(sg.setting.R))
     end

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -397,11 +397,9 @@ function crystal_from_spacegroup(latvecs::Mat3, positions::Vector{Vec3}, types::
     wyckoffs = find_wyckoff_for_position.(Ref(sg), positions; symprec)
     orbits = crystallographic_orbits_distinct(sg.symops, positions; symprec, wyckoffs)
 
-    # Check that inferred orbits match known multiplicities of the Wyckoffs
+    # Inferred orbits must match known multiplicities of the Wyckoffs
     foreach(orbits, wyckoffs) do orbit, wyckoff
-        if wyckoff.multiplicity ≉ length(orbit) / abs(det(sg.setting.R))
-            error("Internal error filling Wyckoff positions! Please report this.")
-        end
+        @assert wyckoff.multiplicity ≈ length(orbit) / abs(det(sg.setting.R))
     end
 
     all_positions = reduce(vcat, orbits)

--- a/src/Symmetry/LatticeUtils.jl
+++ b/src/Symmetry/LatticeUtils.jl
@@ -61,27 +61,25 @@ function is_standard_form(latvecs::Mat3)
     return latvecs ≈ conventional_latvecs
 end
 
-"""
-    CellType
-
-An enumeration over the different types of 3D Bravais unit cells.
-"""
+# Labels for the 7 lattice systems. Note that these are subtly distinct from the
+# 7 crystal systems. In particular, the rhombohedral lattice system (a=b=c,
+# α=β=γ) should not be confused with the trigonal crystal system. Trigonal
+# spacegroups are characterized by a 3-fold rotational symmetry. All trigonal
+# spacegroups (143-167) admit a hexagonal setting. Some of these (146, 148, 155,
+# 160, 161, 166, 167) additionally admit a rhombohedral setting.
 @enum CellType begin
     triclinic
     monoclinic
     orthorhombic
     tetragonal
-    # Rhombohedral is a special case. It is a lattice type (a=b=c, α=β=γ) but
-    # not a spacegroup type. Trigonal space groups are conventionally described
-    # using either hexagonal or rhombohedral lattices.
     rhombohedral
     hexagonal
     cubic
 end
 
-# Infer the `CellType` of a unit cell from its lattice vectors, i.e. the columns
-# of `latvecs`. Report an error if the unit cell is not in conventional form,
-# which would invalidate the table of symops for a given Hall number.
+# Infer the CellType (lattice system) from lattice vectors. Report an error if
+# the unit cell is not in conventional form, which would invalidate the table of
+# symops for a given Hall number.
 function cell_type(latvecs::Mat3)
     a, b, c, α, β, γ = lattice_params(latvecs)
 
@@ -121,8 +119,7 @@ function cell_type(latvecs::Mat3)
     return triclinic
 end
 
-# Return the standard cell convention for a given Hall number using the
-# convention of spglib, listed at
+# The lattice system that is expected for a given Hall number. Taken from:
 # http://pmsl.planet.sci.kobe-u.ac.jp/~seto/?page_id=37
 function cell_type(hall_number::Int)
     if 1 <= hall_number <= 2

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -26,11 +26,23 @@
     end
     =#
 
+    # Test that the orbit of a Wyckoff matches the multiplicity data.
     for sgnum in 1:230
         sg = Sunny.Spacegroup(Sunny.standard_setting[sgnum])
         for (mult, letter, sitesym, pos) in Sunny.wyckoff_table[sgnum]
             orbit = Sunny.crystallographic_orbit(sg.symops, Sunny.WyckoffExpr(pos))
-            @assert length(orbit) == mult
+            @test length(orbit) == mult
+        end
+    end
+
+    # Test that Wyckoffs can be correctly inferred from a position
+    niters = 20
+    for sgnum in rand(1:230, niters)
+        for (_, letter, _, pos) in Sunny.wyckoff_table[sgnum]
+            w = Sunny.WyckoffExpr(pos)
+            θ = 10 * randn(3)
+            r = w.F * θ + w.c
+            @test letter == Sunny.find_wyckoff_for_position(sgnum, r; symprec=1e-8).letter
         end
     end
 end


### PR DESCRIPTION
Test that the correct Wyckoff can be inferred from a spacegroup number and position coordinates. This is a bit subtle because it requires searching over a range of possible integer offsets.