### PR TITLE
Support GLMakie precompiles on Julia 1.11.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,9 +31,9 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [extensions]
 ExportVTKExt = "WriteVTK"
-GLMakiePrecompilesExt = "GLMakie"
+GLMakiePrecompilesExt = ["Makie", "GLMakie"]
 PlottingExt = "Makie"
-WGLMakiePrecompilesExt = "WGLMakie"
+WGLMakiePrecompilesExt = ["Makie", "WGLMakie"]
 
 [compat]
 Brillouin = "0.5.19"

--- a/ext/GLMakiePrecompilesExt.jl
+++ b/ext/GLMakiePrecompilesExt.jl
@@ -3,10 +3,6 @@ module GLMakiePrecompilesExt
 import Sunny, GLMakie
 import PrecompileTools as PT
 
-# Julia 1.11.1 caused a change in the ordering of precompilation for extensions.
-# See https://github.com/JuliaLang/julia/issues/56204#issuecomment-2439588043
-@static if VERSION < v"1.11.1"
-
 PT.@setup_workload begin
     PT.@compile_workload begin
         cryst = Sunny.bcc_crystal()
@@ -20,7 +16,5 @@ PT.@setup_workload begin
         GLMakie.closeall()
     end
 end
-
-end # VERSION < v"1.11.1"
 
 end

--- a/ext/GLMakiePrecompilesExt.jl
+++ b/ext/GLMakiePrecompilesExt.jl
@@ -3,6 +3,10 @@ module GLMakiePrecompilesExt
 import Sunny, GLMakie
 import PrecompileTools as PT
 
+# Julia 1.11.1 broke extension precompiles, but this was fixed in 1.11.2.
+# https://github.com/JuliaLang/julia/issues/56204#issuecomment-2439588043
+@static if VERSION != v"1.11.1"
+
 PT.@setup_workload begin
     PT.@compile_workload begin
         cryst = Sunny.bcc_crystal()
@@ -15,6 +19,8 @@ PT.@setup_workload begin
 
         GLMakie.closeall()
     end
+end
+
 end
 
 end

--- a/ext/GLMakiePrecompilesExt.jl
+++ b/ext/GLMakiePrecompilesExt.jl
@@ -1,6 +1,6 @@
 module GLMakiePrecompilesExt
 
-import Sunny, GLMakie
+import Sunny, Makie, GLMakie
 import PrecompileTools as PT
 
 # Julia 1.11.1 broke extension precompiles, but this was fixed in 1.11.2.


### PR DESCRIPTION
The extension module GLMakiePrecompilesExt aims to precompile plotting functions for the GLMakie backend. The plotting functions themselves, however, are defined in a different extension module, PlottingExt, which is agnostic to Makie backend. This setup accidentally broke in Julia 1.11.1, which disallowed dependencies between extension modules. Hopefully there will be a solution in Julia 1.11.2, as per https://github.com/JuliaLang/julia/issues/56204#issuecomment-2442652997.

This PR makes the dependencies of GLMakiePrecompilesExt a strict superset of the dependencies of PlottingExt, so that it is safe to make GLMakiePrecompilesExt depend on PlottingExt. Enabled by https://github.com/JuliaLang/julia/pull/56368, which has now been backported to 1.11.