### PR TITLE
Update the documentation landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Sunny is inspired by SpinW, especially regarding symmetry analysis and tradition
 | [Incommensurate spiral order](https://sunnysuite.github.io/Sunny.jl/stable/examples/spinw/SW15_Ba3NbFe3Si2O14.html) | ❌ | ✅ | ✅ |
 | [Interaction renormalization](https://sunnysuite.github.io/Sunny.jl/stable/renormalization.html) | ❌ | ❌ | ✅ |
 | [Multi-flavor spin wave theory](https://sunnysuite.github.io/Sunny.jl/stable/examples/03_LSWT_SU3_FeI2.html) | ✅ | ❌ | ✅ |
-| [Arbitrary spin-multipole couplings](https://sunnysuite.github.io/Sunny.jl/stable/library.html#Sunny.set_pair_coupling!-Union{Tuple{N},%20Tuple{System{N},%20AbstractMatrix,%20Any}}%20where%20N) | ✅ | ❌ | ✅ |
+| [Arbitrary spin-multipole couplings](https://sunnysuite.github.io/Sunny.jl/stable/library.html#Sunny.set_pair_coupling!) | ✅ | ❌ | ✅ |
 | [Classical SU(_N_) spin dynamics](https://sunnysuite.github.io/Sunny.jl/stable/examples/04_GSD_FeI2.html) | ❌ | ❌ | ✅ |
 | [Linear-scaling spin wave theory](https://sunnysuite.github.io/Sunny.jl/stable/examples/09_Disorder_KPM.html) | ❌ | ❌ | ✅ |
 | [Fast long-range dipole interactions](https://sunnysuite.github.io/Sunny.jl/stable/examples/07_Dipole_Dipole.html) | ❌ | ❌ | ✅ |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Codes like [Spirit](https://github.com/spirit-code/spirit) and [Vampire](https:/
 
 ## Join our community
 
-We want to interact with you! Please **[join our Slack community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)** and say hello. If you encounter a problem with Sunny, please ask on the Slack `#helpdesk` channel or  [file a Github issue](https://github.com/SunnySuite/Sunny.jl/issues). If you use Sunny in a paper, please let us know and add it to our [Literature Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).
+We want to interact with you! Please [join our Slack community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA) and say hello. If you encounter a problem with Sunny, please ask on the Slack `#helpdesk` channel. If you use Sunny in a paper, please add it to our [Literature Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).
 
 <br>
 <div>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Codes like [Spirit](https://github.com/spirit-code/spirit) and [Vampire](https:/
 
 ## Join our community
 
-We want to interact with you! Please [join our Slack community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA) and say hello. If you encounter a problem with Sunny, please ask on the Slack `#helpdesk` channel. If you use Sunny in a paper, please add it to our [Literature Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).
+We want to interact with you! Please [join our Slack community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA) and say hello. If you encounter a problem, please ask on the Slack `#helpdesk` channel. If you use Sunny in a paper, please add it to our [Literature Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).
 
 <br>
 <div>

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -125,13 +125,13 @@ Documenter.makedocs(;
             "SpinW ports" => spinw_mds,
             "Contributed" => contributed_mds,
         ],
-        "Guides" => [
+        "library.md",
+        "Details" => [
             "structure-factor.md",
-            "parallelism.md",                        
             "renormalization.md",
+            "parallelism.md",
             # "writevtk.md",
         ],
-        "library.md",
         "versions.md",
     ],
     format = Documenter.HTML(;

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,6 @@
-# julia --project=@. --compiled-modules=existing make.jl
+#=
+julia --project=@. --compiled-modules=existing make.jl
+=#
 
 isdraft = false # set `true` to disable cell evaluation
 
@@ -117,6 +119,7 @@ Documenter.makedocs(;
     sitename = "Documentation",
     pages = [
         "index.md",
+        "why.md",
         "Examples" => [
             example_mds...,
             "SpinW ports" => spinw_mds,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -114,7 +114,7 @@ contributed_mds = isdraft ? [] : prepare_contributed()
 # Build docs as HTML, including the `examples/name.md` markdown built above
 Documenter.makedocs(;
     clean = false, # Don't wipe files in `build/assets/`
-    sitename = "Sunny documentation",
+    sitename = "Documentation",
     pages = [
         "index.md",
         "Examples" => [

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,17 +5,17 @@ magnetic phenomena from microscopic models. It also facilitates calculation of
 the dynamical spin structure factor $\mathcal{S}(𝐪,ω)$ for direct comparison to
 experimental scattering data.
 
-[**Feature highlights**](@ref "Why Choose Sunny?") include symmetry-guided
-modeling and interactive visualization. Sunny also offers novel simulation
-capabilities that reflect [theoretical advances](@ref "Advanced theory made
-accessible") in quantum magnetism.
+[_**Feature highlights**_](@ref "Why Choose Sunny?") include symmetry-guided
+modeling and interactive visualization. Sunny's novel simulation capabilities
+build on [theoretical advances](@ref "Advanced theory made accessible") in
+quantum magnetism.
 
-[**Browse the tutorials**](@ref "1. Spin wave simulations of CoRh₂O₄") to get
+[_**Browse the tutorials**_](@ref "1. Spin wave simulations of CoRh₂O₄") to get
 started. See also [SpinW ports](@ref "SW01 - FM Heisenberg chain") for
 traditional spin wave theory.
 
-[**Library Reference**](@ref "Library Reference") lists all functions and their
-doc-strings.
+[_**Library Reference**_](@ref "Library Reference") lists all functions and
+their doc-strings.
 
 We want to interact with you! Please [join our Slack
 community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,9 @@
 # Welcome
 
 [Sunny](https://github.com/SunnySuite/Sunny.jl/) provides powerful tools to
-study equilibrium and non-equilibrium magnetic phenomena. For example, it
-facilitates calculation of dynamical structure factor intensities
-$\mathcal{S}(𝐪,ω)$ that can be directly compared to experimental scattering
-data.
+simulate equilibrium and non-equilibrium magnetic phenomena from microscopic
+models. It also facilitates calculation of dynamical spin structure factors that
+can be directly compared to experimental scattering data.
 
 To get a feel for Sunny, start by browsing the [CoRh₂O₄ example](@ref "1. Spin
 wave simulations of CoRh₂O₄"). This and subsequent examples demonstrate a range
@@ -16,23 +15,29 @@ chain"), which focus on spin wave theory.
 Sunny is powerful and easy to use. Features include:
 
 - Ability to [specify a crystal](@ref Crystal) from a `.cif` file, from its
-  spacegroup and Wyckoffs, or with symmetries inferred from the chemical cell.
-  Magnetic structures [can be read](@ref set_dipoles_from_mcif!) from `.mcif`
-  files.
+  spacegroup number and representative Wyckoff positions, or from the symmetry
+  operations inferred by [spglib](https://github.com/spglib/spglib). Magnetic
+  structures [can be read](@ref set_dipoles_from_mcif!) from `.mcif` files.
 - Interactive visualization of [3D crystals](@ref view_crystal) and [magnetic
-  ordering](@ref plot_spins).
-- Symmetry analysis to [classify allowed interaction terms](@ref
-  print_symmetry_table), and to propagate them by symmetry.
-- Single-ion anisotropy at arbitrary order, which [can be specified](@ref
-  set_onsite_coupling!) using [Stevens operators](@ref stevens_matrices) or
-  [spin polynomials](@ref spin_matrices). Arbitrary coupling between spin
-  multipoles is [also allowed](@ref set_pair_coupling!).
+  structures](@ref plot_spins).
+- Symmetry analysis to determine [allowed anisotropies and interaction
+  terms](@ref print_symmetry_table), and to propagate them by symmetry.
+- Single-ion anisotropy [can be specified](@ref set_onsite_coupling!) using
+  either [Stevens operators](@ref stevens_matrices) or [spin polynomials](@ref
+  spin_matrices). Arbitrary coupling between spin multipoles is [also
+  supported](@ref set_pair_coupling!). Classical-to-quantum [renormalization
+  factors](@ref "Interaction Renormalization") are included to enhance fidelity.
+- [Fast optimization](@ref minimize_energy!) of magnetic structures using
+  supercells or the propagation vector formalism.
 - Statistical sampling of spins in thermal equilibrium using [Langevin
-  dynamics](@ref Langevin) and [local Monte Carlo updates](@ref LocalSampler).
-- [Fast optimization](@ref minimize_energy!) of the magnetic ground state.
-- Support for non-equilibrium spin dynamics, with [generalization to spin
-  multipoles](@ref "6. Dynamical quench into CP² skyrmion liquid") via the
-  theory of [SU(_N_) coherent states](https://arxiv.org/abs/2209.01265).
+  dynamics](@ref Langevin) or [local Monte Carlo updates](@ref LocalSampler).
+  Advanced Monte Carlo methods such as [parallel
+  tempering](https://github.com/SunnySuite/Sunny.jl/tree/main/examples/extra/Advanced_MC)
+  are effective for simulations of classical spin liquids and frustrated
+  magnetism.
+- [Non-equilibrium spin dynamics](@ref "6. Dynamical quench into CP² skyrmion
+  liquid") with generalization to arbitrary spin multipoles via the theory of
+  [SU(_N_) coherent states](https://arxiv.org/abs/2209.01265).
 - Dynamical correlation measurement via [linear spin wave theory](@ref
   SpinWaveTheory) and its multi-boson generalization. Special support is
   provided for calculations on [incommensurate spiral phases](@ref
@@ -43,9 +48,9 @@ Sunny is powerful and easy to use. Features include:
 - Long-range [dipole-dipole interactions](@ref enable_dipole_dipole!)
   accelerated with the fast Fourier transform (FFT).
 - Conveniences for comparing to experimental data: [form factors](@ref
-  FormFactor), [custom spin contractions](@ref ssf_custom_bm),
-  classical-to-quantum [renormalization factors](@ref "Interaction
-  Renormalization"), etc.
+  FormFactor), [custom spin contractions](@ref ssf_custom_bm), averaging over
+  [powder](@ref powder_average) and [domain orientations](@ref domain_average)
+  etc.
 
 ## Join our community
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,23 +1,22 @@
 # Welcome
 
-[Sunny](https://github.com/SunnySuite/Sunny.jl/) provides powerful tools to
-simulate equilibrium and non-equilibrium magnetic phenomena from microscopic
-models. It also facilitates calculation of the dynamical spin structure factor
-$\mathcal{S}(𝐪,ω)$ for direct comparison to experimental scattering data.
+Sunny provides powerful tools to simulate equilibrium and non-equilibrium
+magnetic phenomena from microscopic models. It also facilitates calculation of
+the dynamical spin structure factor $\mathcal{S}(𝐪,ω)$ for direct comparison to
+experimental scattering data.
 
 [Why Choose Sunny?](@ref) lists feature highlights. The design of Sunny is
 closely tied to our team's [theoretical advances](@ref "Advanced theory made
 accessible") in quantum magnetism.
 
-Learn by browsing the [CoRh₂O₄ tutorial](@ref "1. Spin wave simulations of
-CoRh₂O₄") and subsequent ones. See also the [SpinW ports](@ref "SW01 - FM
-Heisenberg chain") for traditional spin wave theory.
+[Browse the tutorials](@ref "1. Spin wave simulations of CoRh₂O₄") to get
+started. See also [SpinW ports](@ref "SW01 - FM Heisenberg chain") for
+traditional spin wave theory.
 
-The [Library Reference](@ref) lists all functions and their doc-strings.
+[Library Reference](@ref) lists all functions and their doc-strings.
 
 We want to interact with you! Please [join our Slack
 community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)
-and say hello. If you encounter a problem with Sunny, please ask on the Slack
-`#helpdesk` channel. If you use Sunny in a paper, please add it to our
-[Literature
+and say hello. If you encounter a problem, please ask on the Slack `#helpdesk`
+channel. If you use Sunny in a paper, please add it to our [Literature
 Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature#applications).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,13 +15,14 @@ chain"), which focus on spin wave theory.
 Sunny is powerful and easy to use. Features include:
 
 - Ability to [specify a crystal](@ref Crystal) from a `.cif` file, from its
-  spacegroup number and representative Wyckoff positions, or from the symmetry
-  operations inferred by [spglib](https://github.com/spglib/spglib). Magnetic
-  structures [can be read](@ref set_dipoles_from_mcif!) from `.mcif` files.
+  spacegroup number and representative Wyckoff positions, or from automatically
+  inferred symmetry operations. Magnetic structures [can be read](@ref
+  set_dipoles_from_mcif!) from `.mcif` files.
 - Interactive visualization of [3D crystals](@ref view_crystal) and [magnetic
   structures](@ref plot_spins).
 - Symmetry analysis to determine [allowed anisotropies and interaction
-  terms](@ref print_symmetry_table), and to propagate them by symmetry.
+  terms](@ref print_symmetry_table), and to propagate them by symmetry
+  equivalence.
 - Single-ion anisotropy [can be specified](@ref set_onsite_coupling!) using
   either [Stevens operators](@ref stevens_matrices) or [spin polynomials](@ref
   spin_matrices). Arbitrary coupling between spin multipoles is [also

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,82 +5,17 @@ simulate equilibrium and non-equilibrium magnetic phenomena from microscopic
 models. It also facilitates calculation of the dynamical spin structure factor
 $\mathcal{S}(𝐪,ω)$ for direct comparison to experimental scattering data.
 
-To get a feel for Sunny, start by browsing the [CoRh₂O₄ example](@ref "1. Spin
-wave simulations of CoRh₂O₄"). This and subsequent examples demonstrate a range
-of Sunny features. See also the [SpinW ports](@ref "SW01 - FM Heisenberg
-chain"), which focus on traditional spin wave theory.
+See [Why Choose Sunny?](@ref) for feature highlights. The design of Sunny is
+closely tied to [theoretical advances](@ref "Advanced theory made accessible")
+that offer a new perspective on quantum magnetism.
 
-## Why choose Sunny?
+Learn Sunny by browsing the [CoRh₂O₄ tutorial](@ref "1. Spin wave simulations of
+CoRh₂O₄") and subsequent ones. See also the [SpinW ports](@ref "SW01 - FM
+Heisenberg chain") for traditional spin wave theory.
 
-Sunny is powerful and easy to use. Features include:
+The [Library Reference](@ref) lists all functions and their doc-strings.
 
-- Ability to [specify a crystal](@ref Crystal) from a `.cif` file, from its
-  spacegroup number and representative Wyckoff positions, or from automatically
-  inferred symmetry operations. Magnetic structures [can be read](@ref
-  set_dipoles_from_mcif!) from `.mcif` files.
-- Interactive visualization of [3D crystals](@ref view_crystal) and [magnetic
-  structures](@ref plot_spins).
-- Symmetry analysis to determine [allowed anisotropies and interaction
-  terms](@ref print_symmetry_table), and to propagate them by symmetry
-  equivalence.
-- Single-ion anisotropy [can be specified](@ref set_onsite_coupling!) using
-  either [Stevens operators](@ref stevens_matrices) or [spin polynomials](@ref
-  spin_matrices). Arbitrary coupling between spin multipoles is [also
-  supported](@ref set_pair_coupling!). Classical-to-quantum [renormalization
-  factors](@ref "Interaction Renormalization") enhance fidelity.
-- [Fast optimization](@ref minimize_energy!) of magnetic structures using
-  supercells or the [propagation vector formalism](@ref
-  minimize_spiral_energy!).
-- Statistical sampling of spins in thermal equilibrium using [Langevin
-  dynamics](@ref Langevin) or [local Monte Carlo updates](@ref LocalSampler).
-  Advanced Monte Carlo methods such as [parallel
-  tempering](https://github.com/SunnySuite/Sunny.jl/tree/main/examples/extra/Advanced_MC)
-  are effective for simulations of classical spin liquids and frustrated
-  magnetism.
-- Classical spin dynamics with generalization to spin multipoles via the theory
-  of SU(_N_) coherent states. This allows for the measurement of [dynamical
-  correlations at finite temperature](@ref SampledCorrelations), and the study of
-  [highly nonequilibrium phenomena](@ref "6. Dynamical quench into CP² skyrmion
-  liquid").
-- Generalized [linear spin wave theory](@ref SpinWaveTheory) for low-temperature
-  spin dynamics. Special support is provided for calculations on [incommensurate
-  spiral phases](@ref SpinWaveTheorySpiral) and on [large, disordered magnetic
-  cells](@ref SpinWaveTheoryKPM). See also the [FeI₂ example](@ref "3.
-  Multi-flavor spin wave simulations of FeI₂") as a showcase of LSWT with
-  multi-flavor bosons.
-- Long-range [dipole-dipole interactions](@ref enable_dipole_dipole!)
-  accelerated with the fast Fourier transform (FFT).
-- Tools for comparing to experimental data: [form factors](@ref FormFactor),
-  [custom spin contractions](@ref ssf_custom_bm), averaging over [powder](@ref
-  powder_average) and [domain orientations](@ref domain_average), etc.
-
-## Advanced theory made accessible
-
-Sunny is also a platform for [disseminating foundational
-advances](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature#methods)
-in quantum magnetism and computational methods. The theory of [SU(_N_) coherent
-states](https://doi.org/10.1103/PhysRevB.104.104409) offers a group theoretic
-framework to formulate alternative classical limits of a microscopic quantum
-model. [New algorithms](https://doi.org/10.1103/PhysRevB.106.235154) enable
-highly efficient simulation of spin-multipoles and beyond. For reasons not fully
-understood, such classical limits can be [remarkably accurate at finite
-temperatures](https://doi.org/10.1103/PhysRevB.109.014427) when used in
-conjunction with appropriate renormalization schemes. The SU(_N_) picture also
-suggests new geometric interpretations of quantum spin. This leads to a [deeper
-understanding](https://arxiv.org/abs/2304.03874) of existing renormalization
-schemes for traditional spin wave theory, and suggests a whole landscape in
-which to search for novel topological states, [e.g. CP²
-skyrmions](https://doi.org/10.1038/s41467-023-39232-8). Ongoing Sunny research
-aims to incorporate more quantum entanglement into the classical picture. Local
-units of strongly entangled spins will soon be supported and show great promise
-for cases like [dimerized ladders](https://doi.org/10.1103/PhysRevB.110.104403).
-Longer term, Sunny also aims to include perturbative corrections beyond linear
-spin wave theory, as well as a non-perturbative treatment of quantum bound
-states.
-
-## Join our community
-
-We want to interact with you! Please [join our Slack
+If you use Sunny, we want to interact with you! Please [join our Slack
 community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)
 and say hello. If you encounter a problem with Sunny, please ask on the Slack
 `#helpdesk` channel. If you use Sunny in a paper, please add it to our

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,8 +2,8 @@
 
 [Sunny](https://github.com/SunnySuite/Sunny.jl/) provides powerful tools to
 simulate equilibrium and non-equilibrium magnetic phenomena from microscopic
-models. It also facilitates calculation of dynamical spin structure factors that
-can be directly compared to experimental scattering data.
+models. It also facilitates calculation of the dynamical spin structure factor
+$\mathcal{S}(𝐪,ω)$ for direct comparison to experimental scattering data.
 
 To get a feel for Sunny, start by browsing the [CoRh₂O₄ example](@ref "1. Spin
 wave simulations of CoRh₂O₄"). This and subsequent examples demonstrate a range

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,18 +5,19 @@ magnetic phenomena from microscopic models. It also facilitates calculation of
 the dynamical spin structure factor $\mathcal{S}(𝐪,ω)$ for direct comparison to
 experimental scattering data.
 
-[Why Choose Sunny?](@ref) lists feature highlights. The design of Sunny is
-closely tied to our team's [theoretical advances](@ref "Advanced theory made
-accessible") in quantum magnetism.
+[**Feature highlights**](@ref "Why Choose Sunny?") include symmetry-guided modeling
+and interactive visualization. Sunny also offers novel simulation capabilities
+that reflect [theoretical advances](@ref "Advanced theory made accessible") in
+quantum magnetism.
 
-[Browse the tutorials](@ref "1. Spin wave simulations of CoRh₂O₄") to get
+[**Browse the tutorials**](@ref "1. Spin wave simulations of CoRh₂O₄") to get
 started. See also [SpinW ports](@ref "SW01 - FM Heisenberg chain") for
 traditional spin wave theory.
 
-[Library Reference](@ref) lists all functions and their doc-strings.
+[**Library Reference**](@ref) lists all functions and their doc-strings.
 
 We want to interact with you! Please [join our Slack
 community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)
 and say hello. If you encounter a problem, please ask on the Slack `#helpdesk`
 channel. If you use Sunny in a paper, please add it to our [Literature
-Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature#applications).
+Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,28 +56,27 @@ Sunny is powerful and easy to use. Features include:
 
 ## Advanced theory made accessible
 
-Sunny also serves as a platform for [disseminating foundational
+Sunny is also a platform for [disseminating foundational
 advances](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature#methods)
-in quantum magnetism and computational methods. Sunny builds on the theory of
-[SU(_N_) coherent states](https://doi.org/10.1103/PhysRevB.104.104409), which
-offers a group theoretic framework to formulate alternative classical limits of
-a microscopic quantum model. Sunny also introduces [highly efficient
-algorithms](https://doi.org/10.1103/PhysRevB.106.235154) for simulating the
-coupled dynamics of quantum spin-multipoles. For reasons not fully understood,
-classical dynamics can be [remarkably accurate at finite
+in quantum magnetism and computational methods. The theory of [SU(_N_) coherent
+states](https://doi.org/10.1103/PhysRevB.104.104409) offers a group theoretic
+framework to formulate alternative classical limits of a microscopic quantum
+model. [New algorithms](https://doi.org/10.1103/PhysRevB.106.235154) enable
+highly efficient simulation of spin-multipoles and beyond. For reasons not fully
+understood, such classical limits can be [remarkably accurate at finite
 temperatures](https://doi.org/10.1103/PhysRevB.109.014427) when used in
 conjunction with appropriate renormalization schemes. The SU(_N_) picture also
 suggests new geometric interpretations of quantum spin. This leads to a [deeper
 understanding](https://arxiv.org/abs/2304.03874) of existing renormalization
-schemes for traditional spin wave theory, and suggests a new landscape to search
-novel topological states [such as CP²
+schemes for traditional spin wave theory, and suggests a whole landscape in
+which to search for novel topological states, [e.g. CP²
 skyrmions](https://doi.org/10.1038/s41467-023-39232-8). Ongoing Sunny research
 aims to incorporate more quantum entanglement into the classical picture. Local
 units of strongly entangled spins will soon be supported and show great promise
 for cases like [dimerized ladders](https://doi.org/10.1103/PhysRevB.110.104403).
-In the medium term, Sunny also aims to include perturbative corrections beyond
-linear spin wave theory, as well as a non-perturbative treatment of quantum
-bound states.
+Longer term, Sunny also aims to include perturbative corrections beyond linear
+spin wave theory, as well as a non-perturbative treatment of quantum bound
+states.
 
 ## Join our community
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,20 +1,30 @@
-# A toolkit for atomic scale magnetism
+# Welcome
 
 [Sunny](https://github.com/SunnySuite/Sunny.jl/) provides powerful tools to
-study equilibrium and non-equilibrium magnetic phenomena. In particular, it
-allows estimation of dynamical structure factor intensities,
-$\mathcal{S}(𝐪,ω)$, to support quantitative modeling of experimental scattering
+study equilibrium and non-equilibrium magnetic phenomena. For example, it
+facilitates calculation of dynamical structure factor intensities
+$\mathcal{S}(𝐪,ω)$ that can be directly compared to experimental scattering
 data.
 
-## Start with the examples
+## Look around
 
-[The examples](@ref "1. Spin wave simulations of CoRh₂O₄") teach Sunny concepts
-in a progressive way. See also the [SpinW ports](@ref "SW01 - FM Heisenberg
-chain") for a focus on traditional spin wave theory.
+A good place to start is the [CoRh₂O₄ example](@ref "1. Spin wave simulations of
+CoRh₂O₄"). This and subsequent tutorials demonstrate a range of Sunny features.
+One can also browse the [SpinW ports](@ref "SW01 - FM Heisenberg chain"), which
+focus on spin wave theory.
+
+## Join our community
+
+We want to interact with you! Please [join our Slack
+community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)
+and say hello. If you encounter a problem with Sunny, please ask on the Slack
+`#helpdesk` channel. If you use Sunny in a paper, please add it to our
+[Literature Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).
+
 
 ## Why choose Sunny?
 
-Sunny is both powerful and easy to use. Features include:
+Sunny is powerful and easy to use. Features include:
 
 - Ability to [specify a crystal](@ref Crystal) from a `.cif` file, from its
   spacegroup and Wyckoffs, or with symmetries inferred from the chemical cell.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ $\mathcal{S}(𝐪,ω)$ for direct comparison to experimental scattering data.
 To get a feel for Sunny, start by browsing the [CoRh₂O₄ example](@ref "1. Spin
 wave simulations of CoRh₂O₄"). This and subsequent examples demonstrate a range
 of Sunny features. See also the [SpinW ports](@ref "SW01 - FM Heisenberg
-chain"), which focus on spin wave theory.
+chain"), which focus on traditional spin wave theory.
 
 ## Why choose Sunny?
 
@@ -27,7 +27,7 @@ Sunny is powerful and easy to use. Features include:
   either [Stevens operators](@ref stevens_matrices) or [spin polynomials](@ref
   spin_matrices). Arbitrary coupling between spin multipoles is [also
   supported](@ref set_pair_coupling!). Classical-to-quantum [renormalization
-  factors](@ref "Interaction Renormalization") are included to enhance fidelity.
+  factors](@ref "Interaction Renormalization") enhance fidelity.
 - [Fast optimization](@ref minimize_energy!) of magnetic structures using
   supercells or the [propagation vector formalism](@ref
   minimize_spiral_energy!).
@@ -37,21 +37,47 @@ Sunny is powerful and easy to use. Features include:
   tempering](https://github.com/SunnySuite/Sunny.jl/tree/main/examples/extra/Advanced_MC)
   are effective for simulations of classical spin liquids and frustrated
   magnetism.
-- [Non-equilibrium spin dynamics](@ref "6. Dynamical quench into CP² skyrmion
-  liquid") with generalization to arbitrary spin multipoles via the theory of
-  [SU(_N_) coherent states](https://arxiv.org/abs/2209.01265).
-- Dynamical correlation measurement via [linear spin wave theory](@ref
-  SpinWaveTheory) and its multi-boson generalization. Special support is
-  provided for calculations on [incommensurate spiral phases](@ref
-  SpinWaveTheorySpiral) and on [large, disordered magnetic cells](@ref
-  SpinWaveTheoryKPM). At finite temperatures, one can use classical dynamics to
-  [sample dynamical correlations](@ref SampledCorrelations) with strong
-  nonlinearities.
+- Classical spin dynamics with generalization to spin multipoles via the theory
+  of SU(_N_) coherent states. This allows for the measurement of [dynamical
+  correlations at finite temperature](@ref SampledCorrelations), and the study of
+  [highly nonequilibrium phenomena](@ref "6. Dynamical quench into CP² skyrmion
+  liquid").
+- [Linear spin wave theory](@ref SpinWaveTheory) for low-temperature spin
+  dynamics. Special support is provided for calculations on [incommensurate
+  spiral phases](@ref SpinWaveTheorySpiral) and on [large, disordered magnetic
+  cells](@ref SpinWaveTheoryKPM). See also the [FeI₂ example](@ref "3.
+  Multi-flavor spin wave simulations of FeI₂") as a showcase of LSWT with
+  multi-flavor bosons.
 - Long-range [dipole-dipole interactions](@ref enable_dipole_dipole!)
   accelerated with the fast Fourier transform (FFT).
 - Tools for comparing to experimental data: [form factors](@ref FormFactor),
   [custom spin contractions](@ref ssf_custom_bm), averaging over [powder](@ref
   powder_average) and [domain orientations](@ref domain_average), etc.
+
+## Advanced theory made accessible
+
+Sunny also serves as a platform for [disseminating foundational
+advances](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature#methods)
+in quantum magnetism and computational methods. Sunny builds on the theory of
+[SU(_N_) coherent states](https://doi.org/10.1103/PhysRevB.104.104409), which
+offers a group theoretic framework to formulate alternative classical limits of
+a microscopic quantum model. Sunny also introduces [highly efficient
+algorithms](https://doi.org/10.1103/PhysRevB.106.235154) for simulating the
+coupled dynamics of quantum spin-multipoles. For reasons not fully understood,
+classical dynamics can be [remarkably accurate at finite
+temperatures](https://doi.org/10.1103/PhysRevB.109.014427) when used in
+conjunction with appropriate renormalization schemes. The SU(_N_) picture also
+suggests new geometric interpretations of quantum spin. This leads to a [deeper
+understanding](https://arxiv.org/abs/2304.03874) of existing renormalization
+schemes for traditional spin wave theory, and suggests a new landscape to search
+novel topological states [such as CP²
+skyrmions](https://doi.org/10.1038/s41467-023-39232-8). Ongoing Sunny research
+aims to incorporate more quantum entanglement into the classical picture. Local
+units of strongly entangled spins will soon be supported and show great promise
+for cases like [dimerized ladders](https://doi.org/10.1103/PhysRevB.110.104403).
+In the medium term, Sunny also aims to include perturbative corrections beyond
+linear spin wave theory, as well as a non-perturbative treatment of quantum
+bound states.
 
 ## Join our community
 
@@ -59,4 +85,5 @@ We want to interact with you! Please [join our Slack
 community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)
 and say hello. If you encounter a problem with Sunny, please ask on the Slack
 `#helpdesk` channel. If you use Sunny in a paper, please add it to our
-[Literature Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).
+[Literature
+Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature#applications).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,10 @@
-# Overview
+# A toolkit for atomic scale magnetism
 
-[Sunny](https://github.com/SunnySuite/Sunny.jl/) is a Julia package for modeling
-atomic-scale magnetism. It provides powerful tools to study equilibrium and
-non-equilibrium magnetic phenomena. In particular, it allows estimation of
-dynamical structure factor intensities, $\mathcal{S}(𝐪,ω)$, to support
-quantitative modeling of experimental scattering data.
+[Sunny](https://github.com/SunnySuite/Sunny.jl/) provides powerful tools to
+study equilibrium and non-equilibrium magnetic phenomena. In particular, it
+allows estimation of dynamical structure factor intensities,
+$\mathcal{S}(𝐪,ω)$, to support quantitative modeling of experimental scattering
+data.
 
 ## Start with the examples
 
@@ -12,7 +12,7 @@ quantitative modeling of experimental scattering data.
 in a progressive way. See also the [SpinW ports](@ref "SW01 - FM Heisenberg
 chain") for a focus on traditional spin wave theory.
 
-## Why use Sunny?
+## Why choose Sunny?
 
 Sunny is both powerful and easy to use. Features include:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,9 +6,8 @@ the dynamical spin structure factor $\mathcal{S}(𝐪,ω)$ for direct comparison
 experimental scattering data.
 
 [_**Feature highlights**_](@ref "Why Choose Sunny?") include symmetry-guided
-modeling and interactive visualization. Sunny's simulation capabilities build on
-[theoretical advances](@ref "Advanced theory made accessible") in quantum
-magnetism.
+modeling, interactive visualization, and more accurate approximations to quantum
+spin dynamics.
 
 [_**Browse the tutorials**_](@ref "1. Spin wave simulations of CoRh₂O₄") to get
 started. See also [SpinW ports](@ref "SW01 - FM Heisenberg chain") for

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,10 +5,10 @@ magnetic phenomena from microscopic models. It also facilitates calculation of
 the dynamical spin structure factor $\mathcal{S}(𝐪,ω)$ for direct comparison to
 experimental scattering data.
 
-[**Feature highlights**](@ref "Why Choose Sunny?") include symmetry-guided modeling
-and interactive visualization. Sunny also offers novel simulation capabilities
-that reflect [theoretical advances](@ref "Advanced theory made accessible") in
-quantum magnetism.
+[**Feature highlights**](@ref "Why Choose Sunny?") include symmetry-guided
+modeling and interactive visualization. Sunny also offers novel simulation
+capabilities that reflect [theoretical advances](@ref "Advanced theory made
+accessible") in quantum magnetism.
 
 [**Browse the tutorials**](@ref "1. Spin wave simulations of CoRh₂O₄") to get
 started. See also [SpinW ports](@ref "SW01 - FM Heisenberg chain") for

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,12 +6,10 @@ facilitates calculation of dynamical structure factor intensities
 $\mathcal{S}(𝐪,ω)$ that can be directly compared to experimental scattering
 data.
 
-## Look around
-
-A good place to start is the [CoRh₂O₄ example](@ref "1. Spin wave simulations of
-CoRh₂O₄"). This and subsequent tutorials demonstrate a range of Sunny features.
-One can also browse the [SpinW ports](@ref "SW01 - FM Heisenberg chain"), which
-focus on spin wave theory.
+To get a feel for Sunny, start by browsing the [CoRh₂O₄ example](@ref "1. Spin
+wave simulations of CoRh₂O₄"). This and subsequent examples demonstrate a range
+of Sunny features. See also the [SpinW ports](@ref "SW01 - FM Heisenberg
+chain"), which focus on spin wave theory.
 
 ## Why choose Sunny?
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,24 +6,44 @@ non-equilibrium magnetic phenomena. In particular, it allows estimation of
 dynamical structure factor intensities, $\mathcal{S}(𝐪,ω)$, to support
 quantitative modeling of experimental scattering data.
 
-**Features include**:
+## Start with the examples
 
-- Generalized spin dynamics using [SU(_N_) coherent
-  states](https://arxiv.org/abs/2209.01265).
-- Ability to specify a crystal from a `.cif` file or its spacegroup symmetry.
-  Magnetic structures can be read from `.mcif` files.
-- Interactive visualizations of the 3D crystals and magnetic ordering.
-- Symmetry analysis to classify allowed interaction terms, and to propagate them
-  by symmetry.
-- Single-ion anisotropy at arbitrary order, which can be specified using Stevens
-  operators or as a polynomial of spin operators.
-- Monte Carlo sampling of spin configurations in thermal equilibrium, and
-  optimization tools.
-- Measurements of dynamical correlations. At low temperature, one can use linear
-  spin wave theory and its multi-boson generalization. This generalizes to
-  finite temperatures using the classical dynamics, which allows for strongly
-  nonlinear effects.
-- Long-range dipole-dipole interactions accelerated with the fast Fourier
-  transform (FFT).
-- Support for comparison with experimental data: form factor, dipole factor,
-  temperature-dependent classical-to-quantum factors, etc.
+[The examples](@ref "1. Spin wave simulations of CoRh₂O₄") teach Sunny concepts
+in a progressive way. See also the [SpinW ports](@ref "SW01 - FM Heisenberg
+chain") for a focus on traditional spin wave theory.
+
+## Why use Sunny?
+
+Sunny is both powerful and easy to use. Features include:
+
+- Ability to [specify a crystal](@ref Crystal) from a `.cif` file, from its
+  spacegroup and Wyckoffs, or with symmetries inferred from the chemical cell.
+  Magnetic structures [can be read](@ref set_dipoles_from_mcif!) from `.mcif`
+  files.
+- Interactive visualization of [3D crystals](@ref view_crystal) and [magnetic
+  ordering](@ref plot_spins).
+- Symmetry analysis to [classify allowed interaction terms](@ref
+  print_symmetry_table), and to propagate them by symmetry.
+- Single-ion anisotropy at arbitrary order, which [can be specified](@ref
+  set_onsite_coupling!) using [Stevens operators](@ref stevens_matrices) or
+  [spin polynomials](@ref spin_matrices). Arbitrary coupling between spin
+  multipoles is [also allowed](@ref set_pair_coupling!).
+- Statistical sampling of spins in thermal equilibrium using [Langevin
+  dynamics](@ref Langevin) and [local Monte Carlo updates](@ref LocalSampler).
+- [Fast optimization](@ref minimize_energy!) of the magnetic ground state.
+- Support for non-equilibrium spin dynamics, with [generalization to spin
+  multipoles](@ref "6. Dynamical quench into CP² skyrmion liquid") via the
+  theory of [SU(_N_) coherent states](https://arxiv.org/abs/2209.01265).
+- Dynamical correlation measurement via [linear spin wave theory](@ref
+  SpinWaveTheory) and its multi-boson generalization. Special support is
+  provided for calculations on [incommensurate spiral phases](@ref
+  SpinWaveTheorySpiral) and on [large, disordered magnetic cells](@ref
+  SpinWaveTheoryKPM). At finite temperatures, one can use classical dynamics to
+  [sample dynamical correlations](@ref SampledCorrelations) with strong
+  nonlinearities.
+- Long-range [dipole-dipole interactions](@ref enable_dipole_dipole!)
+  accelerated with the fast Fourier transform (FFT).
+- Conveniences for comparing to experimental data: [form factors](@ref
+  FormFactor), [custom spin contractions](@ref ssf_custom_bm),
+  classical-to-quantum [renormalization factors](@ref "Interaction
+  Renormalization"), etc.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,8 +6,8 @@ models. It also facilitates calculation of the dynamical spin structure factor
 $\mathcal{S}(𝐪,ω)$ for direct comparison to experimental scattering data.
 
 See [Why Choose Sunny?](@ref) for feature highlights. The design of Sunny is
-closely tied to [theoretical advances](@ref "Advanced theory made accessible")
-that offer a new perspective on quantum magnetism.
+closely tied to our team's [theoretical advances](@ref "Advanced theory made
+accessible") in quantum magnetism.
 
 Learn Sunny by browsing the [CoRh₂O₄ tutorial](@ref "1. Spin wave simulations of
 CoRh₂O₄") and subsequent ones. See also the [SpinW ports](@ref "SW01 - FM

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,8 @@ Sunny is powerful and easy to use. Features include:
   supported](@ref set_pair_coupling!). Classical-to-quantum [renormalization
   factors](@ref "Interaction Renormalization") are included to enhance fidelity.
 - [Fast optimization](@ref minimize_energy!) of magnetic structures using
-  supercells or the propagation vector formalism.
+  supercells or the [propagation vector formalism](@ref
+  minimize_spiral_energy!).
 - Statistical sampling of spins in thermal equilibrium using [Langevin
   dynamics](@ref Langevin) or [local Monte Carlo updates](@ref LocalSampler).
   Advanced Monte Carlo methods such as [parallel
@@ -48,10 +49,9 @@ Sunny is powerful and easy to use. Features include:
   nonlinearities.
 - Long-range [dipole-dipole interactions](@ref enable_dipole_dipole!)
   accelerated with the fast Fourier transform (FFT).
-- Conveniences for comparing to experimental data: [form factors](@ref
-  FormFactor), [custom spin contractions](@ref ssf_custom_bm), averaging over
-  [powder](@ref powder_average) and [domain orientations](@ref domain_average)
-  etc.
+- Tools for comparing to experimental data: [form factors](@ref FormFactor),
+  [custom spin contractions](@ref ssf_custom_bm), averaging over [powder](@ref
+  powder_average) and [domain orientations](@ref domain_average), etc.
 
 ## Join our community
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,8 +42,8 @@ Sunny is powerful and easy to use. Features include:
   correlations at finite temperature](@ref SampledCorrelations), and the study of
   [highly nonequilibrium phenomena](@ref "6. Dynamical quench into CP² skyrmion
   liquid").
-- [Linear spin wave theory](@ref SpinWaveTheory) for low-temperature spin
-  dynamics. Special support is provided for calculations on [incommensurate
+- Generalized [linear spin wave theory](@ref SpinWaveTheory) for low-temperature
+  spin dynamics. Special support is provided for calculations on [incommensurate
   spiral phases](@ref SpinWaveTheorySpiral) and on [large, disordered magnetic
   cells](@ref SpinWaveTheoryKPM). See also the [FeI₂ example](@ref "3.
   Multi-flavor spin wave simulations of FeI₂") as a showcase of LSWT with

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,9 +6,9 @@ the dynamical spin structure factor $\mathcal{S}(𝐪,ω)$ for direct comparison
 experimental scattering data.
 
 [_**Feature highlights**_](@ref "Why Choose Sunny?") include symmetry-guided
-modeling and interactive visualization. Sunny's novel simulation capabilities
-build on [theoretical advances](@ref "Advanced theory made accessible") in
-quantum magnetism.
+modeling and interactive visualization. Sunny's simulation capabilities build on
+[theoretical advances](@ref "Advanced theory made accessible") in quantum
+magnetism.
 
 [_**Browse the tutorials**_](@ref "1. Spin wave simulations of CoRh₂O₄") to get
 started. See also [SpinW ports](@ref "SW01 - FM Heisenberg chain") for

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,15 +13,6 @@ CoRh₂O₄"). This and subsequent tutorials demonstrate a range of Sunny featur
 One can also browse the [SpinW ports](@ref "SW01 - FM Heisenberg chain"), which
 focus on spin wave theory.
 
-## Join our community
-
-We want to interact with you! Please [join our Slack
-community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)
-and say hello. If you encounter a problem with Sunny, please ask on the Slack
-`#helpdesk` channel. If you use Sunny in a paper, please add it to our
-[Literature Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).
-
-
 ## Why choose Sunny?
 
 Sunny is powerful and easy to use. Features include:
@@ -57,3 +48,11 @@ Sunny is powerful and easy to use. Features include:
   FormFactor), [custom spin contractions](@ref ssf_custom_bm),
   classical-to-quantum [renormalization factors](@ref "Interaction
   Renormalization"), etc.
+
+## Join our community
+
+We want to interact with you! Please [join our Slack
+community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)
+and say hello. If you encounter a problem with Sunny, please ask on the Slack
+`#helpdesk` channel. If you use Sunny in a paper, please add it to our
+[Literature Wiki](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,7 +14,8 @@ accessible") in quantum magnetism.
 started. See also [SpinW ports](@ref "SW01 - FM Heisenberg chain") for
 traditional spin wave theory.
 
-[**Library Reference**](@ref) lists all functions and their doc-strings.
+[**Library Reference**](@ref "Library Reference") lists all functions and their
+doc-strings.
 
 We want to interact with you! Please [join our Slack
 community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,17 +5,17 @@ simulate equilibrium and non-equilibrium magnetic phenomena from microscopic
 models. It also facilitates calculation of the dynamical spin structure factor
 $\mathcal{S}(𝐪,ω)$ for direct comparison to experimental scattering data.
 
-See [Why Choose Sunny?](@ref) for feature highlights. The design of Sunny is
+[Why Choose Sunny?](@ref) lists feature highlights. The design of Sunny is
 closely tied to our team's [theoretical advances](@ref "Advanced theory made
 accessible") in quantum magnetism.
 
-Learn Sunny by browsing the [CoRh₂O₄ tutorial](@ref "1. Spin wave simulations of
+Learn by browsing the [CoRh₂O₄ tutorial](@ref "1. Spin wave simulations of
 CoRh₂O₄") and subsequent ones. See also the [SpinW ports](@ref "SW01 - FM
 Heisenberg chain") for traditional spin wave theory.
 
 The [Library Reference](@ref) lists all functions and their doc-strings.
 
-If you use Sunny, we want to interact with you! Please [join our Slack
+We want to interact with you! Please [join our Slack
 community](https://join.slack.com/t/sunny-users/shared_invite/zt-1otxwwko6-LzPtp7Fazkjx2XEqfgKqtA)
 and say hello. If you encounter a problem with Sunny, please ask on the Slack
 `#helpdesk` channel. If you use Sunny in a paper, please add it to our

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -5,7 +5,7 @@ This page describes the public types and functions exported by Sunny. This docum
 ## Index
 
 ```@index
-Modules = [Sunny, PlottingExt, ExportVTKExt]
+Modules = [Sunny]
 ```
 
 ## Core Sunny functions

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -1,13 +1,113 @@
-# Library API
+# Library Reference
 
 This page describes the public types and functions exported by Sunny. This documentation can be also be accessed using the Julia help system (enter `?` at the Julia command prompt).
 
+## Index
+
 ```@index
+Modules = [Sunny, PlottingExt, ExportVTKExt]
 ```
 
-```@autodocs
-Modules = [Sunny]
-Private = false
+## Core Sunny functions
+
+```@docs
+BinningParameters
+Bond
+Crystal
+FormFactor
+ImplicitMidpoint
+Langevin
+LocalSampler
+Moment
+SampledCorrelations
+SampledCorrelationsStatic
+Site
+SpinWaveTheory
+SpinWaveTheoryKPM
+SpinWaveTheorySpiral
+System
+Units
+add_sample!
+clone_correlations
+clone_system
+dispersion
+dmvec
+domain_average
+eachsite
+enable_dipole_dipole!
+energy
+energy_per_site
+excitations
+excitations!
+gaussian
+global_position
+intensities
+intensities_bands
+intensities_static
+lattice_params
+lattice_vectors
+load_nxs
+lorentzian
+magnetic_moment
+merge_correlations
+minimize_energy!
+minimize_spiral_energy!
+modify_exchange_with_truncated_dipole_dipole!
+polarize_spins!
+position_to_site
+powder_average
+primitive_cell
+print_bond
+print_irreducible_bz_paths
+print_site
+print_stevens_expansion
+print_suggested_frame
+print_symmetry_table
+print_wrapped_intensities
+propose_delta
+propose_flip
+propose_uniform
+q_space_grid
+q_space_path
+randomize_spins!
+reference_bonds
+remove_periodicity!
+repeat_periodically
+repeat_periodically_as_spiral
+reshape_supercell
+resize_supercell
+rotate_operator
+set_coherent!
+set_dipole!
+set_dipoles_from_mcif!
+set_exchange!
+set_exchange_at!
+set_field!
+set_field_at!
+set_onsite_coupling!
+set_onsite_coupling_at!
+set_pair_coupling!
+set_pair_coupling_at!
+set_spin_rescaling!
+set_vacancy_at!
+spin_label
+spin_matrices
+spiral_energy
+spiral_energy_per_site
+ssf_custom
+ssf_custom_bm
+ssf_perp
+ssf_trace
+standardize
+step!
+stevens_matrices
+subcrystal
+suggest_magnetic_supercell
+suggest_timestep
+symmetry_equivalent_bonds
+to_inhomogeneous
+to_product_space
+@mix_proposals
 ```
 
 ## Optional Makie extensions

--- a/docs/src/renormalization.md
+++ b/docs/src/renormalization.md
@@ -90,8 +90,7 @@ The latter are defined as any states where the expected dipole 3-vector,
 ```math
 \boldsymbol{\Omega} ≡ \langle \boldsymbol{\Omega}| \hat{\mathbf{S}} | \boldsymbol{\Omega}\rangle,
 ```
-has maximal magnitude $|\boldsymbol{\Omega}| = s$ and
-arbitrary direction.
+has maximal magnitude $|\boldsymbol{\Omega}| = s$ and arbitrary direction.
 
 For a pure dipole state, group theory dictates that expectations of the Stevens
 operators can be expressed as a renormalization of the classical Stevens
@@ -126,7 +125,6 @@ dynamics of dipoles, but involving $E_{\mathrm{local}}(\boldsymbol{\Omega})$ as
 the classical Hamiltonian. The renormalization factors $c_k$ can therefore be
 interpreted as a correction to the traditional large-$s$ classical limit.
 
-
 Renormalization also applies to the coupling between different sites. In Sunny,
 couplings will often be expressed as a polynomial of spin operators using
 [`set_pair_coupling!`](@ref), but any such coupling can be decomposed as a sum
@@ -142,16 +140,21 @@ renormalized Stevens functions.
 
 ## Use `:dipole_uncorrected` mode to disable renormalization
 
-Although we generally recommend the above renormalization procedure, there are
-cases where it is not desirable. Examples include reproducing a legacy study, or
-modeling a micromagnetic system for which the $s\to\infty$ limit is a good
-approximation. To simulate dipoles without interaction strength renormalization,
+The above renormalization procedure is valid under the assumption that the
+starting model is the true microscopic quantum Hamiltonian. Sometimes, however,
+the starting model is instead an effective classical Hamiltonian that has been
+fitted to experimental data. In this case, the model parameters will already
+incorporate any appropriate renormalizations, and no further renormalization
+should be applied. Similarly, renormalization is unneeded for effective models
+of micromagnets that are far from the quantum regime.
+
+To specify an effective spin-dipole Hamiltonian with renormalization disabled,
 construct a [`System`](@ref) using the mode `:dipole_uncorrected` instead of
-`:dipole`. The fundamental difference between the two modes is the type of
-operator expected by [`set_onsite_coupling!`](@ref). The mode
-`:dipole_uncorrected` expects infinite-dimensional operators in the $s → ∞$
-limit. These can be obtained by passing `Inf` to either [`spin_matrices`](@ref)
-or [`stevens_matrices`](@ref).
+`:dipole`. Formally, `:dipole_uncorrected` takes the $s → ∞$ limit, such that
+all local operators become infinite dimensional and commute. A symbolic
+representation of these operators can be obtained by passing `Inf` to either
+[`spin_matrices`](@ref) or [`stevens_matrices`](@ref). Polynomials of such spin
+operators can be used, e.g., in [`set_onsite_coupling!`](@ref).
 
 ## Definition of Stevens operators
 

--- a/docs/src/structure-factor.md
+++ b/docs/src/structure-factor.md
@@ -340,7 +340,8 @@ sublattice $j$.
 Calculating the structure factor involves several steps, with various possible
 settings. Sunny provides tools to facilitate this calculation and to extract
 information from the results. For details, please see our [tutorials](@ref "1.
-Spin wave simulations of CoRh₂O₄") as well as the complete [Library API](@ref).
+Spin wave simulations of CoRh₂O₄") as well as the complete [Library
+Reference](@ref).
 
 Through [`ssf_custom`](@ref) and related functions, Sunny will calculate the
 spin structure factor as a 3×3 matrix in dimensionless units,

--- a/docs/src/why.md
+++ b/docs/src/why.md
@@ -1,0 +1,71 @@
+
+# Why Choose Sunny?
+
+Sunny is powerful and easy to use. Features include:
+
+- Ability to [specify a crystal](@ref Crystal) from a `.cif` file, from its
+  spacegroup number and representative Wyckoff positions, or from automatically
+  inferred symmetry operations. Magnetic structures [can be read](@ref
+  set_dipoles_from_mcif!) from `.mcif` files.
+- Interactive visualization of [3D crystals](@ref view_crystal) and [magnetic
+  structures](@ref plot_spins).
+- Symmetry analysis to determine [allowed anisotropies and interaction
+  terms](@ref print_symmetry_table), and to propagate them by symmetry
+  equivalence.
+- Single-ion anisotropy [can be specified](@ref set_onsite_coupling!) using
+  either [Stevens operators](@ref stevens_matrices) or [spin polynomials](@ref
+  spin_matrices). Arbitrary coupling between spin multipoles is [also
+  supported](@ref set_pair_coupling!). Classical-to-quantum [renormalization
+  factors](@ref "Interaction Renormalization") enhance fidelity.
+- [Fast optimization](@ref minimize_energy!) of magnetic structures using
+  supercells or the [propagation vector formalism](@ref
+  minimize_spiral_energy!).
+- Statistical sampling of spins in thermal equilibrium using [Langevin
+  dynamics](@ref Langevin) or [local Monte Carlo updates](@ref LocalSampler).
+  Advanced Monte Carlo methods such as [parallel
+  tempering](https://github.com/SunnySuite/Sunny.jl/tree/main/examples/extra/Advanced_MC)
+  are effective for simulations of classical spin liquids and frustrated
+  magnetism.
+- Classical spin dynamics with generalization to spin multipoles via the theory
+  of SU(_N_) coherent states. This allows for the measurement of [dynamical
+  correlations at finite temperature](@ref SampledCorrelations), and the study of
+  [highly nonequilibrium phenomena](@ref "6. Dynamical quench into CP² skyrmion
+  liquid").
+- Generalized [linear spin wave theory](@ref SpinWaveTheory) for low-temperature
+  spin dynamics. Special support is provided for calculations on [incommensurate
+  spiral phases](@ref SpinWaveTheorySpiral) and on [large, disordered magnetic
+  cells](@ref SpinWaveTheoryKPM). See also the [FeI₂ example](@ref "3.
+  Multi-flavor spin wave simulations of FeI₂") as a showcase of LSWT with
+  multi-flavor bosons.
+- Long-range [dipole-dipole interactions](@ref enable_dipole_dipole!)
+  accelerated with the fast Fourier transform (FFT).
+- Tools for comparing to experimental data: [form factors](@ref FormFactor),
+  [custom spin contractions](@ref ssf_custom_bm), averaging over [powder](@ref
+  powder_average) and [domain orientations](@ref domain_average), etc.
+
+Sunny does not yet have GPU acceleration of classical spin dynamics. For this,
+an alternative might be [Vampire](https://vampire.york.ac.uk/).
+
+## Advanced theory made accessible
+
+Sunny is also a platform for [disseminating foundational
+advances](https://github.com/SunnySuite/Sunny.jl/wiki/Sunny-literature#methods)
+in quantum magnetism and computational methods. The theory of [SU(_N_) coherent
+states](https://doi.org/10.1103/PhysRevB.104.104409) offers a group theoretic
+framework to formulate alternative classical limits of a microscopic quantum
+model. [New algorithms](https://doi.org/10.1103/PhysRevB.106.235154) enable
+highly efficient simulation of spin-multipoles and beyond. For reasons not fully
+understood, such classical limits can be [remarkably accurate at finite
+temperatures](https://doi.org/10.1103/PhysRevB.109.014427) when used in
+conjunction with appropriate renormalization schemes. The SU(_N_) picture also
+suggests new geometric interpretations of quantum spin. This leads to a [deeper
+understanding](https://arxiv.org/abs/2304.03874) of existing renormalization
+schemes for traditional spin wave theory, and suggests a whole landscape in
+which to search for novel topological states, [e.g. CP²
+skyrmions](https://doi.org/10.1038/s41467-023-39232-8). Ongoing Sunny research
+aims to incorporate more quantum entanglement into the classical picture. Local
+units of strongly entangled spins will soon be supported and show great promise
+for cases like [dimerized ladders](https://doi.org/10.1103/PhysRevB.110.104403).
+Longer term, Sunny also aims to include perturbative corrections beyond linear
+spin wave theory, as well as a non-perturbative treatment of quantum bound
+states.

--- a/docs/src/why.md
+++ b/docs/src/why.md
@@ -1,12 +1,14 @@
 
 # Why Choose Sunny?
 
-Sunny is powerful and easy to use. Features include:
+## Powerful and easy to use
+
+Feature highlights include:
 
 - Ability to [specify a crystal](@ref Crystal) from a `.cif` file, from its
-  spacegroup number and representative Wyckoff positions, or from automatically
-  inferred symmetry operations. Magnetic structures [can be read](@ref
-  set_dipoles_from_mcif!) from `.mcif` files.
+  spacegroup number and Wyckoffs, or from a full chemical cell with
+  automatically inferred symmetry operations. Magnetic structures [can be
+  read](@ref set_dipoles_from_mcif!) from `.mcif` files.
 - Interactive visualization of [3D crystals](@ref view_crystal) and [magnetic
   structures](@ref plot_spins).
 - Symmetry analysis to determine [allowed anisotropies and interaction
@@ -22,29 +24,35 @@ Sunny is powerful and easy to use. Features include:
   minimize_spiral_energy!).
 - Statistical sampling of spins in thermal equilibrium using [Langevin
   dynamics](@ref Langevin) or [local Monte Carlo updates](@ref LocalSampler).
-  Advanced Monte Carlo methods such as [parallel
-  tempering](https://github.com/SunnySuite/Sunny.jl/tree/main/examples/extra/Advanced_MC)
-  are effective for simulations of classical spin liquids and frustrated
-  magnetism.
-- Classical spin dynamics with generalization to spin multipoles via the theory
-  of SU(_N_) coherent states. This allows for the measurement of [dynamical
-  correlations at finite temperature](@ref SampledCorrelations), and the study of
-  [highly nonequilibrium phenomena](@ref "6. Dynamical quench into CP² skyrmion
-  liquid").
-- Generalized [linear spin wave theory](@ref SpinWaveTheory) for low-temperature
-  spin dynamics. Special support is provided for calculations on [incommensurate
-  spiral phases](@ref SpinWaveTheorySpiral) and on [large, disordered magnetic
-  cells](@ref SpinWaveTheoryKPM). See also the [FeI₂ example](@ref "3.
-  Multi-flavor spin wave simulations of FeI₂") as a showcase of LSWT with
-  multi-flavor bosons.
-- Long-range [dipole-dipole interactions](@ref enable_dipole_dipole!)
+  Advanced Monte Carlo methods, such as [parallel
+  tempering](https://github.com/SunnySuite/Sunny.jl/tree/main/examples/extra/Advanced_MC),
+  for simulations of classical spin liquids and frustrated magnetism.
+- Classical dynamics of spin dipoles and its generalization to SU(_N_) coherent
+  states. One can [sample dynamical correlations](@ref SampledCorrelations) at
+  finite temperature. The [CP² skyrmion example](@ref "6. Dynamical quench into
+  CP² skyrmion liquid") illustrates a highly non-equilibrium quench process that
+  depends crucially on spin quadrupole degrees of freedom.
+- Generalized [linear spin wave theory](@ref SpinWaveTheory) (LSWT) for
+  low-temperature spin dynamics. Special support is provided for efficient
+  calculations on [incommensurate spiral phases](@ref SpinWaveTheorySpiral) and
+  on [very large magnetic cells](@ref SpinWaveTheoryKPM). The [FeI₂
+  example](@ref "3. Multi-flavor spin wave simulations of FeI₂") showcases LSWT
+  with multi-flavor bosons. The [disordered system example](@ref "9. Disordered
+  system with KPM") demonstrates acceleration for large system sizes.
+- [Dipole-dipole interactions](@ref enable_dipole_dipole!) with full Ewald
+  summation, as illustrated in the [pyrochlore LSWT example](@ref "7. Long-range
+  dipole interactions"). Dipole-dipole interactions in classical dynamics are
   accelerated with the fast Fourier transform (FFT).
 - Tools for comparing to experimental data: [form factors](@ref FormFactor),
   [custom spin contractions](@ref ssf_custom_bm), averaging over [powder](@ref
   powder_average) and [domain orientations](@ref domain_average), etc.
+- Programmatic interface in the [Julia language](https://julialang.org/) for
+  full flexibility and performance.
 
-Sunny does not yet have GPU acceleration of classical spin dynamics. For this,
-an alternative might be [Vampire](https://vampire.york.ac.uk/).
+But still evolving:
+
+- Sunny does not yet have GPU acceleration of classical spin dynamics. An
+  alternative here might be [Vampire](https://vampire.york.ac.uk/).
 
 ## Advanced theory made accessible
 
@@ -61,11 +69,11 @@ conjunction with appropriate renormalization schemes. The SU(_N_) picture also
 suggests new geometric interpretations of quantum spin. This leads to a [deeper
 understanding](https://arxiv.org/abs/2304.03874) of existing renormalization
 schemes for traditional spin wave theory, and suggests a whole landscape in
-which to search for novel topological states, [e.g. CP²
-skyrmions](https://doi.org/10.1038/s41467-023-39232-8). Ongoing Sunny research
-aims to incorporate more quantum entanglement into the classical picture. Local
-units of strongly entangled spins will soon be supported and show great promise
-for cases like [dimerized ladders](https://doi.org/10.1103/PhysRevB.110.104403).
+which to search for [novel topological
+states](https://doi.org/10.1038/s41467-023-39232-8). Ongoing Sunny research aims
+to incorporate more quantum entanglement into the classical picture. Local units
+of strongly entangled spins will soon be supported and show great promise for
+cases like [dimerized ladders](https://doi.org/10.1103/PhysRevB.110.104403).
 Longer term, Sunny also aims to include perturbative corrections beyond linear
 spin wave theory, as well as a non-perturbative treatment of quantum bound
 states.

--- a/src/Spiral/SpiralEnergy.jl
+++ b/src/Spiral/SpiralEnergy.jl
@@ -187,10 +187,10 @@ end
 Finds a generalized spiral order that minimizes the [`spiral_energy`](@ref).
 This involves optimization of the spin configuration in `sys`, and the
 propagation wavevector ``𝐤``, which will be returned in reciprocal lattice
-units (RLU). The `axis` vector normal to the polarization plane should be
-provided in global Cartesian coordinates, and will usually be determined by
-symmetry configurations. The initial `k_guess` will be random, unless otherwise
-provided.
+units (RLU). The `axis` vector normal to the polarization plane cannot yet be
+optimized; it should be determined according to symmetry considerations and
+provided in global Cartesian coordinates. The initial `k_guess` will be random,
+unless otherwise provided.
 
 See also [`suggest_magnetic_supercell`](@ref) to find a system shape that is
 approximately commensurate with the returned propagation wavevector ``𝐤``.


### PR DESCRIPTION
The docs landing page better describes what Sunny is, and provides links to its various features.

Within the Library Reference page, URLs for function docstrings now omit type information.