### PR TITLE
Replace KPM with Lanczos

### DIFF
--- a/docs/src/structure-factor.md
+++ b/docs/src/structure-factor.md
@@ -374,12 +374,12 @@ calculated to leading order in inverse powers of the quantum spin-$s$. For
 systems constructed with `mode = :SUN`, Sunny automatically switches to a
 multi-flavor boson variant of spin wave theory, which captures more single-ion
 physics. Use [`SpinWaveTheorySpiral`](@ref) to study generalized spiral phases,
-which allow for an incommensurate propagation wavevector. The experimental
-module [`SpinWaveTheoryKPM`](@ref) implements [spin wave calculations using the
-kernel polynomial method](https://arxiv.org/abs/2312.0834). In the KPM approach,
-the computational cost scales linearly in the magnetic cell size. It can be
-useful for studying systems with large magnetic cells include systems with
-long-wavelength structures, or systems with quenched chemical disorder.
+which allow for an incommensurate propagation wavevector. The module
+[`SpinWaveTheoryKPM`](@ref) uses [iterated matrix-vector
+multiplication](https://arxiv.org/abs/2312.0834) to achieve linear-scaling cost
+in the magnetic cell size. It can be useful for studying systems with large
+magnetic cells include systems with long-wavelength structures, or systems with
+quenched chemical disorder.
 
 
 ## Calculations with classical spin dynamics

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -7,6 +7,8 @@
   wave theory. Empty sites are modeled using bosons that do not excite.
 * Fix correctness of [`suggest_magnetic_supercell`](@ref) when multiple
   wavevectors are provided.
+* The default implementation of [`SpinWaveTheoryKPM`](@ref) now uses Lanczos for
+  higher accuracy.
 
 ## v0.7.5
 (Jan 20, 2025)

--- a/docs/src/why.md
+++ b/docs/src/why.md
@@ -38,7 +38,7 @@ Feature highlights include:
   on [very large magnetic cells](@ref SpinWaveTheoryKPM). The [FeI₂
   example](@ref "3. Multi-flavor spin wave simulations of FeI₂") showcases LSWT
   with multi-flavor bosons. The [disordered system example](@ref "9. Disordered
-  system with KPM") demonstrates acceleration for large system sizes.
+  systems") demonstrates acceleration for large system sizes.
 - [Dipole-dipole interactions](@ref enable_dipole_dipole!) with full Ewald
   summation, as illustrated in the [pyrochlore LSWT example](@ref "7. Long-range
   dipole interactions"). Dipole-dipole interactions in classical dynamics are

--- a/examples/09_Disorder_KPM.jl
+++ b/examples/09_Disorder_KPM.jl
@@ -1,14 +1,14 @@
-# # 9. Disordered system with KPM
+# # 9. Disordered systems
 #
-# This example uses the [kernel polynomial method](@ref SpinWaveTheoryKPM) to
-# efficiently calculate the neutron scattering spectrum of a disordered
-# triangular antiferromagnet. The model is inspired by YbMgGaO4, as studied in
-# [Paddison et al, Nature Phys., **13**, 117–122
-# (2017)](https://doi.org/10.1038/nphys3971) and [Zhu et al, Phys. Rev. Lett.
-# **119**, 157201 (2017)](https://doi.org/10.1103/PhysRevLett.119.157201).
-# Disordered occupancy of non-magnetic Mg/Ga sites can be modeled as a
-# stochastic distribution of exchange constants and ``g``-factors. Including
-# this disorder introduces broadening of the spin wave spectrum.
+# This example uses [`SpinWaveTheoryKPM`](@ref) to efficiently calculate the
+# neutron scattering spectrum of a disordered triangular antiferromagnet. The
+# model is inspired by YbMgGaO4, as studied in [Paddison et al, Nature Phys.,
+# **13**, 117–122 (2017)](https://doi.org/10.1038/nphys3971) and [Zhu et al,
+# Phys. Rev. Lett. **119**, 157201
+# (2017)](https://doi.org/10.1103/PhysRevLett.119.157201). Disordered occupancy
+# of non-magnetic Mg/Ga sites can be modeled as a stochastic distribution of
+# exchange constants and ``g``-factors. Including this disorder introduces
+# broadening of the spin wave spectrum.
 
 using Sunny, GLMakie
 
@@ -61,16 +61,15 @@ end
 minimize_energy!(sys_inhom, maxiters=5_000)
 plot_spins(sys_inhom; color=[S[3] for S in sys_inhom.dipoles], ndims=2)
 
-# Spin wave theory with exact diagonalization becomes impractical for large
-# system sizes. Significant acceleration is possible with an iterative Krylov
-# space solver. With [`SpinWaveTheoryKPM`](@ref), the cost of an
-# [`intensities`](@ref) calculation scales linearly in the system size and
-# inversely with the width of the line broadening `kernel`. Good choices for the
-# dimensionless error tolerance are `tol=0.05` (more speed) or `tol=0.01` (more
-# accuracy).
+# Traditional spin wave theory with exact diagonalization becomes impractical
+# for large system sizes. Using [`SpinWaveTheoryKPM`](@ref), the cost of an
+# [`intensities`](@ref) calculation becomes _linear_ in the system size, with a
+# prefactor that inversely in the width of the line broadening `kernel`. Good
+# choices for the dimensionless error tolerance are `tol=0.05` (more speed) or
+# `tol=0.01` (more accuracy).
 #
-# Observe from the KPM calculation that disorder in the nearest-neighbor
-# exchange serves to broaden the discrete excitation bands into a continuum.
+# Observe that disorder in the nearest-neighbor exchange serves to broaden the
+# discrete excitation bands into a continuum.
 
 swt = SpinWaveTheoryKPM(sys_inhom; measure=ssf_perp(sys_inhom), tol=0.05)
 res = intensities(swt, path; energies, kernel)

--- a/src/KPM/Lanczos.jl
+++ b/src/KPM/Lanczos.jl
@@ -8,7 +8,7 @@
 # representative of extremal eigenvalues of A (in an appropriate S-measure
 # sense). Second, one obtains a very good approximation to the matrix-vector
 # product, f(A S) v ≈ Q f(T) e₁, valid for any function f [1].
-# 
+#
 # The generalization of Lanczos to an arbitrary measure S is implemented as
 # follows: Each matrix-vector product A v is replaced by A S v, and each vector
 # inner product w† v is replaced by w† S v. Similar generalizations of Lanczos
@@ -56,11 +56,12 @@ end
 
 
 # An optimized implementation of the generalized Lanczos method. See
-# `lanczos_ref` for explanation, and a reference implementation. This optimized
-# implementation follows "the most stable" of the four variants considered by
-# Paige [1], as listed on Wikipedia. Here, however, we allow for an arbitary
-# measure S. In practice, this means that each matrix-vector product A v is
-# replaced by A S v, and each inner product w† v is replaced by w† S v.
+# `lanczos_ref` for explanation, and a reference implementation. No explicit
+# orthogonalization is performed. This optimized implementation follows "the
+# most stable" of the four variants considered by Paige [1], as listed on
+# Wikipedia. Here, however, we allow for an arbitary measure S. In practice,
+# this means that each matrix-vector product A v is replaced by A S v, and each
+# inner product w† v is replaced by w† S v.
 #
 # In this implementation, each Lanczos iteration requires only one matrix-vector
 # multiplication involving A and S, respectively. 
@@ -70,20 +71,22 @@ end
 # * The return value is a pair, (T, lhs† Q). The symbol `lhs` denotes "left-hand
 #   side" column vectors, packed horizontally into a matrix. If the `lhs`
 #   argument is ommitted, its default value will be a matrix of width 0.
-# * If the initial vector `v` is not normalized, then this normalization will be
-#   performed automatically, and the scale `√v S v` will be absorbed into the
-#   return value `lhs† Q`.
-# * The number of iterations will never exceed length(v). If this limit is hit
-#   then, mathematically, the Krylov subspace should be complete, and the matrix
-#   T should be exactly similar to the matrix A S. In practice, however,
-#   numerical error at finite precision may be severe. Further testing is
-#   required to determine whether the Lanczos method is appropriate in this
-#   case, where the matrices have modest dimension. (Direct diagonalization may
-#   be preferable.)
+# * The initial vector `v` must be normalized such that `√v S v ≈ 1`. (An
+#   alternative implementation might absorb this scale into the return value
+#   `lhs† Q`.)
 # * After `min_iters` iterations, this procedure will estimate the spectral
 #   bandwidth Δϵ between extreme eigenvalues of T. Then `Δϵ / resolution` will
 #   be an upper bound on the total number of iterations (which includes the
 #   initial `min_iters` iterations as well as subsequent ones).
+# * The number of iterations will never exceed length(v). If this limit is hit
+#   then, mathematically, the Krylov subspace should be complete, and the matrix
+#   T should be exactly similar to the matrix A S. In practice, however,
+#   numerical error at finite precision may be severe.
+# * Accumulation of numerical roundoff error can lead to significant artifacts
+#   in some cases. See https://github.com/SunnySuite/Sunny.jl/pull/339 for
+#   examples. An explicit orthogonalization step may be considered for future
+#   work. But note that there can be mixing between near-degenerate eigenvalues
+#   even when the number of Lanczos iterations is small.
 #
 # 1. C. C. Paige, IMA J. Appl. Math., 373-381 (1972),
 #    https://doi.org/10.1093%2Fimamat%2F10.3.373.

--- a/src/KPM/Lanczos.jl
+++ b/src/KPM/Lanczos.jl
@@ -1,13 +1,40 @@
-# Reference implementation, without consideration of speed.
+# Reference implementation of the generalized Lanczos method, without
+# consideration of speed. The input A can be any Hermitian matrix. The optional
+# argument S is an inner-product that must be both Hermitian and positive
+# definite. Intuitively, Lanczos finds a low-rank approximant A S ≈ Q T Q† S,
+# where T is tridiagonal and Q is orthogonal in the sense that Q† S Q = I. The
+# first column of Q is the initial vector v, which must be normalized. The
+# Lanczos method is useful in two ways. First, eigenvalues of T are
+# representative of extremal eigenvalues of A (in an appropriate S-measure
+# sense). Second, one obtains a very good approximation to the matrix-vector
+# product, f(A S) v ≈ Q f(T) e₁, valid for any function f [1].
+# 
+# The generalization of Lanczos to an arbitrary measure S is implemented as
+# follows: Each matrix-vector product A v is replaced by A S v, and each vector
+# inner product w† v is replaced by w† S v. Similar generalizations of Lanczos
+# have been considered in [2] and [3].
+#
+# 1. N. Amsel, T. Chen, A. Greenbaum, C. Musco, C. Musco, Near-optimal
+#    approximation of matrix functions by the Lanczos method, (2013)
+#    https://arxiv.org/abs/2303.03358v2.
+# 2. H. A. van der Vorst, Math. Comp. 39, 559-561 (1982),
+#    https://doi.org/10.1090/s0025-5718-1982-0669648-0
+# 3. M. Grüning, A. Marini, X. Gonze, Comput. Mater. Sci. 50, 2148-2156 (2011),
+#    https://doi.org/10.1016/j.commatsci.2011.02.021.
 function lanczos_ref(A, S, v; niters)
     αs = Float64[]
     βs = Float64[]
+    vs = typeof(v)[]
 
-    v /= sqrt(real(dot(v, S, v)))
+    c = sqrt(real(dot(v, S, v)))
+    @assert c ≈ 1 "Initial vector not normalized"
+    v /= c
+
     w = A * S * v
     α = real(dot(w, S, v))
     w = w - α * v
     push!(αs, α)
+    push!(vs, v)
 
     for _ in 2:niters
         β = sqrt(real(dot(w, S, w)))
@@ -19,35 +46,54 @@ function lanczos_ref(A, S, v; niters)
         v = vp
         push!(αs, α)
         push!(βs, β)
+        push!(vs, v)
     end
 
-    return SymTridiagonal(αs, βs)
+    Q = reduce(hcat, vs)
+    T = SymTridiagonal(αs, βs)
+    return (; Q, T)
 end
 
 
-
-# Use Lanczos iterations to find a truncated tridiagonal representation of A S,
-# up to similarity transformation. Here, A is any Hermitian matrix, while S is
-# both Hermitian and positive definite. Traditional Lanczos uses the identity
-# matrix, S = I. The extension to non-identity matrices S is as follows: Each
-# matrix-vector product A v becomes A S v, and each vector inner product w† v
-# becomes w† S v. The implementation below follows the notation of Wikipedia,
-# and is the most stable of the four variants considered by Paige [1]. Each
-# Lanczos iteration requires only one matrix-vector multiplication for A and S,
-# respectively.
-
-# Similar generalizations of Lanczos have been considered in [2] and [3].
+# An optimized implementation of the generalized Lanczos method. See
+# `lanczos_ref` for explanation, and a reference implementation. This optimized
+# implementation follows "the most stable" of the four variants considered by
+# Paige [1], as listed on Wikipedia. Here, however, we allow for an arbitary
+# measure S. In practice, this means that each matrix-vector product A v is
+# replaced by A S v, and each inner product w† v is replaced by w† S v.
+#
+# In this implementation, each Lanczos iteration requires only one matrix-vector
+# multiplication involving A and S, respectively. 
+#
+# Details:
+#
+# * The return value is a pair, (T, lhs† Q). The symbol `lhs` denotes "left-hand
+#   side" column vectors, packed horizontally into a matrix. If the `lhs`
+#   argument is ommitted, its default value will be a matrix of width 0.
+# * If the initial vector `v` is not normalized, then this normalization will be
+#   performed automatically, and the scale `√v S v` will be absorbed into the
+#   return value `lhs† Q`.
+# * The number of iterations will never exceed length(v). If this limit is hit
+#   then, mathematically, the Krylov subspace should be complete, and the matrix
+#   T should be exactly similar to the matrix A S. In practice, however,
+#   numerical error at finite precision may be severe. Further testing is
+#   required to determine whether the Lanczos method is appropriate in this
+#   case, where the matrices have modest dimension. (Direct diagonalization may
+#   be preferable.)
+# * After `min_iters` iterations, this procedure will estimate the spectral
+#   bandwidth Δϵ between extreme eigenvalues of T. Then `Δϵ / resolution` will
+#   be an upper bound on the total number of iterations (which includes the
+#   initial `min_iters` iterations as well as subsequent ones).
 #
 # 1. C. C. Paige, IMA J. Appl. Math., 373-381 (1972),
-# https://doi.org/10.1093%2Fimamat%2F10.3.373.
-# 2. H. A. van der Vorst, Math. Comp. 39, 559-561 (1982),
-# https://doi.org/10.1090/s0025-5718-1982-0669648-0
-# 3. M. Grüning, A. Marini, X. Gonze, Comput. Mater. Sci. 50, 2148-2156 (2011),
-# https://doi.org/10.1016/j.commatsci.2011.02.021.
-function lanczos(mulA!, mulS!, v; niters)
+#    https://doi.org/10.1093%2Fimamat%2F10.3.373.
+
+function lanczos(mulA!, mulS!, v; min_iters, resolution=Inf, lhs=zeros(length(v), 0), verbose=false)
     αs = Float64[]
     βs = Float64[]
+    lhs_adj_Q = Vector{ComplexF64}[]
 
+    v = copy(v)
     vp  = zero(v)
     Sv  = zero(v)
     Svp = zero(v)
@@ -56,6 +102,7 @@ function lanczos(mulA!, mulS!, v; niters)
 
     mulS!(Sv, v)
     c = sqrt(real(dot(v, Sv)))
+    @assert c ≈ 1 "Initial vector not normalized"
     @. v /= c
     @. Sv /= c
 
@@ -64,10 +111,36 @@ function lanczos(mulA!, mulS!, v; niters)
     @. w = w - α * v
     mulS!(Sw, w)
     push!(αs, α)
+    push!(lhs_adj_Q, lhs' * v)
 
-    for _ in 2:niters
-        β = sqrt(real(dot(w, Sw)))
-        iszero(β) && break
+    # The maximum number of iterations is length(v)-1, because that is the
+    # dimension of the full vector space. Break out early if niters has been
+    # reached, which will be set according to the spectral bounds Δϵ after
+    # iteration i == min_iters.
+    niters = typemax(Int)
+    for i in 1:length(v)-1
+        if i == min_iters
+            T = SymTridiagonal(αs, βs)
+            Δϵ = eigmax(T) - eigmin(T)
+            niters = max(min_iters, fld(Δϵ, resolution))
+            niters += mod(niters, 2) # Round up to nearest even integer
+            if verbose
+                println("Δϵ=$Δϵ, niters=$niters")
+            end
+        end
+
+        i >= niters && break
+
+        # Let β = w† S w. If β < 0 then S is not a valid positive definite
+        # measure. If β = 0, this would formally indicate that v is a linear
+        # combination of only a subset of the eigenvectors of A S. In this case,
+        # it is valid to break early for purposes of approximating the
+        # matrix-vector product f(A S) v. 
+        β² = real(dot(w, Sw))
+        iszero(β²) && break
+        β² < 0 && error("S is not a positive definite measure")
+
+        β = sqrt(β²)
         @. vp = w / β
         @. Svp = Sw / β
         mulA!(w, Svp)
@@ -77,9 +150,10 @@ function lanczos(mulA!, mulS!, v; niters)
         @. v = vp
         push!(αs, α)
         push!(βs, β)
+        push!(lhs_adj_Q, lhs' * v)
     end
 
-    return SymTridiagonal(αs, βs)
+    return SymTridiagonal(αs, βs), reduce(hcat, lhs_adj_Q)
 end
 
 
@@ -107,6 +181,9 @@ function eigbounds(swt, q_reshaped, niters)
     end
 
     v = randn(ComplexF64, 2L)
-    tridiag = lanczos(mulA!, mulS!, v; niters)
-    return eigmin(tridiag), eigmax(tridiag)
+    Sv = zero(v)
+    mulS!(Sv, v)
+    v /= sqrt(v' * Sv)
+    T, _ = lanczos(mulA!, mulS!, v; min_iters=niters)
+    return eigmin(T), eigmax(T)
 end

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -3,20 +3,19 @@
                       niters=nothing, niters_bounds=10, method=:lanczos)
 
 A variant of [`SpinWaveTheory`](@ref) that estimates [`intensities`](@ref) using
-only iterated matrix-vector products. By avoiding direct matrix diagonalization,
-this method reduces computational cost from cubic to linear-scaling in the
-system size ``N``. Iterative methods can be especially useful for models of
-quenched disorder or models with nearly incommensurate ordering wavevectors.
+iterated matrix-vector products. By avoiding direct matrix diagonalization, this
+method reduces computational cost from cubic to linear-scaling in the system
+size ``N``. Large system sizes can arise, e.g., for models of quenched disorder
+or models with nearly incommensurate ordering wavevectors.
 
 Computational cost scales like ``𝒪(N M + M^2)``. The number of iterations ``M``
-can be specified directly with the `niters` parameter. More commonly an error
-tolerance `tol` will be specified; in this case, `M ≈ -2 log10(tol) Δϵ / fwhm`
-where `Δϵ` is the estimated spectral bandwidth of excitations and `fwhm` is the
-full width at half maximum of the user-supplied broadening `kernel`. Common
-choices for the dimensionless `tol` parameter are `0.05` (more speed) or `0.01`
-(more accuracy). Exactly one of `tol` or `niters` must be provided. The
-parameter `niters_bounds` selects the Krylov subspace dimension to be used for
-estimating spectral bounds.
+may be specified directly with the `niters` parameter. Alternatively, one may
+specify a dimensionless error tolerance `tol` such that `M ≈ -2 log10(tol) Δϵ /
+fwhm` where `Δϵ` is the estimated spectral bandwidth of excitations and `fwhm`
+is the full width at half maximum of the user-supplied broadening `kernel`.
+Common choices for `tol` are `0.05` (more speed) or `0.01` (more accuracy).
+Either `tol` or `niters` is required. The parameter `niters_bounds` selects the
+Krylov subspace dimension to be used for estimating spectral bounds.
 
 !!! warning "Accuracy considerations"  
     Energy-space resolution scales inversely with the number ``M`` of
@@ -24,12 +23,12 @@ estimating spectral bounds.
     tolerance parameter `tol`. A more serious problem is intensity loss at bands
     with small excitation energy, e.g., in the viscinity of Goldstone modes. In
     certain cases this missing intensity will be due to numerical roundoff error
-    and cannot be fixed by increasing the number of iterations ``M``.
+    that cannot be fixed by increasing the number of iterations ``M``.
 
-The default Krylov subspace method is Lanczos [1], which achieves near-optimal
-accuracy for a given number of iterations [2]. Alternatively, `method=:kpm` will
-select the historical Kernel Polynomial Method [3], which is expected to be less
-accurate.
+Two `method` options are available, `:lanczos` and `:kpm`.  Lanczos is generally
+preferred, as it achieves near-optimal accuracy for a given number of iterations
+[1, 2]. The Lanczos implementation builds on earlier research using the Kernel
+Polynomial Method [3], which may be of historical interest.
 
 ## References
 

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -8,25 +8,25 @@ this method reduces computational cost from cubic to linear-scaling in the
 system size ``N``. Iterative methods can be especially useful for models of
 quenched disorder or models with nearly incommensurate ordering wavevectors.
 
-!!! warning "Accuracy considerations"  
-    Energy-space resolution scales inversely with the number ``M`` of
-    iterations. In practice, numerical broadening effects can be well controlled
-    via the tolerance parameter `tol`. A more serious problem is intensity loss
-    at bands with small excitation energy, e.g., in the viscinity of Goldstone
-    modes. This missing intensity may be due to floating point round-off errors,
-    whcih are not fixable by increasing ``M``.
-
 Computational cost scales like ``𝒪(N M + M^2)``. The number of iterations ``M``
 can be specified directly with the `niters` parameter. More commonly an error
 tolerance `tol` will be specified; in this case, `M ≈ -2 log10(tol) Δϵ / fwhm`
 where `Δϵ` is the estimated spectral bandwidth of excitations and `fwhm` is the
-full width at half maximum of the user-supplied broadening `kernel`. Good
-choices for the dimensionless `tol` parameter may be `0.05` (more speed) or
-`0.01` (more accuracy). Exactly one of `tol` or `niters` must be provided. The
+full width at half maximum of the user-supplied broadening `kernel`. Common
+choices for the dimensionless `tol` parameter are `0.05` (more speed) or `0.01`
+(more accuracy). Exactly one of `tol` or `niters` must be provided. The
 parameter `niters_bounds` selects the Krylov subspace dimension to be used for
 estimating spectral bounds.
 
-The default Krylov sub-space method is Lanczos [1], which achieves near-optimal
+!!! warning "Accuracy considerations"  
+    Energy-space resolution scales inversely with the number ``M`` of
+    iterations. Such broadening errors can usually be well controlled via the
+    tolerance parameter `tol`. A more serious problem is intensity loss at bands
+    with small excitation energy, e.g., in the viscinity of Goldstone modes. In
+    certain cases this missing intensity will be due to numerical roundoff error
+    and cannot be fixed by increasing the number of iterations ``M``.
+
+The default Krylov subspace method is Lanczos [1], which achieves near-optimal
 accuracy for a given number of iterations [2]. Alternatively, `method=:kpm` will
 select the historical Kernel Polynomial Method [3], which is expected to be less
 accurate.

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -97,7 +97,7 @@ function excitations!(T, tmp, swt::SpinWaveTheory, q)
     try
         return bogoliubov!(T, tmp)
     catch _
-        error("Instability at wavevector q = $q")
+        rethrow(ErrorException("Not an energy-minimum; wavevector q = $q unstable."))
     end
 end
 

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -4,7 +4,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
     (; local_rotations, stevens_coefs, sqrtS) = data
     (; extfield, gs) = sys
 
-    L = nbands(swt) 
+    L = nbands(swt)
     @assert size(H) == (2L, 2L)
 
     # Initialize Hamiltonian buffer 

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -1,27 +1,35 @@
 @testitem "Lanczos" begin
     using LinearAlgebra
 
-    N = 200
+    N = 40
     A = hermitianpart(randn(N, N))
-    A = diagm(vcat(ones(N÷2), -ones(N÷2)))
 
     S = randn(N, N)
     S = S' * S
     S = S / eigmax(S)
-    S = S + 0.0I
+    S = S + 1e-2I
 
+    # Check that fast and slow Lanczos implementations match
+
+    lhs = randn(N, 2)
     v = randn(N)
-    ev1 = eigvals(Sunny.lanczos_ref(A*S*A, S, v; niters=10))
+    v /= sqrt(dot(v, S, v))
+    (; Q, T) = Sunny.lanczos_ref(A, S, v; niters=10)
+    ev1 = eigvals(T)
 
-    mulA!(w, v) = (w .= A * S * A * v)
+    mulA!(w, v) = mul!(w, A, v)
     mulS!(w, v) = mul!(w, S, v)
-    ev2 = eigvals(Sunny.lanczos(mulA!, mulS!, copy(v); niters=10))
+    T, lhs_adj_Q = Sunny.lanczos(mulA!, mulS!, copy(v); lhs, min_iters=10)
+    ev2 = eigvals(T)
 
     @test ev1 ≈ ev2
+    @test lhs' * Q ≈ lhs_adj_Q
 
-    ev3 = extrema(eigvals(Sunny.lanczos_ref(A*S*A, S, v; niters=100)))
-    ev4 = extrema(eigvals((A*S)^2))
-    @test isapprox(collect(ev3), collect(ev4); atol=1e-3)
+    # Check that extremal eigenvalues match to reasonable accuracy
+
+    T, _ = Sunny.lanczos(mulA!, mulS!, copy(v); min_iters=20)
+    @test isapprox(eigmin(T), eigmin(A * S); atol=1e-3)
+    @test isapprox(eigmax(T), eigmax(A * S); atol=1e-3)
 end
 
 

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -102,18 +102,18 @@ end
 
         # Note that KPM accuracy is currently limited by Gibbs ringing
         # introduced in the thermal occupancy (Heaviside step) function.
-        swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=1e-8, method=:kpm)
-        res2 = intensities(swt_kpm, [q]; energies, kernel, kT)
+        swt_kry = SpinWaveTheoryKPM(sys; measure, tol=1e-8, method=:kpm)
+        res2 = intensities(swt_kry, [q]; energies, kernel, kT)
         @test isapprox(res1.data, res2.data, rtol=1e-5)
 
         # Default Lanczos method does this task well
-        # swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=1e-3)
-        # res3 = intensities(swt_kpm, [q]; energies, kernel, kT)
-        # @test isapprox(res1.data, res3.data, rtol=1e-8)
+        swt_kry = SpinWaveTheoryKPM(sys; measure, tol=1e-2)
+        res3 = intensities(swt_kry, [q]; energies, kernel, kT)
+        @test isapprox(res1.data, res3.data, rtol=1e-8)
 
         # Very high accuracy after 4 iterations
-        swt_kpm = SpinWaveTheoryKPM(sys; measure, niters=4)
-        res3 = intensities(swt_kpm, [q]; energies, kernel, kT)
+        swt_kry = SpinWaveTheoryKPM(sys; measure, niters=4)
+        res3 = intensities(swt_kry, [q]; energies, kernel, kT)
         @test isapprox(res1.data, res3.data, rtol=1e-8)
     end
 end

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -107,9 +107,9 @@ end
         @test isapprox(res1.data, res2.data, rtol=1e-5)
 
         # Default Lanczos method does this task well
-        swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=0.01)
+        swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=1e-3)
         res3 = intensities(swt_kpm, [q]; energies, kernel, kT)
-        @test isapprox(res1.data, res3.data, rtol=1e-5)
+        @test isapprox(res1.data, res3.data, rtol=1e-8)
 
         # Very high accuracy after 4 iterations
         swt_kpm = SpinWaveTheoryKPM(sys; measure, niters=4)

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -107,9 +107,9 @@ end
         @test isapprox(res1.data, res2.data, rtol=1e-5)
 
         # Default Lanczos method does this task well
-        swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=1e-3)
-        res3 = intensities(swt_kpm, [q]; energies, kernel, kT)
-        @test isapprox(res1.data, res3.data, rtol=1e-8)
+        # swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=1e-3)
+        # res3 = intensities(swt_kpm, [q]; energies, kernel, kT)
+        # @test isapprox(res1.data, res3.data, rtol=1e-8)
 
         # Very high accuracy after 4 iterations
         swt_kpm = SpinWaveTheoryKPM(sys; measure, niters=4)

--- a/test/test_kpm.jl
+++ b/test/test_kpm.jl
@@ -106,12 +106,12 @@ end
         res2 = intensities(swt_kpm, [q]; energies, kernel, kT)
         @test isapprox(res1.data, res2.data, rtol=1e-5)
 
-        # Default Lanczos method does this task perfectly
+        # Default Lanczos method does this task well
         swt_kpm = SpinWaveTheoryKPM(sys; measure, tol=0.01)
         res3 = intensities(swt_kpm, [q]; energies, kernel, kT)
-        @test isapprox(res1.data, res3.data, rtol=1e-8)
+        @test isapprox(res1.data, res3.data, rtol=1e-5)
 
-        # Only 4 iterations required
+        # Very high accuracy after 4 iterations
         swt_kpm = SpinWaveTheoryKPM(sys; measure, niters=4)
         res3 = intensities(swt_kpm, [q]; energies, kernel, kT)
         @test isapprox(res1.data, res3.data, rtol=1e-8)


### PR DESCRIPTION
The Lanczos algorithm promises these benefits relative to KPM:

 - Higher accuracy at a fixed number of iterations (i.e., at a fixed Krylov subspace dimension).
 - Does not require an initialization phase that bounds the spectrum prior to polynomial expansion.
 - Ability to detect instabilities (negative eigenvalues) in the dynamical matrix.
 - Allows for a sharp cutoff between positive and negative eigenvalues near zero. ~~Whereas KPM is susceptible to a loss of intensity near Goldstone modes, Lanczos seems to avoid this problem.~~ (Unfortunately, despite my initial hopes, intensity is still lost via various mechanisms. See examples below.)

As currently implemented, Lanczos is slower than KPM _per iteration_. But fewer iterations are required, so Lanczos still seems favorable in overall speed. And future optimizations may be possible, e.g., operating on multiple right-hand side vectors in parallel.

A possible disadvantage of Lanczos is the accumulation of numerical roundoff error (loss of orthogonality in basis vectors for the Krylov space), and the effects of this are harder to quantify. See https://arxiv.org/abs/2410.11090 for a modern mathematical review of the Lanczos method. A backward stability analysis, in Sec. 4, suggests that the instabilities of Lanczos are not catastrophic for the desired observables. Empirically, however, Lanczos can still exhibit severe artifacts in estimating the intensities of bands near zero energy (quantified in examples below). Note, however, that these are cases where KPM also fails.

Another consideration is that Lanczos requires direct diagonalization of a tridiagonal matrix. After $k$ Lanczos iterations, this cost should scale like $\mathcal{O}(k^2)$, which may dominate if $k$ sufficiently large.

