### PR TITLE
Write examples/extra folder as Jupyter notebooks

### DIFF
--- a/examples/extra/Advanced_MC/PT_WHAM_ising2d.jl
+++ b/examples/extra/Advanced_MC/PT_WHAM_ising2d.jl
@@ -34,10 +34,10 @@ Sunny.step_ensemble!(PT, n_therm, exch_interval)
 
 # Start PT simulation
 for _ in 1:n_measure
-    # Run some sweeps and replica exchanges
+    ## Run some sweeps and replica exchanges
     Sunny.step_ensemble!(PT, measure_interval, exch_interval)
 
-    # Measurements - assuming LocalSampler used
+    ## Measurements - assuming LocalSampler used
     for (j, sampler) in enumerate(PT.samplers)
         E_hists[j][sampler.ΔE] += 1
     end

--- a/examples/extra/Advanced_MC/REWL_ising2d.jl
+++ b/examples/extra/Advanced_MC/REWL_ising2d.jl
@@ -26,7 +26,7 @@ exch_interval = 100
 for i in 1:n_iters
     for mcs in 1:max_hchecks_per_iter
         Sunny.step_ensemble!(REWL, hcheck_interval, exch_interval)
-        # If flat, go to next iteration
+        ## If flat, go to next iteration
         flat = fill(false, length(REWL.samplers))
         @Threads.threads for i in eachindex(REWL.samplers)
             flat[i] = Sunny.check_flat(REWL.samplers[i].hist; p=0.5)

--- a/examples/extra/Advanced_MC/WL_ising2d.jl
+++ b/examples/extra/Advanced_MC/WL_ising2d.jl
@@ -20,14 +20,14 @@ nsweeps = 1_000
 for i in 1:n_iters
     for mcs in 1:max_hchecks_per_iter
         Sunny.step_ensemble!(WL, nsweeps)
-        # If flat, go to next iteration
+        ## If flat, go to next iteration
         if Sunny.check_flat(WL.hist; p=0.5)
             break
         end
     end
     println("iteration $i complete.")
     Sunny.reset!(WL.hist)
-    # Can change to 1/t algorithm or other
+    ## Can change to 1/t algorithm or other
     WL.ln_f /= 2
 end
 

--- a/examples/extra/KPM/chebyshev_usage.jl
+++ b/examples/extra/KPM/chebyshev_usage.jl
@@ -51,24 +51,24 @@ end
 
 # Examine approximations using different numbers of polynomials.
 begin
-    maxN = 40 # Number of polynomials to use in reconstruction -- choose between 2 and 1000
+    maxN = 40 ## Number of polynomials to use in reconstruction -- choose between 2 and 1000
 
-    # Calculate the coefficients
+    ## Calculate the coefficients
     a = 0.05
     bounds = (-1, 1)
     coefs = cheb_coefs(maxN, nsamps, x -> bose_reg(x, a), bounds)
     coefs_jackson = apply_jackson_kernel!(copy(coefs))
 
-    # Create reference (evaluate original function on 1000 points)
+    ## Create reference (evaluate original function on 1000 points)
     xs_ref = range(bounds[1], bounds[2], 1000) 
     ref = map(x -> bose_reg(x, 0.05), xs_ref) # "Ground truth"
 
-    # Reconstruct from coefficients, without and with Jackson kernel
+    ## Reconstruct from coefficients, without and with Jackson kernel
     xs_rec = range(bounds[1], bounds[2], 200)  # Points to evaluate reconstruction
     rec = map(x -> cheb_eval(x, bounds, coefs), xs_rec)
     jac = map(x -> cheb_eval(x, bounds, coefs_jackson), xs_rec)
 
-    # Plot results
+    ## Plot results
     p = lines(xs_ref, ref; color=(:black, 0.6), label="Reference")
     scatter!(xs_rec, rec; marker=:circle, markersize=10.0, color=:orange, label="Reconstruction")
     scatter!(xs_rec, jac; marker=:cross, markersize=10.0, color=:magenta, label="Reconstruction (Jackson)")
@@ -80,30 +80,30 @@ end
 # Example of how coefficients die off with varying width parameter
 begin
     fig = Figure(resolution=(1200,500))
-    as = [0.1, 0.05, 0.025]  # Width parameter of regularized Bose function
+    as = [0.1, 0.05, 0.025]  ## Width parameter of regularized Bose function
 
-    # Plot coefficient magnitudes for each case
+    ## Plot coefficient magnitudes for each case
     numtokeep = Int64[]
     stored_coefs = []
     for (n, a) in enumerate(as)
-        # Calculate and save coefficients
+        ## Calculate and save coefficients
         coefs = cheb_coefs(npolys, nsamps, x -> bose_reg(x, a), bounds)
         push!(stored_coefs, coefs)
 
-        # Plot
+        ## Plot
         axis = Axis(fig[1,n]; yscale=log10, ylabel = n == 1 ? L"c_n" : "", xlabel=L"n")
         scatter!(axis, abs.(coefs); markersize=2.0)
 
-        # Figure out how many coefficients to use for reconstruction (clip when below certain value)
+        ## Figure out how many coefficients to use for reconstruction (clip when below certain value)
         push!(numtokeep, findfirst(x -> abs(x) < 1e-5, coefs[begin:2:end]))
     end
 
-    # Plot original function and reconstruction in each case
+    ## Plot original function and reconstruction in each case
     for (n, (maxM, coefs, a)) in enumerate(zip(numtokeep, stored_coefs, as))
-        # Reconstruct functions from saved coefficients -- used saved number of coefficients
+        ## Reconstruct functions from saved coefficients -- used saved number of coefficients
         rec = map(x -> cheb_eval(x, bounds, coefs[1:maxM]), xs_rec)
 
-        # Plot
+        ## Plot
         ax = Axis(fig[2,n]; ylabel = n == 1 ? L"f(x)" : "", xlabel=L"x")
         ref = map(x -> bose_reg(x, a), xs_ref) 
         lines!(ax, xs_ref, ref; color=(:black, 0.6), label="Reference")

--- a/examples/extra/Plotting/plotting2d.jl
+++ b/examples/extra/Plotting/plotting2d.jl
@@ -65,11 +65,11 @@ function plot_triangular_plaquettes(f, frames;
     colormap=:RdBu, colorrange=(-0.5, 0.5), offset_spacing=1,
     numcols=nothing, texts=nothing, force_aspect=true, text_offset = (0.0, 0.0), fig_kwargs...
 )
-    # Consolidate lattice info and panel layout
+    ## Consolidate lattice info and panel layout
     numpanels = length(frames)
     isnothing(numcols) && (numcols = numpanels)
     numrows = floor(Int, (numpanels - 1) / numcols) + 1
-    v₁, v₂ = [1, 0, 0], [-1/2, √3/2, 0] # Derives from lattice_vectors(a,a,c,90,90,120)
+    v₁, v₂ = [1, 0, 0], [-1/2, √3/2, 0] ## Derives from lattice_vectors(a,a,c,90,90,120)
     nx, ny = size(frames[1])[1:2]
     v₁, v₂ = Point3f(v₁), Point3f(v₂)
     x, y = [1.0, 0, 0], [0.0, 1, 0]
@@ -79,7 +79,7 @@ function plot_triangular_plaquettes(f, frames;
     y_panel = -ny * v₂
     aspect = aspect_ratio(x_panel, y_panel, x_offset, y_offset, numrows, numcols; adhoc_offset=text_offset)
 
-    # Set up figure
+    ## Set up figure
     fig = Figure(; fig_kwargs...)
     if force_aspect
         ax = Axis(fig[1, 1:length(frames)]; aspect)
@@ -89,7 +89,7 @@ function plot_triangular_plaquettes(f, frames;
     hidespines!(ax)
     hidedecorations!(ax)
 
-    # Plot panels
+    ## Plot panels
     plaq1(p) = Makie.Polygon(Point2f.([p, p+v₁+v₂, p+v₂]))
     plaq2(p) = Makie.Polygon(Point2f.([p, p+v₁, p+v₂+v₁]))
     for (i, frame) ∈ enumerate(frames)


### PR DESCRIPTION
This updates comments from `#` to `##` in the examples/extra folder so that they can be written as Jupyter notebooks.