### PR TITLE
Support vacancies in spin wave theory

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sunny"
 uuid = "2b4a2ac8-8f8b-43e8-abf4-3cb0c45e8736"
 authors = ["The Sunny team"]
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -1,5 +1,11 @@
 # Version History
 
+## v0.7.6
+(In development)
+
+* Vacancies defined by [`set_vacancy_at!`](@ref) are supported in linear spin
+  wave theory. Empty sites are modeled using bosons that do not excite.
+
 ## v0.7.5
 (Jan 20, 2025)
 

--- a/src/Operators/Rotation.jl
+++ b/src/Operators/Rotation.jl
@@ -10,14 +10,16 @@ function angle_between_vectors(u, v)
 end
 
 # Returns that smallest rotation matrix R such that `R u = v` where u and v are
-# the normalized input vectors. If `u = v` then `R = I` and if `u = -v` then R
+# the input vectors, normalized. If `u = v` then `R = I` and if `u = -v` then R
 # is a rotation by π about an arbitrary axis perpendicular to u and v.
 function rotation_between_vectors(u, v)
+    @assert !iszero(u) && !iszero(v)
+
     u, v = normalize.((u, v))
     axis = u × v
     θ = angle_between_vectors(u, v)
 
-    if iszero(norm(axis))
+    if iszero(axis)
         # Need to find an arbitrary axis that is orthogonal to u and v. First,
         # find a normalized vector w such that w⋅u ≠ ±1.
         _, i = findmin(abs.(u))
@@ -30,12 +32,13 @@ function rotation_between_vectors(u, v)
     return R
 end
 
-# Magnitude of axis n is ignored. Angle θ in radians. By Rodrigues formula, is
+# Magnitude of axis is ignored. Angle θ in radians. By Rodrigues formula, is
 # equivalently written `I + s K + (1-c) K²`, with `K = [0 -z y; z 0 -x; -y x 0]`
-# involving `s, c = sincos(θ)` and `x, y, z = normalize(n)`.
-function axis_angle_to_matrix(n, θ)
-    @assert !iszero(norm(n))
-    x, y, z = normalize(n)
+# involving `s, c = sincos(θ)` and `x, y, z = normalize(axis)`.
+function axis_angle_to_matrix(axis, θ)
+    @assert !iszero(axis)
+
+    x, y, z = normalize(axis)
     s, c = sincos(θ)
     t = 1 - c
     return SA[t*x*x+c    t*x*y-z*s  t*x*z+y*s

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -31,7 +31,7 @@ end
 #   x̄ du/dα = x̄ du/dv P
 #
 @inline function vjp_stereographic_projection(x̄, α, n)
-    all(isnan, n) && return zero(Vec3) # No gradient when α = [0, 0, 0] is fixed
+    all(isnan, n) && return zero(n') # No gradient when α is fixed to zero
 
     @assert n'*n ≈ 1
 
@@ -47,7 +47,7 @@ end
 
 # Returns v such that u = (2v + (1-v²)n)/(1+v²) and v⋅n = 0
 function inverse_stereographic_projection(u, n)
-    all(isnan, n) && return zero(Vec3) # NaN values denote α = v = [0, 0, 0]
+    all(isnan, n) && return zero(n) # NaN values denote α = v = zero
 
     @assert u'*u ≈ 1
 

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -195,7 +195,6 @@ function multiply_by_hamiltonian_dipole!(y::AbstractMatrix{ComplexF64}, x::Abstr
     # Pair interactions 
     for ints in sys.interactions_union
 
-        # Bilinear exchange
         for coupling in ints.pair
             (; isculled, bond) = coupling
             isculled && break
@@ -209,6 +208,7 @@ function multiply_by_hamiltonian_dipole!(y::AbstractMatrix{ComplexF64}, x::Abstr
                 cis(2π*dot(q, bond.n))
             end
 
+            # Bilinear exchange
             if !iszero(coupling.bilin)
                 J = coupling.bilin  # This is Rij in previous notation (transformed exchange matrix)
 

--- a/src/System/OnsiteCoupling.jl
+++ b/src/System/OnsiteCoupling.jl
@@ -187,6 +187,8 @@ See also [`set_onsite_coupling!`](@ref).
 """
 function set_onsite_coupling_at!(sys::System, op, site::Site)
     is_homogeneous(sys) && error("Use `to_inhomogeneous` first.")
+    is_vacant(sys, site) && error("Cannot couple vacant site")
+
     ints = interactions_inhomog(sys)
     site = to_cartesian(site)
     ints[site].onsite = onsite_coupling(sys, site, op)

--- a/src/System/PairExchange.jl
+++ b/src/System/PairExchange.jl
@@ -429,6 +429,7 @@ end
 
 function set_pair_coupling_at_aux!(sys::System, scalar::Float64, bilin::Union{Float64, Mat3}, biquad::Union{Float64, Mat5}, tensordec::TensorDecomposition, site1::Site, site2::Site, offset)
     is_homogeneous(sys) && error("Use `to_inhomogeneous` first.")
+    (is_vacant(sys, site1) || is_vacant(sys, site2)) && error("Cannot couple vacant site")
     ints = interactions_inhomog(sys)
 
     # General interactions require SU(N) mode

--- a/test/shared.jl
+++ b/test/shared.jl
@@ -45,7 +45,7 @@ function add_quadratic_interactions!(sys, mode)
                     0  0 1.1  0 -1.4
                     0  0   0  1    0
                     0  0 1.4  0  1.3]
-        set_pair_coupling!(sys, 0.01(Qi'*biquad*Qj), Bond(1, 1, [0, 0, 1]))
+        set_pair_coupling!(sys, 0.01(Qi'*biquad*Qj), Bond(1, 2, [0, 0, 0]))
         =#
     end
 end

--- a/test/test_energy_consistency.jl
+++ b/test/test_energy_consistency.jl
@@ -4,8 +4,7 @@
 
     function make_system(; mode, inhomog)
         cryst = Sunny.diamond_crystal()
-        # TODO: Debug case of dims=(3, 2, 1)
-        sys = System(cryst, [1 => Moment(s=2, g=2)], mode; dims=(3, 2, 2), seed=0)
+        sys = System(cryst, [1 => Moment(s=2, g=2)], mode; dims=(2, 2, 2), seed=0)
         add_linear_interactions!(sys, mode)
         add_quadratic_interactions!(sys, mode)
         add_quartic_interactions!(sys, mode)
@@ -26,9 +25,9 @@
             # Add some inhomogeneous interactions
             sys2 = to_inhomogeneous(sys)
             @test energy(sys2) ≈ energy(sys)
-            set_vacancy_at!(sys2, (1,1,1,1))
+            set_vacancy_at!(sys2, (1,1,1,2))
             set_exchange_at!(sys2, 0.5, (1,1,1,1), (2,1,1,2); offset=(1, 0, 0))
-            set_pair_coupling_at!(sys2, (Si, Sj) -> 0.7*(Si'*Sj)^2, (3,2,1,2), (3,1,1,3); offset=(0,-1,0))
+            set_pair_coupling_at!(sys2, (Si, Sj) -> 0.7*(Si'*Sj)^2, (2,2,1,2), (2,1,1,3); offset=(0,-1,0))
 
             set_onsite_coupling_at!(sys2, S -> 0.4*(S[1]^4+S[2]^4+S[3]^4), (2,2,1,4))
             return sys2


### PR DESCRIPTION
Make linear spin wave theory compatible with `set_vacancy_at!`. To simplify the indexing of a system, vacant sites are not truly removed. However, they are marked as non-magnetic with `iszero(sys.κs[site])`. When LSWT detects this case, all operators on the vacant site will be set to zero. Consequently, bosons on vacant sites will not be excited, and do not contribute to any intensities. Note, however, that vacant sites will still produce artificial zero-energy bands that must be ignored.