### PR TITLE
Fix `suggest_magnetic_supercell` with multiple wavevectors

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -5,6 +5,8 @@
 
 * Vacancies defined by [`set_vacancy_at!`](@ref) are supported in linear spin
   wave theory. Empty sites are modeled using bosons that do not excite.
+* Fix correctness of [`suggest_magnetic_supercell`](@ref) when multiple
+  wavevectors are provided.
 
 ## v0.7.5
 (Jan 20, 2025)

--- a/src/MagneticOrdering.jl
+++ b/src/MagneticOrdering.jl
@@ -100,20 +100,20 @@ suggest_magnetic_supercell([[0, 0, 1/√5], [0, 0, 1/√7]]; tol=1e-2)
 ```
 """
 function suggest_magnetic_supercell(ks; tol=1e-12, maxsize=100)
+    denoms = zeros(Int, 3)
     new_ks = zeros(Rational{Int}, 3, length(ks))
 
     for i in 1:3
         xs = [k[i] for k in ks]
         numers, denom = rationalize_simultaneously(xs; tol, maxsize)
+        denoms[i] = denom
         new_ks[i, :] = numers .// denom
     end
 
-    suggest_magnetic_supercell_aux(eachcol(new_ks))
+    suggest_magnetic_supercell_aux(eachcol(new_ks), denoms)
 end
 
-function suggest_magnetic_supercell_aux(ks)
-    denoms = denominator.(first(ks))
-
+function suggest_magnetic_supercell_aux(ks, denoms)
     # All possible periodic offsets, sorted by length
     nmax = div.(denoms, 2)
     ns = [[n1, n2, n3] for n1 in -nmax[1]:nmax[1], n2 in -nmax[2]:nmax[2], n3 in -nmax[3]:nmax[3]][:]
@@ -125,7 +125,7 @@ function suggest_magnetic_supercell_aux(ks)
 
     # Filter out elements of ns that are not consistent with k ∈ ks
     for k in ks
-        ns = filter(ns) do n            
+        ns = filter(ns) do n
             # Wave vector `k` in RLU is commensurate if `n⋅k` is integer,
             # corresponding to the condition `exp(-i 2π n⋅k) = 1`.
             isinteger(n⋅k)

--- a/src/MagneticOrdering.jl
+++ b/src/MagneticOrdering.jl
@@ -100,7 +100,7 @@ suggest_magnetic_supercell([[0, 0, 1/√5], [0, 0, 1/√7]]; tol=1e-2)
 ```
 """
 function suggest_magnetic_supercell(ks; tol=1e-12, maxsize=100)
-    @assert eltype(ks) <: AbstractVector{<: Number} "Pass a list of wavevectors"
+    eltype(ks) <: AbstractVector{<: Number} || error("Pass a list of wavevectors")
 
     rational_ks = zeros(Rational{Int}, 3, length(ks))
     for i in 1:3

--- a/test/test_resize.jl
+++ b/test/test_resize.jl
@@ -36,6 +36,18 @@
 
             [[0, 1/2, 0]]
         """
+    capt = IOCapture.capture() do
+        suggest_magnetic_supercell([[1/2,0,0], [0,1/2,0]])
+    end
+    @test capt.output == """
+        Possible magnetic supercell in multiples of lattice vectors:
+
+            [2 0 0; 0 2 0; 0 0 1]
+
+        for the rationalized wavevectors:
+
+            [[1/2, 0, 0], [0, 1/2, 0]]
+        """
 
     A1 = [1 0 0; 0 2 0; 0 0 1]
     A2 = [1 0 0; 1 2 0; 0 0 1]
@@ -43,7 +55,7 @@
     newsys2 = reshape_supercell(sys, A2)
 
     @test energy_per_site(sys) ≈ 2.55
-    
+
     newsys = reshape_supercell(sys, A1)
     @test energy_per_site(newsys) ≈ 2.55
     newsys = reshape_supercell(sys, A2)


### PR DESCRIPTION
With this fix, `suggest_magnetic_supercell([1/2, 0, 0], [0, 1/2, 0])` correctly reports `[2 0 0; 0 2 0; 0 0 1]`.