### PR TITLE
Remove EntangledSpinWaveTheory

### DIFF
--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -12,7 +12,6 @@ struct EntangledSpinWaveTheory <: AbstractSpinWaveTheory
 
     crystal_origin   :: Crystal
     contraction_info :: CrystalContractionInfo
-    Ns_unit          :: Vector{Vector{Int64}}
 end
  
 
@@ -28,7 +27,8 @@ function SpinWaveTheory(esys::EntangledSystem; measure, regularization=1e-8)
         error("Size mismatch. Check that measure is built using consistent system.")
     end
 
-    # Reshape (flatten) both sys and sys_origin in corresponding ways
+    # Reshape (flatten) both sys and sys_origin in corresponding ways.
+    # The reshaped sys_origin will just be used to construct
     sys, sys_origin = map([sys, sys_origin]) do sys
         new_shape = cell_shape(sys) * diagm(Vec3(sys.dims))
         new_cryst = reshape_crystal(orig_crystal(sys), new_shape)
@@ -57,7 +57,7 @@ function SpinWaveTheory(esys::EntangledSystem; measure, regularization=1e-8)
 
     data = swt_data_entangled(sys, sys_origin, new_Ns_unit, new_contraction_info, measure)
 
-    return EntangledSpinWaveTheory(sys, data, measure, regularization, crystal_origin, new_contraction_info, new_Ns_unit)
+    return EntangledSpinWaveTheory(sys, data, measure, regularization, crystal_origin, new_contraction_info)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", swt::EntangledSpinWaveTheory)

--- a/src/EntangledUnits/EntangledUnits.jl
+++ b/src/EntangledUnits/EntangledUnits.jl
@@ -238,8 +238,8 @@ end
 
 
 # More battle-tested approach. Iterates over over contracted system. Move to
-# iteration scheme of original system moving forward for clarity and support of
-# inhomogenous interactioninteractions
+# iteration scheme over original system moving forward for clarity and support of
+# inhomogenous interactions.
 function entangle_system(sys::System{M}, units) where M
     # Construct contracted crystal
     contracted_crystal, contraction_info = contract_crystal(sys.crystal, units)


### PR DESCRIPTION
Setting up a PR to keep track of necessary steps to complete the initial version of "Entangled Units."

- [ ] Make `EntangledSpinWaveTheory` a regular `SpinWaveTheory` and eliminate associated code duplication.
- [ ] To facilitate the above, update intensities calculations to incorporate `offsets` from the `MeasureSpec`.
- [ ] Consider revision of SampledCorrelations to follow similar model (and eliminate fields added to supported entangled units).
- [ ] Correct treatment of `g-factors` from original system.
- [ ] Add stronger tests for Entangled Units spin wave theory, in particular with attention to reshaping and non `q=0` orderings.

A related issue, which may not be for this PR, is to extend the `EntangledSystem` constructor to deal with inhomogenous systems.