### PR TITLE
Self-consistent Gaussian Approximation (SCGA)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sunny"
 uuid = "2b4a2ac8-8f8b-43e8-abf4-3cb0c45e8736"
 authors = ["The Sunny team"]
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -21,7 +21,7 @@ LocalSampler
 Moment
 SampledCorrelations
 SampledCorrelationsStatic
-StaticCorrelationsSCGA
+SCGA
 Site
 SpinWaveTheory
 SpinWaveTheoryKPM

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -21,6 +21,7 @@ LocalSampler
 Moment
 SampledCorrelations
 SampledCorrelationsStatic
+StaticCorrelationsSCGA
 Site
 SpinWaveTheory
 SpinWaveTheoryKPM
@@ -35,6 +36,7 @@ dmvec
 domain_average
 eachsite
 enable_dipole_dipole!
+enable_spin_rescaling_for_static_sum_rule!
 energy
 energy_per_site
 excitations

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,9 +3,8 @@
 ## v0.7.6
 (May 1, 2025)
 
-* Add module [`StaticCorrelationsSCGA`](@ref) for calculating
-  [`intensities_static`](@ref) within the self-consistent Gaussian
-  approximation.
+* Add module [`SCGA`](@ref) for calculating [`intensities_static`](@ref) within
+  the self-consistent Gaussian approximation.
 * Add [`enable_spin_rescaling_for_static_sum_rule!`](@ref) which sets the
   classical dipole magnitude to ``\sqrt{s (s + 1)}`` for each quantum spin-``s``
   moment.

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,6 +3,12 @@
 ## v0.7.6
 (May 1, 2025)
 
+* Add module [`StaticCorrelationsSCGA`](@ref) for calculating
+  [`intensities_static`](@ref) within the self-consistent Gaussian
+  approximation.
+* Add [`enable_spin_rescaling_for_static_sum_rule!`](@ref) which sets the
+  classical dipole magnitude to ``\sqrt{s (s + 1)}`` for each quantum spin-``s``
+  moment.
 * Extend [`powder_average`](@ref) to support static intensities.
 * Vacancies defined by [`set_vacancy_at!`](@ref) are supported in linear spin
   wave theory. Empty sites are modeled using bosons that do not excite.

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -1,10 +1,14 @@
 # Version History
 
-## v0.7.6
-(May 1, 2025)
+## v0.7.7
+(In development)
 
 * Add module [`SCGA`](@ref) for calculating [`intensities_static`](@ref) within
   the self-consistent Gaussian approximation.
+
+## v0.7.6
+(May 1, 2025)
+
 * Add [`enable_spin_rescaling_for_static_sum_rule!`](@ref) which sets the
   classical dipole magnitude to ``\sqrt{s (s + 1)}`` for each quantum spin-``s``
   moment.

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,15 +3,15 @@
 ## v0.7.7
 (In development)
 
+* Add [`enable_spin_rescaling_for_static_sum_rule!`](@ref) which sets the
+  classical dipole magnitude to ``\sqrt{s (s + 1)}`` for each quantum spin-``s``
+  moment.
 * Add module [`SCGA`](@ref) for calculating [`intensities_static`](@ref) within
   the self-consistent Gaussian approximation.
 
 ## v0.7.6
 (May 1, 2025)
 
-* Add [`enable_spin_rescaling_for_static_sum_rule!`](@ref) which sets the
-  classical dipole magnitude to ``\sqrt{s (s + 1)}`` for each quantum spin-``s``
-  moment.
 * Extend [`powder_average`](@ref) to support static intensities.
 * Vacancies defined by [`set_vacancy_at!`](@ref) are supported in linear spin
   wave theory. Empty sites are modeled using bosons that do not excite.

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -215,8 +215,8 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
                 end
             end
 
-            map!(corrbuf, measure.corr_pairs) do (α, β)
-                Avec[α] * conj(Avec[β]) / Ncells
+            map!(corrbuf, measure.corr_pairs) do (μ, ν)
+                Avec[μ] * conj(Avec[ν]) / Ncells
             end
             intensity[band, iq] = thermal_prefactor(disp[band, iq]; kT) * measure.combiner(q_global, corrbuf)
         end

--- a/src/SCGA/NewtonBacktracking.jl
+++ b/src/SCGA/NewtonBacktracking.jl
@@ -1,4 +1,4 @@
-function newton_with_backtracking(fgh!, x0; f_reltol=NaN, x_reltol=NaN, g_abstol=NaN, maxiters=20, armijo_c=1e-2, armijo_backoff=0.1, armijo_α_min=1e-4, show_trace=false)
+function newton_with_backtracking(fgh!, x0; f_reltol=NaN, x_reltol=NaN, g_abstol=NaN, maxiters=20, armijo_c=1e-4, armijo_backoff=0.5, armijo_α_min=1e-4, show_trace=false)
     # Make a copy of the initial guess.
     x = copy(x0)
 
@@ -45,7 +45,7 @@ function newton_with_backtracking(fgh!, x0; f_reltol=NaN, x_reltol=NaN, g_abstol
         end
 
         if show_trace
-            println("Iter $k: f(x)=$candidate_f, x=$candidate_x, α=$α, |g|=$(norm(g))")
+            println("Iter $k: α=$α, |g|=$(norm(g)), f(x)=$candidate_f, x=$candidate_x")
         end
         has_converged(x, candidate_x, f, candidate_f, g) && return candidate_x
 

--- a/src/SCGA/NewtonBacktracking.jl
+++ b/src/SCGA/NewtonBacktracking.jl
@@ -1,0 +1,56 @@
+function newton_with_backtracking(fgh!, x0; g_abstol=NaN, f_reltol=1e-12, maxiters=20, armijo_c=1e-4, armijo_backoff=0.5, armijo_α_min=1e-6, show_trace=false)
+    # Make a copy of the initial guess.
+    x = copy(x0)
+
+    # Preallocate buffers
+    candidate_x = zero(x0)
+    g = zero(x0)
+    H = zeros(eltype(x0), length(x0), length(x0))
+    p = zero(x0)
+
+    # Evaluate objective function f, gradient, and Hessian.
+    f = fgh!(0.0, g, H, x)
+
+    function has_converged(f, candidate_f, g)
+        return (norm(g) < g_abstol) || isapprox(f, candidate_f; rtol=f_reltol)
+    end
+    has_converged(NaN, NaN, g) && return x
+
+    for k in 1:maxiters
+        # Newton direction p = H \ g. If H is not guaranteed positive definite,
+        # then use lu! instead of cholesky! decomposition.
+        ldiv!(p, cholesky!(Hermitian(H)), g)
+
+        # To be used for Armijo backtracking.
+        g_dot_p = dot(g, p)
+
+        # Start with full Newton step.
+        α = 1.0
+
+        # Candidate updates to x and f.
+        @. candidate_x = x - α * p
+        candidate_f = fgh!(0.0, g, H, candidate_x)
+
+        # Backtracking line search until Armijo condition is satisfied:
+        # f(candidate_x) ≤ f(x) - c * α * dot(g, p)
+        while candidate_f > f - armijo_c * α * g_dot_p
+            has_converged(f, candidate_f, g) && return x
+            α < armijo_α_min && error("Failed to satisfy Armijo condition. Consider reducing armijo_α_min=$armijo_α_min or a tolerance parameter.")
+
+            α *= armijo_backoff
+            @. candidate_x = x - α * p
+            candidate_f = fgh!(0.0, g, H, candidate_x)
+        end
+
+        if show_trace
+            println("Iter $k: f(x)=$candidate_f, x=$candidate_x, α=$α, |g|=$(norm(g))")
+        end
+        has_converged(f, candidate_f, g) && return x
+
+        # Accept candidate updates. Note that g and H will also be reused.
+        x .= candidate_x
+        f = candidate_f
+    end
+
+    error("Failed to converge in maxiters=$maxiters iterations.")
+end

--- a/src/SCGA/SCGA.jl
+++ b/src/SCGA/SCGA.jl
@@ -1,9 +1,9 @@
 """
     SCGA(sys::System; measure, kT, dq)
 
-Constructs an object to calculate [`intensities_static`](@ref) within the self
-consistent gaussian approximation (SCGA). This theory assumes a classical
-Boltzmann distribution with temperature `kT`. It is expected to be meangingful
+Constructs an object to calculate [`intensities_static`](@ref) within the
+self-consistent Gaussian approximation (SCGA). This theory assumes a classical
+Boltzmann distribution with temperature `kT`. It is expected to be meaningful
 above the ordering temperature, where fluctuations are approximately Gaussian.
 
 Only `:dipole` and `:dipole_uncorrected` system modes are supported.

--- a/src/SCGA/SCGA.jl
+++ b/src/SCGA/SCGA.jl
@@ -1,5 +1,5 @@
 """
-    StaticCorrelationsSCGA(sys::System; measure, kT, dq)
+    SCGA(sys::System; measure, kT, dq)
 
 Constructs an object to calculate [`intensities_static`](@ref) within the self
 consistent gaussian approximation (SCGA). This theory assumes a classical
@@ -21,13 +21,13 @@ calculations can be accelerated. Construct a smaller system with
 discretized ``𝐪``-point grid runs over the full Brillouin zone associated with
 the primitive cell of the crystal.
 """
-struct StaticCorrelationsSCGA
+struct SCGA
     sys :: System
     measure :: MeasureSpec
     β :: Float64
     λs :: Vector{Float64}
 
-    function StaticCorrelationsSCGA(sys::System; measure::Union{Nothing, MeasureSpec}, kT::Real, dq::Float64)
+    function SCGA(sys::System; measure::Union{Nothing, MeasureSpec}, kT::Real, dq::Float64)
         sys.dims == (1, 1, 1) || error("System dims must be (1, 1, 1).")
 
         measure = @something measure empty_measurespec(sys)
@@ -167,7 +167,7 @@ function find_lagrange_multiplier_multi(sys, Js, β, λ_init)
 end
 
 
-function intensities_static(scga::StaticCorrelationsSCGA, qpts)
+function intensities_static(scga::SCGA, qpts)
     (; sys, measure, λs, β) = scga
     Λ = Diagonal(repeat(λs, inner=3))
 

--- a/src/SCGA/StaticCorrelationsSCGA.jl
+++ b/src/SCGA/StaticCorrelationsSCGA.jl
@@ -1,0 +1,200 @@
+"""
+    StaticCorrelationsSCGA(sys::System; measure, kT, dq)
+
+Constructs an object to calculate [`intensities_static`](@ref) within the self
+consistent gaussian approximation (SCGA). This theory assumes a classical
+Boltzmann distribution with temperature `kT`. It is expected to be meangingful
+above the ordering temperature, where fluctuations are approximately Gaussian.
+
+Only `:dipole` and `:dipole_uncorrected` system modes are supported.
+
+The theory of SCGA approximates local spin magnitude constraints with a _weaker_
+global constraint condition. For each spin sublattice, the global spin sum rule
+can be expressed as an integral over the unit cube ``𝐪 ∈ [0,1]^3`` for
+wavevectors ``𝐪`` in reciprocal lattice units (RLU). Each such integral will be
+approximated as a discrete sum over a regular grid of `floor(1/dq)^3`
+wavevectors for the provided `dq` value.
+
+If the conventional crystal cell admits a smaller primitive cell, then the SCGA
+calculations can be accelerated. Construct a smaller system with
+[`reshape_supercell`](@ref) and [`primitive_cell`](@ref). In this case, the
+discretized ``𝐪``-point grid runs over the full Brillouin zone associated with
+the primitive cell of the crystal.
+"""
+struct StaticCorrelationsSCGA
+    sys :: System
+    measure :: MeasureSpec
+    β :: Float64
+    λs :: Vector{Float64}
+
+    function StaticCorrelationsSCGA(sys::System; measure::Union{Nothing, MeasureSpec}, kT::Float64, dq::Float64)
+        measure = @something measure empty_measurespec(sys)
+        if size(eachsite(sys)) != size(measure.observables)[2:5]
+            error("Size mismatch. Check that measure is built using consistent system.")
+        end
+
+        kT > 0 || error("Temperature kT must be positive")
+        β = 1 / kT
+
+        qs = make_q_grid(sys, dq)
+        Js = [fourier_exchange_matrix(sys; q) for q in qs]
+
+        sublattice_resolved = !allequal(sys.crystal.classes)
+        if sublattice_resolved
+            λs = find_lagrange_multiplier_opt_sublattice(sys, Js, β)
+        else
+            λ = find_lagrange_multiplier(sys, Js, β)
+            λs = fill(λ, natoms(sys.crystal))
+        end
+
+        return new(sys, measure, β, λs)
+    end
+end
+
+function make_q_grid(sys, dq)
+    wraps = [false, false, false]
+    for i in 1:natoms(sys.crystal)
+        for coupling in sys.interactions_union[i].pair
+            (; isculled, bond) = coupling
+            isculled && break
+            @. wraps = wraps || !iszero(bond.n)
+        end
+    end
+
+    qα = [w ? (-1/2 : dq : 1/2-dq) : [0] for w in wraps]
+    return vec([to_standard_rlu(sys, Vec3(q_reshaped)) for q_reshaped in Iterators.product(qα...)])
+end
+
+# Computes the Lagrange multiplier for the standard SCGA approach with a common
+# Lagrange multiplier for all sublattices.
+function find_lagrange_multiplier(sys, Js, β)
+    starting_offset = 0.2
+    maxiters = 500
+    tol = 1e-10
+
+    evals = Iterators.flatten(eigvals(J) for J in Js)
+
+    Nq = length(Js)
+    s² = norm2(sys.κs)
+
+    function f(λ)
+        return sum(1 / (λ + ev) for ev in evals) / (β * Nq)
+    end
+    function J(λ)
+        return -sum(1 / (λ + ev)^2 for ev in evals) / (β * Nq)
+    end
+
+    λn = starting_offset*0.1/β - minimum(evals)
+    for n in 1:maxiters
+        λ = λn + (1/J(λn))*(s²-f(λn))
+        if abs(λ-λn) < tol
+            println("Newton's method converged to within tolerance, $tol, after $n steps.")
+            return λ
+        else
+            λn = λ
+        end
+    end
+end
+
+
+function find_lagrange_multiplier_opt_sublattice(sys, Js, β)
+    tol = 1e-6
+    maxiters = 500
+
+    Na = natoms(sys.crystal)
+    evals = Iterators.flatten(eigvals(J) for J in Js)
+    λ_min, λ_max = extrema(evals)
+    λ_init = -λ_min + (λ_max - λ_min) / 2
+    λs = λ_init*ones(Float64, Na)
+    s² = vec(sys.κs .^ 2)
+
+    function fg!(_, gbuffer, λs)
+        fbuffer = 0.0
+        if !isnothing(gbuffer)
+            gbuffer .= 0
+        end
+
+        Λ = diagm(repeat(λs, inner=3))
+
+        for J in Js
+            A = β * (J + Λ)
+            T = eigen(A)
+            eig_vals = T.values
+            U = T.vectors
+            A⁻¹ = U * Diagonal(inv.(eig_vals)) * U'
+            A⁻¹ = reshape(A⁻¹, 3, Na, 3, Na)
+
+            if minimum(eig_vals) < 0
+                F = -Inf
+            else
+                F = (1/2β) * sum(log.(eig_vals))
+            end
+            # To maximize free energy G = F - λᵢ sᵢ² we should minimize f = -G
+            fbuffer += λs' * s² / 2 - F
+
+            if !isnothing(gbuffer)
+                for i in 1:Na
+                    gbuffer[i] += s²[i] / 2 - real(tr(view(A⁻¹, :, i, :, i))) / 2
+                end
+            end
+        end
+
+        return fbuffer
+    end
+
+    # f(λs) = fg!(NaN, nothing, λs)
+
+    options = Optim.Options(; iterations=maxiters, show_trace=false, g_tol=tol)
+    result = Optim.optimize(Optim.only_fg!(fg!), λs, Optim.ConjugateGradient(), options)
+    min = Optim.minimizer(result)
+    return real.(min)
+end
+
+
+function intensities_static(scga::StaticCorrelationsSCGA, qpts)
+    (; sys, measure, λs, β) = scga
+    Λ = Diagonal(repeat(λs, inner=3))
+
+    qpts = convert(AbstractQPoints, qpts)
+    cryst = orig_crystal(scga.sys)
+
+    Na = nsites(sys)
+    Ncells = Na / natoms(cryst)
+    Nq = length(qpts.qs)
+
+    Nobs = num_observables(measure)
+    Ncorr = length(measure.corr_pairs)
+    corrbuf = zeros(ComplexF64, Ncorr)
+
+    intensity = zeros(eltype(measure), Nq)
+
+    r = sys.crystal.positions
+
+    for (iq, q) in enumerate(qpts.qs)
+        pref = zeros(ComplexF64, Nobs, Na)
+        q_reshaped = to_reshaped_rlu(sys, q)
+        q_global = cryst.recipvecs * q
+        for i in 1:Na, μ in 1:3
+            ff = get_swt_formfactor(measure, μ, i)
+            pref[μ, i] = exp(-2π * im * dot(q_reshaped, r[i])) * compute_form_factor(ff, norm2(q_global))
+        end
+        Jq = fourier_exchange_matrix(sys; q)
+        inverted_matrix = inv(β*Λ + β*Jq) # this is [(Iλ+J(q))^-1]^αβ_μν
+        inverted_matrix = reshape(inverted_matrix, 3, Na, 3, Na)
+
+        ssf = zero(CMat3)
+        for i in 1:Na, j in 1:Na
+            ssf += pref[1, i] * conj(pref[1, j]) * view(inverted_matrix, :, i, :, j)
+        end
+
+        @assert ssf ≈ ssf'
+        @assert all(>=(0), real(diag(ssf)))
+
+        map!(corrbuf, measure.corr_pairs) do (α, β)
+            ssf[α, β] / Ncells
+        end
+        intensity[iq] = measure.combiner(q_global, corrbuf)
+    end
+
+    return StaticIntensities(sys.crystal, qpts, reshape(intensity, size(qpts.qs)))
+end

--- a/src/SCGA/StaticCorrelationsSCGA.jl
+++ b/src/SCGA/StaticCorrelationsSCGA.jl
@@ -27,7 +27,7 @@ struct StaticCorrelationsSCGA
     β :: Float64
     λs :: Vector{Float64}
 
-    function StaticCorrelationsSCGA(sys::System; measure::Union{Nothing, MeasureSpec}, kT::Float64, dq::Float64)
+    function StaticCorrelationsSCGA(sys::System; measure::Union{Nothing, MeasureSpec}, kT::Real, dq::Float64)
         sys.dims == (1, 1, 1) || error("System dims must be (1, 1, 1).")
 
         measure = @something measure empty_measurespec(sys)

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -172,7 +172,6 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
     disp = zeros(Float64, L, Nq)
     intensity = zeros(eltype(measure), L, Nq)
 
-
     for (iq, q) in enumerate(qpts.qs)
         q_global = cryst.recipvecs * q
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)
@@ -214,8 +213,8 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
                 end
             end
 
-            map!(corrbuf, measure.corr_pairs) do (α, β)
-                Avec[α] * conj(Avec[β]) / Ncells
+            map!(corrbuf, measure.corr_pairs) do (μ, ν)
+                Avec[μ] * conj(Avec[ν]) / Ncells
             end
             intensity[band, iq] = thermal_prefactor(disp[band, iq]; kT) * measure.combiner(q_global, corrbuf)
         end

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -177,7 +177,7 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)
 
         for i in 1:Na, μ in 1:Nobs
-            r_global = global_position(sys, (1,1,1,i)) # + offsets[μ,i]
+            r_global = global_position(sys, (1, 1, 1, i)) # + offsets[μ, i]
             ff = get_swt_formfactor(measure, μ, i)
             Avec_pref[μ, i] = exp(- im * dot(q_global, r_global))
             Avec_pref[μ, i] *= compute_form_factor(ff, norm2(q_global))

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -43,7 +43,7 @@ function SpinWaveTheory(sys::System; measure::Union{Nothing, MeasureSpec}, regul
     end
 
     measure = @something measure empty_measurespec(sys)
-    if nsites(sys) != prod(size(measure.observables)[2:5])
+    if size(eachsite(sys)) != size(measure.observables)[2:5]
         error("Size mismatch. Check that measure is built using consistent system.")
     end
 
@@ -89,9 +89,13 @@ function nbands(swt::SpinWaveTheory)
 end
 
 
+function to_standard_rlu(sys::System, q_reshaped)
+    return orig_crystal(sys).recipvecs \ (sys.crystal.recipvecs * q_reshaped)
+end
+
 # Given q in reciprocal lattice units (RLU) for the original crystal, return a
 # q_reshaped in RLU for the possibly-reshaped crystal.
-function to_reshaped_rlu(sys::System{N}, q) where N
+function to_reshaped_rlu(sys::System, q)
     return sys.crystal.recipvecs \ (orig_crystal(sys).recipvecs * q)
 end
 

--- a/src/Spiral/LuttingerTisza.jl
+++ b/src/Spiral/LuttingerTisza.jl
@@ -14,16 +14,16 @@ function fourier_exchange_matrix(sys::System; q)
 
             (; j, n) = bond
             J = exp(2π * im * dot(q_reshaped, n)) * Mat3(bilin*I)
-            J_q[:, i, :, j] += J
-            J_q[:, j, :, i] += J'
+            J_q[:, i, :, j] .+= J
+            J_q[:, j, :, i] .+= J'
         end
     end
 
     if !isnothing(sys.ewald)
-        A_q = Sunny.precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), q_reshaped) * sys.ewald.μ0_μB²
+        A_q = precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), q_reshaped) * sys.ewald.μ0_μB²
         A_q = reshape(A_q, Na, Na)
         for i in 1:Na, j in 1:Na
-            J_q[:, i, :, j] += sys.gs[i]' * A_q[i, j] * sys.gs[j]
+            J_q[:, i, :, j] .+= sys.gs[i]' * A_q[i, j] * sys.gs[j]
         end
     end
 
@@ -34,12 +34,12 @@ function fourier_exchange_matrix(sys::System; q)
         anisotropy = SA[c2[1]-c2[3]        c2[5] 0.5c2[2];
                               c2[5] -c2[1]-c2[3] 0.5c2[4];
                            0.5c2[2]     0.5c2[4]   2c2[3]]
-        J_q[:, i, :, i] += 2 * anisotropy
+        J_q[:, i, :, i] .+= 2 * anisotropy
     end
 
     J_q = reshape(J_q, 3Na, 3Na)
     @assert diffnorm2(J_q, J_q') < 1e-15
-    return hermitianpart(J_q)
+    return hermitianpart!(J_q)
 end
 
 

--- a/src/Spiral/LuttingerTisza.jl
+++ b/src/Spiral/LuttingerTisza.jl
@@ -53,8 +53,8 @@ end
 # propagation wavevector k between chemical cells. The LT analysis minimizes
 # energy E = (1/2) Sₖ† Jₖ Sₖ, where Sₖ is some length-3Nₐ vector and Jₖ is the
 # 3Nₐ×3Nₐ exchange matrix. Given a minimum energy eigenpair (λₖ, Sₖ) the
-# LT-predicted energy is |Sₖ|^2 λₖ/2 with normalization |Sₖ|^2 = ∑ᵢ|Sᵢ|^2, where
-# i denotes spin sublattice of the chemical cell. If the components of Sₖ
+# LT-predicted energy is |Sₖ|^2 λₖ/2 with normalization |Sₖ|² = ∑ᵢ|Sᵢ|², where
+# index i denotes spin sublattice of the chemical cell. If the components of Sₖ
 # satisfy local spin normalization constraints, then the LT energy minimized
 # over k is physically correct for the spiral ground state. In practice, the
 # eigenvector Sₖ may violate local spin normalization and the LT-predicted

--- a/src/Spiral/SpinWaveTheorySpiral.jl
+++ b/src/Spiral/SpinWaveTheorySpiral.jl
@@ -25,7 +25,7 @@ struct SpinWaveTheorySpiral <: AbstractSpinWaveTheory
 
     function SpinWaveTheorySpiral(sys::System; k::AbstractVector, axis::AbstractVector, measure::Union{Nothing, MeasureSpec}, regularization=1e-8)
         if !(sys.mode in (:dipole, :dipole_uncorrected))
-            error("SCGA requires :dipole or :dipole_uncorrected mode.")
+            error("SpinWaveTheorySpiral requires :dipole or :dipole_uncorrected mode.")
         end
 
         L = length(eachsite(sys))

--- a/src/Spiral/SpinWaveTheorySpiral.jl
+++ b/src/Spiral/SpinWaveTheorySpiral.jl
@@ -219,24 +219,24 @@ end
 
 # Observables must be dipole moments, with some choice of apply_g. Extract and
 # return this parameter.
-function is_apply_g(swt::SpinWaveTheory, measure::MeasureSpec)
+function is_apply_g(sys::System, measure::MeasureSpec)
     obs1 = measure.observables
     for apply_g in (true, false)
-        obs2 = all_dipole_observables(swt.sys; apply_g)
+        obs2 = all_dipole_observables(sys; apply_g)
         vec(obs1) ≈ vec(obs2) && return apply_g
     end
     error("General measurements not supported for spiral calculation")
 end
 
-function gs_as_scalar(swt::SpinWaveTheory, measure::MeasureSpec)
-    return if is_apply_g(swt, measure)
-        map(swt.sys.gs) do g
+function gs_as_scalar(sys::System, measure::MeasureSpec)
+    return if is_apply_g(sys, measure)
+        map(sys.gs) do g
             g = to_float_or_mat3(g; atol=1e-12)
             g isa Float64 || error("Anisotropic g-tensor not supported for spiral calculation")
             g
         end
     else
-        map(swt.sys.gs) do _
+        map(sys.gs) do _
             1.0
         end
     end
@@ -282,7 +282,7 @@ function intensities_bands(sswt::SpinWaveTheorySpiral, qpts; kT=0) # TODO: branc
     Avec_pref = zeros(ComplexF64, Na)
 
     # If g-tensors are included in observables, they must be scalar. Precompute.
-    gs = gs_as_scalar(swt, measure)
+    gs = gs_as_scalar(sys, measure)
 
     for (iq, q) in enumerate(qpts.qs)
         q_global = cryst.recipvecs * q

--- a/src/Spiral/SpiralEnergy.jl
+++ b/src/Spiral/SpiralEnergy.jl
@@ -26,14 +26,15 @@ normal to the polarization plane (in global Cartesian coordinates).
 
 When ``𝐤`` is incommensurate, this calculation can be viewed as creating an
 infinite number of periodic copies of `sys`. The spins on each periodic copy are
-rotated about the `axis` vector, with the angle ``θ = 2π 𝐤⋅𝐫``, where `𝐫`
+rotated about the `axis` vector, with the angle ``θ = 2π 𝐤⋅𝐫``, where ``𝐫``
 denotes the displacement vector between periodic copies of `sys` in multiples of
 the lattice vectors of the chemical cell.
 
-The return value is the energy associated with one periodic copy of `sys`. The
-special case ``𝐤 = 0`` yields result is identical to [`energy`](@ref).
+The return value is the energy associated with one periodic copy of `sys`.
+Selecting ``𝐤 = 0`` yields the ordinary system [`energy`](@ref).
 
-See also [`minimize_spiral_energy!`](@ref) and [`repeat_periodically_as_spiral`](@ref).
+See also [`minimize_spiral_energy!`](@ref) and
+[`repeat_periodically_as_spiral`](@ref).
 """
 function spiral_energy(sys::System{0}; k, axis)
     sys.mode in (:dipole, :dipole_uncorrected) || error("SU(N) mode not supported")

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -116,6 +116,7 @@ include("SampledCorrelations/DataRetrieval.jl")
 export SampledCorrelations, SampledCorrelationsStatic, add_sample!, clone_correlations,
     merge_correlations
 
+include("SCGA/NewtonBacktracking.jl")
 include("SCGA/StaticCorrelationsSCGA.jl")
 export StaticCorrelationsSCGA
 

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -117,8 +117,8 @@ export SampledCorrelations, SampledCorrelationsStatic, add_sample!, clone_correl
     merge_correlations
 
 include("SCGA/NewtonBacktracking.jl")
-include("SCGA/StaticCorrelationsSCGA.jl")
-export StaticCorrelationsSCGA
+include("SCGA/SCGA.jl")
+export SCGA
 
 include("EntangledUnits/TypesAndAliasing.jl")
 include("EntangledUnits/EntangledUnits.jl")

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -60,7 +60,8 @@ include("System/OnsiteCoupling.jl")
 include("System/Ewald.jl")
 include("System/Interactions.jl")
 export Moment, System, Site, clone_system, eachsite, position_to_site, global_position, magnetic_moment,
-    set_coherent!, set_dipole!, polarize_spins!, randomize_spins!, set_spin_rescaling!, energy, energy_per_site,
+    set_coherent!, set_dipole!, polarize_spins!, randomize_spins!, set_spin_rescaling!,
+    enable_spin_rescaling_for_static_sum_rule!, energy, energy_per_site,
     spin_label, set_onsite_coupling!, set_pair_coupling!, set_exchange!, dmvec, enable_dipole_dipole!,
     set_field!, to_inhomogeneous, set_field_at!, set_vacancy_at!, set_onsite_coupling_at!,
     set_exchange_at!, set_pair_coupling_at!, symmetry_equivalent_bonds, remove_periodicity!,
@@ -114,6 +115,9 @@ include("SampledCorrelations/PhaseAveraging.jl")
 include("SampledCorrelations/DataRetrieval.jl")
 export SampledCorrelations, SampledCorrelationsStatic, add_sample!, clone_correlations,
     merge_correlations
+
+include("SCGA/StaticCorrelationsSCGA.jl")
+export StaticCorrelationsSCGA
 
 include("EntangledUnits/TypesAndAliasing.jl")
 include("EntangledUnits/EntangledUnits.jl")

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -552,10 +552,10 @@ Sets the classical dipole magnitude to ``\\sqrt{s(s+1)}`` rather than ``s`` for
 each quantum spin-``s`` moment. Valid only for systems in dipole mode.
 
 This dipole rescaling convention may be helpful in combination with
-[`SampledCorrelationsStatic`](@ref) or [`StaticCorrelationsSCGA`](@ref)
-calculators, which sample spins from the classical Boltzmann distribution. The
-estimated [`intensities_static`](@ref) ``\\mathcal{S}(𝐪)``, when integrated
-over all ``𝐪``, will be exactly consistent with the quantum-mechanical identity
+[`SampledCorrelationsStatic`](@ref) or [`SCGA`](@ref) calculators, which sample
+spins from the classical Boltzmann distribution. The estimated
+[`intensities_static`](@ref) ``\\mathcal{S}(𝐪)``, when integrated over all
+``𝐪``, will be exactly consistent with the quantum-mechanical identity
 ``⟨\\hat{S}^2⟩ = s(s+1)`` for dipole operator ``\\hat{S}``.
 
 At high temperatures, this dipole rescaling may also be useful in combination

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -1,0 +1,173 @@
+@testitem "diamond_lattice" begin
+    # test against JuliaSCGA (S. Gao)
+    res_jscga = [0.7046602277469309, 0.8230846832863896, 0.23309034250417973, 0.40975668535137943, 0.8474163786642979,
+                 0.8230846832694241, 0.723491683211756, 0.5939752161027589, 0.6506966347286152, 0.8012263819500781]
+    a = 8.5031 # (Å)
+    latvecs = lattice_vectors(a, a, a, 90, 90, 90)
+    cryst = Crystal(latvecs, [[0, 0, 0]], 227; choice="1")
+    s = 3/2
+    sys = System(cryst, [1 => Moment(; s, g=1)], :dipole; seed=0)
+    sys = reshape_supercell(sys, primitive_cell(cryst))
+    set_exchange!(sys, -1/s^2, Bond(1, 3, [0, 0, 0]))
+    set_exchange!(sys, 1/(2s)^2, Bond(1, 2, [0, 0, 0]))
+    measure = ssf_perp(sys)
+    kT = 15*meV_per_K
+    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/8)
+    γ = s^2 * Sunny.natoms(cryst)
+    grid = q_space_grid(cryst, [1, 0, 0], range(0, 3.6, 5), [0, 1, 0], range(0, 0.9, 2))
+    res = intensities_static(scga, grid)
+    @test isapprox(vec(res.data)/γ, res_jscga; rtol=1e-8)
+end
+
+@testitem "square_lattice" begin
+    # test against JuliaSCGA (S. Gao)
+    res_jscga = [0.3578208506624103, 0.3850668587212228, 0.4211633125595451, 0.3930558742921638, 0.3586715762816389,
+                 0.3775147329089877, 0.4188431376589759, 0.4009835864744404, 0.36119385315852837]
+    a = 1 # (Å)
+    latvecs = lattice_vectors(a, a, 10a, 90, 90, 90)
+    cryst = Crystal(latvecs, [[0, 0, 0]])
+    sys = System(cryst, [1 => Moment(; s=1, g=1)], :dipole; seed=0)
+    set_exchange!(sys, -1, Bond(1, 1, [1, 0, 0]))
+    set_exchange!(sys, 0.5, Bond(1, 1, [1, 1, 0]))
+    set_exchange!(sys, 0.25, Bond(1, 1, [2, 0, 0]))
+    measure = ssf_perp(sys)
+    kT = 27.5*meV_per_K
+    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/8)
+    path = q_space_path(cryst, [[-1, -1, 0], [-0.04, -1, 0]], 9)
+    res = Sunny.intensities_static(scga, path)
+    @test isapprox(vec(res.data)/2, res_jscga; rtol=1e-5)
+end
+
+@testitem "MgCr2O4" begin
+    using LinearAlgebra
+    # Reproduce calculation in Conlon and Chalker, PRL 102, 237206 (2009)
+    latvecs = lattice_vectors(8.3342, 8.3342, 8.3342, 90, 90, 90)
+    positions = [[1/2, 1/2, 1/2]]
+    cryst = Crystal(latvecs, positions, 227)
+    s = 3/2
+    sys = System(cryst, [1 => Moment(; s, g=1)], :dipole)
+    sys = reshape_supercell(sys, primitive_cell(cryst))
+    enable_spin_rescaling_for_static_sum_rule!(sys)
+    J1 = 3.27                                            # in meV, from Bai's PRL
+    J_mgcro = [1.0, 0.0815, 0.1050, 0.0085] * J1         # further neighbor pyrochlore relevant for MgCr2O4
+    set_exchange!(sys, J_mgcro[1], Bond(1, 2, [0, 0, 0]))  # J1
+    set_exchange!(sys, J_mgcro[2], Bond(1, 7, [0, 0, 0]))  # J2
+    set_exchange!(sys, J_mgcro[3], Bond(1, 3, [1, 0, 0]))  # J3a
+    set_exchange!(sys, J_mgcro[4], Bond(1, 3, [0, 0, 0]))  # J3b
+    measure = ssf_custom((q, ssf) -> real(ssf[1,1]), sys)
+    kT = 20*meV_per_K
+    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/4)
+    grid = q_space_grid(cryst, [1, 0, 0], range(-1.5, 1.5, 4), [0, 1, 0], range(-1.5, 1.5, 4))
+    res = Sunny.intensities_static(scga, grid)
+    res_cc = [2.4168819 1.237733 1.237733 2.4168819;
+              1.237733 0.16242284 0.16242284 1.237733;
+              1.237733 0.16242284 0.16242284 1.237733;
+              2.4168819 1.237733 1.237733 2.4168819]
+    γ = s*(s+1) / det(primitive_cell(cryst)) # Adapt to normalization convention of C+C
+    @test isapprox(vec(res.data), γ*vec(res_cc); rtol=1e-3)
+end
+
+@testitem "Arbitrary Anisotropy" begin
+    # test against JuliaSCGA (S. Gao)
+    res_jscga = [0.700944539713289, 0.6175127864675868, 0.5205893697530085, 0.48172879530096047,
+                 0.5219040226511135, 0.6218544838522482, 0.7110417061581527, 0.738269833048121]
+    latvecs = lattice_vectors(1, 1, 10, 90, 90, 90)
+    cryst = Crystal(latvecs, [[0,0,0]],1)
+    sys = System(cryst, [1 => Moment(; s=1, g=1)], :dipole; seed=0)
+    set_exchange!(sys, -1, Bond(1, 1, [1,0,0]))
+    set_exchange!(sys, -1, Bond(1, 1, [0,1,0]))
+    set_exchange!(sys, 0.5, Bond(1, 1, [1,1,0]))
+    set_exchange!(sys, 0.5, Bond(1, 1, [-1,1,0]))
+    set_exchange!(sys, 0.25, Bond(1, 1, [2,0,0]))
+    set_exchange!(sys, 0.25, Bond(1, 1, [0,2,0]))
+    to_inhomogeneous(sys)
+    anis = [0.23 0.56 0.34;
+            0.56 0.12 0.45;
+            0.34 0.45 0.67]
+    anis = 0.5.*(anis + anis')
+    set_onsite_coupling!(sys, S -> S'*anis*S, 1)
+    measure = ssf_perp(sys)
+    kT = 55*meV_per_K
+    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/8)
+    path = q_space_path(cryst, [[0.125, 0.625, 0], [1, 0.625, 0]], 8)
+    res = Sunny.intensities_static(scga, path)
+    @test isapprox(vec(res.data), res_jscga; rtol=1e-6)
+end
+
+@testitem "Ferrimagnetic chain sum rule" begin
+    latvecs = lattice_vectors(3, 5, 8, 90, 90, 90)
+    positions = [[0, 0, 0], [0.5, 0, 0]]
+    types = ["Ni2", "Fe3"]
+    cryst = Crystal(latvecs, positions;types)
+    s1 = 1
+    s2 = 5/2
+    moments = [1 => Moment(; s=s1, g=1), 2 => Moment(; s=s2, g=1)]
+    sys = System(cryst, moments, :dipole)
+    J1 = 1
+    set_exchange!(sys, J1, Bond(1, 2, [0, 0, 0]))
+    measure = ssf_trace(sys; apply_g=false)
+    kT = 22.5*meV_per_K
+    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/100)
+    qs = [[qx, 0, 0] for qx in range(0, 2, 100)]
+    res = Sunny.intensities_static(scga, qs)
+    @test isapprox(sum(res.data)/length(qs), s1^2 + s2^2; rtol=1e-2)
+end
+
+@testitem "Ferrimagnetic chain" begin
+    latvecs = lattice_vectors(3, 5, 8, 90, 90, 90)
+    positions = [[0, 0, 0], [0.5, 0, 0]]
+    types = ["Ni2","Fe3"]
+    cryst = Crystal(latvecs, positions; types)
+    moments = [1 => Moment(; s=1, g=1),2 => Moment(; s=5/2, g=1)]
+    sys = System(cryst, moments, :dipole)
+    J1 = 1
+    set_exchange!(sys, J1, Bond(1, 2, [0, 0, 0]))
+    measure = ssf_trace(sys; apply_g=false)
+    kT = 17.5 * meV_per_K
+    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/40)
+    qs = q_space_path(cryst, [[0, 0, 0], [2, 0, 0]], 5)
+    res = Sunny.intensities_static(scga, qs)
+    # println(round.(res.data; digits=12))
+    golden_data = [5.279822408597, 4.864293310586, 16.331744429121, 4.864293310586, 5.279822408597]
+    @test isapprox(golden_data, res.data; atol=1e-9)
+end
+
+@testitem "SCGA Kitchen sink" begin
+    using LinearAlgebra
+    a = 5.
+    c = 17.
+    latvecs = lattice_vectors(a, a, c, 90, 90, 120)
+    positions = [[2/3, 1/3, 0.5], [1/3, 2/3, 0.25]]
+    types = ["Fe", "Mn"]
+    cryst = Crystal(latvecs, positions, 148; types)
+    moments = [1 => Moment(; s=1, g=3.4), 7 => Moment(; s=2, g=2)]
+    sys = System(cryst, moments, :dipole)
+    sys = reshape_supercell(sys, primitive_cell(cryst)) # Works either way!
+    J1 = -2.0*diagm([1, 1, 1.2])
+    J2 = 5.25*[1 0.05 0; 0.05 1 0; 0 0 0]
+    J3 = 0.75*diagm([1, 0.25, 1.23]) + 0.23dmvec([0.23, 0.87, 0.43])
+    J4 = 0.25*diagm([0.34, 0.12, 1.16]) + 0.23dmvec([0.98, 0.65, 0.353])
+    J5 = 0.23*[1 0 0; 0 1 0.34; 0 0.34 0]
+    J6 = -0.1*diagm([1, 1, 1.8]) + 0.086dmvec([0, 0, 1])
+    J7 = 0.098*diagm([1, 1, 1.8]) + 0.021dmvec([0.2, 0.34, 0.65])
+    J8 =  -0.23*diagm([1, 0.8, 1]) + 0.021dmvec([0.94, 0.24, 0.15])
+    J9 = 1*diagm([1.21, 1.11, 0.76]) + 0.3dmvec([0.7, 0.61, 0.62])
+    J10 = -0.265diagm([1, 1, 0.45])
+    D1 = -0.27
+    D2 = 0.12
+    set_exchange!(sys, J1, Bond(7, 8, [0, 0, 0])) # Mn dimer XXZ
+    set_exchange!(sys, J2, Bond(1, 2, [0, 0, 0])) # Fe HC 1nn XYZ + PsD
+    set_exchange!(sys, J3, Bond(1, 7, [0, 0, 0])) # Mn-Fe  XYZ + DMI [GHI]
+    set_exchange!(sys, J4, Bond(1, 8, [0, 0, 0])) # Mn-Fe  XYZ + DMI [GHI]
+    set_exchange!(sys, J7, Bond(1, 1, [1, 0, 0])) # Fe HC 2nn XYZ + DMI [G H I]
+    set_exchange!(sys, J8, Bond(7, 7, [1, 0, 0])) # Mn in-plane XYZ + DMI [G H I]
+    set_onsite_coupling!(sys, S -> D1*S[3]^2, 1)
+    set_onsite_coupling!(sys, S -> D2*S[3]^2, 7)
+    measure = ssf_perp(sys)
+    kT = 80.5*meV_per_K
+    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/4)
+    qs = [[0, 0, 0], [0, 1/2, 1/2], [0.06, 0.49, 0.59]]
+    res = Sunny.intensities_static(scga, qs)
+    golden_data = [31.01225057947166, 21.57163073261797, 21.573267694880727]
+    @test isapprox(res.data, golden_data; rtol=1e-3)
+end

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -128,7 +128,7 @@ end
     qs = q_space_path(cryst, [[0, 0, 0], [2, 0, 0]], 5)
     res = Sunny.intensities_static(scga, qs)
     # println(round.(res.data; digits=12))
-    golden_data = [5.279822408597, 4.864293310586, 16.331744429121, 4.864293310586, 5.279822408597]
+    golden_data = [5.279823931604, 4.864293896132, 16.331751863295, 4.864293896132, 5.279823931604]
     @test isapprox(golden_data, res.data; atol=1e-9)
 end
 
@@ -168,6 +168,7 @@ end
     scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/4)
     qs = [[0, 0, 0], [0, 1/2, 1/2], [0.06, 0.49, 0.59]]
     res = Sunny.intensities_static(scga, qs)
-    golden_data = [31.01225057947166, 21.57163073261797, 21.573267694880727]
-    @test isapprox(res.data, golden_data; rtol=1e-3)
+    # println(round.(res.data; digits=12))
+    golden_data = [30.9994728142, 21.567001306416, 21.568681851738]
+    @test isapprox(res.data, golden_data; rtol=1e-9)
 end

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -169,6 +169,6 @@ end
     qs = [[0, 0, 0], [0, 1/2, 1/2], [0.06, 0.49, 0.59]]
     res = Sunny.intensities_static(scga, qs)
     # println(round.(res.data; digits=10))
-    golden_data = [30.9994727537, 21.5670012852, 21.5686818308]
+    golden_data = [129.5389081127, 111.0369328807, 112.1694261822]
     @test isapprox(res.data, golden_data; rtol=1e-8)
 end

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -116,7 +116,7 @@ end
 @testitem "Ferrimagnetic chain" begin
     latvecs = lattice_vectors(3, 5, 8, 90, 90, 90)
     positions = [[0, 0, 0], [0.5, 0, 0]]
-    types = ["Ni2","Fe3"]
+    types = ["Ni2", "Fe3"]
     cryst = Crystal(latvecs, positions; types)
     moments = [1 => Moment(; s=1, g=1),2 => Moment(; s=5/2, g=1)]
     sys = System(cryst, moments, :dipole)

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -12,7 +12,7 @@
     set_exchange!(sys, 1/(2s)^2, Bond(1, 2, [0, 0, 0]))
     measure = ssf_perp(sys)
     kT = 15*meV_per_K
-    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/8)
+    scga = SCGA(sys; measure, kT, dq=1/8)
     γ = s^2 * Sunny.natoms(cryst)
     grid = q_space_grid(cryst, [1, 0, 0], range(0, 3.6, 5), [0, 1, 0], range(0, 0.9, 2))
     res = intensities_static(scga, grid)
@@ -32,7 +32,7 @@ end
     set_exchange!(sys, 0.25, Bond(1, 1, [2, 0, 0]))
     measure = ssf_perp(sys)
     kT = 27.5*meV_per_K
-    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/8)
+    scga = SCGA(sys; measure, kT, dq=1/8)
     path = q_space_path(cryst, [[-1, -1, 0], [-0.04, -1, 0]], 9)
     res = Sunny.intensities_static(scga, path)
     @test isapprox(vec(res.data)/2, res_jscga; rtol=1e-5)
@@ -56,7 +56,7 @@ end
     set_exchange!(sys, J_mgcro[4], Bond(1, 3, [0, 0, 0]))  # J3b
     measure = ssf_custom((q, ssf) -> real(ssf[1,1]), sys)
     kT = 20*meV_per_K
-    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/4)
+    scga = SCGA(sys; measure, kT, dq=1/4)
     grid = q_space_grid(cryst, [1, 0, 0], range(-1.5, 1.5, 4), [0, 1, 0], range(-1.5, 1.5, 4))
     res = Sunny.intensities_static(scga, grid)
     res_cc = [2.4168819 1.237733 1.237733 2.4168819;
@@ -88,7 +88,7 @@ end
     set_onsite_coupling!(sys, S -> S'*anis*S, 1)
     measure = ssf_perp(sys)
     kT = 55*meV_per_K
-    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/8)
+    scga = SCGA(sys; measure, kT, dq=1/8)
     path = q_space_path(cryst, [[0.125, 0.625, 0], [1, 0.625, 0]], 8)
     res = Sunny.intensities_static(scga, path)
     @test isapprox(vec(res.data), res_jscga; rtol=1e-6)
@@ -107,7 +107,7 @@ end
     set_exchange!(sys, J1, Bond(1, 2, [0, 0, 0]))
     measure = ssf_trace(sys; apply_g=false)
     kT = 22.5*meV_per_K
-    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/100)
+    scga = SCGA(sys; measure, kT, dq=1/100)
     qs = [[qx, 0, 0] for qx in range(0, 2, 100)]
     res = Sunny.intensities_static(scga, qs)
     @test isapprox(sum(res.data)/length(qs), s1^2 + s2^2; rtol=1e-2)
@@ -124,7 +124,7 @@ end
     set_exchange!(sys, J1, Bond(1, 2, [0, 0, 0]))
     measure = ssf_trace(sys; apply_g=false)
     kT = 17.5 * meV_per_K
-    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/40)
+    scga = SCGA(sys; measure, kT, dq=1/40)
     qs = q_space_path(cryst, [[0, 0, 0], [2, 0, 0]], 5)
     res = Sunny.intensities_static(scga, qs)
     # println(round.(res.data; digits=10))
@@ -165,7 +165,7 @@ end
     set_onsite_coupling!(sys, S -> D2*S[3]^2, 7)
     measure = ssf_perp(sys)
     kT = 80.5*meV_per_K
-    scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/4)
+    scga = SCGA(sys; measure, kT, dq=1/4)
     qs = [[0, 0, 0], [0, 1/2, 1/2], [0.06, 0.49, 0.59]]
     res = Sunny.intensities_static(scga, qs)
     # println(round.(res.data; digits=10))

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -48,8 +48,8 @@ end
     sys = System(cryst, [1 => Moment(; s, g=1)], :dipole)
     sys = reshape_supercell(sys, primitive_cell(cryst))
     enable_spin_rescaling_for_static_sum_rule!(sys)
-    J1 = 3.27                                            # in meV, from Bai's PRL
-    J_mgcro = [1.0, 0.0815, 0.1050, 0.0085] * J1         # further neighbor pyrochlore relevant for MgCr2O4
+    J1 = 3.27                                              # In meV, from Bai's PRL
+    J_mgcro = [1.0, 0.0815, 0.1050, 0.0085] * J1           # Further exchanges for MgCr2O4
     set_exchange!(sys, J_mgcro[1], Bond(1, 2, [0, 0, 0]))  # J1
     set_exchange!(sys, J_mgcro[2], Bond(1, 7, [0, 0, 0]))  # J2
     set_exchange!(sys, J_mgcro[3], Bond(1, 3, [1, 0, 0]))  # J3a

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -72,14 +72,14 @@ end
     res_jscga = [0.700944539713289, 0.6175127864675868, 0.5205893697530085, 0.48172879530096047,
                  0.5219040226511135, 0.6218544838522482, 0.7110417061581527, 0.738269833048121]
     latvecs = lattice_vectors(1, 1, 10, 90, 90, 90)
-    cryst = Crystal(latvecs, [[0,0,0]],1)
+    cryst = Crystal(latvecs, [[0, 0 ,0]], 1)
     sys = System(cryst, [1 => Moment(; s=1, g=1)], :dipole; seed=0)
-    set_exchange!(sys, -1, Bond(1, 1, [1,0,0]))
-    set_exchange!(sys, -1, Bond(1, 1, [0,1,0]))
-    set_exchange!(sys, 0.5, Bond(1, 1, [1,1,0]))
-    set_exchange!(sys, 0.5, Bond(1, 1, [-1,1,0]))
-    set_exchange!(sys, 0.25, Bond(1, 1, [2,0,0]))
-    set_exchange!(sys, 0.25, Bond(1, 1, [0,2,0]))
+    set_exchange!(sys, -1, Bond(1, 1, [1, 0, 0]))
+    set_exchange!(sys, -1, Bond(1, 1, [0, 1, 0]))
+    set_exchange!(sys, 0.5, Bond(1, 1, [1, 1, 0]))
+    set_exchange!(sys, 0.5, Bond(1, 1, [-1, 1, 0]))
+    set_exchange!(sys, 0.25, Bond(1, 1, [2, 0, 0]))
+    set_exchange!(sys, 0.25, Bond(1, 1, [0, 2, 0]))
     to_inhomogeneous(sys)
     anis = [0.23 0.56 0.34;
             0.56 0.12 0.45;

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -127,9 +127,9 @@ end
     scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/40)
     qs = q_space_path(cryst, [[0, 0, 0], [2, 0, 0]], 5)
     res = Sunny.intensities_static(scga, qs)
-    # println(round.(res.data; digits=12))
-    golden_data = [5.279823931604, 4.864293896132, 16.331751863295, 4.864293896132, 5.279823931604]
-    @test isapprox(golden_data, res.data; atol=1e-9)
+    # println(round.(res.data; digits=10))
+    golden_data = [5.2798224086, 4.8642933106, 16.3317444291, 4.8642933106, 5.2798224086]
+    @test isapprox(golden_data, res.data; rtol=1e-8)
 end
 
 @testitem "SCGA Kitchen sink" begin
@@ -168,7 +168,7 @@ end
     scga = StaticCorrelationsSCGA(sys; measure, kT, dq=1/4)
     qs = [[0, 0, 0], [0, 1/2, 1/2], [0.06, 0.49, 0.59]]
     res = Sunny.intensities_static(scga, qs)
-    # println(round.(res.data; digits=12))
-    golden_data = [30.9994728142, 21.567001306416, 21.568681851738]
-    @test isapprox(res.data, golden_data; rtol=1e-9)
+    # println(round.(res.data; digits=10))
+    golden_data = [30.9994727537, 21.5670012852, 21.5686818308]
+    @test isapprox(res.data, golden_data; rtol=1e-8)
 end


### PR DESCRIPTION
Takes inspiration from [Spinteract](https://arxiv.org/abs/2210.09016) and [JuliaSCGA](https://github.com/moon-dust/JuliaSCGA.jl). However, this implementation is unique in that it allows for a distinct sum-rule constraint on each symmetry-inequivalent sublattice. It turns out that we can determine the Lagrange multipliers by _maximizing_ the appropriate free energy as worked out in the attached note:
[SCGA-notes.lyx.zip](https://github.com/user-attachments/files/19985137/SCGA-notes.lyx.zip)
[SCGA-notes.pdf](https://github.com/user-attachments/files/19985141/SCGA-notes.pdf)

We use a custom implementation of Newton-Raphson with backtracking using an Armijo condition. Optim's implementation of Newton-Raphson method uses line search, which requires more overall iterations and provides less control in the tolerance parameters.

Test the new feature using `add Sunny#scga` and then try this example code:

```jl
    # Reproduce calculation in Conlon and Chalker, PRL 102, 237206 (2009)
    latvecs = lattice_vectors(8.3342, 8.3342, 8.3342, 90, 90, 90)
    positions = [[1/2, 1/2, 1/2]]
    cryst = Crystal(latvecs, positions, 227)
    sys = System(cryst, [1 => Moment(; s=3/2, g=1)], :dipole)
    sys = reshape_supercell(sys, primitive_cell(cryst))
    enable_spin_rescaling_for_static_sum_rule!(sys)
    J1 = 3.27                                            # in meV, from Bai's PRL
    J_mgcro = [1.0, 0.0815, 0.1050, 0.0085] * J1         # further neighbor pyrochlore relevant for MgCr2O4
    set_exchange!(sys, J_mgcro[1], Bond(1, 2, [0,0,0]))  # J1
    set_exchange!(sys, J_mgcro[2], Bond(1, 7, [0,0,0]))  # J2
    set_exchange!(sys, J_mgcro[3], Bond(1, 3, [1,0,0]))  # J3a -- Careful here!
    set_exchange!(sys, J_mgcro[4], Bond(1, 3, [0,0,0]))  # J3b -- And here!
    measure = ssf_custom((q, ssf) -> real(sum(ssf)), sys)
    kT = 20*meV_per_K
    scga = SCGA(sys; measure, kT, dq=1/4)
    grid = q_space_grid(cryst, [1, 0, 0], range(-4, 4, 17), [0, 1, 0], range(-4, 4, 17); orthogonalize=true)
    res = intensities_static(scga, grid)
```

At high temperatures, the result should be consistent with [intensities_static](https://sunnysuite.github.io/Sunny.jl/stable/library.html#Sunny.intensities_static) for the [`SampledCorrelations`](https://sunnysuite.github.io/Sunny.jl/stable/library.html#Sunny.SampledCorrelations) calculator in dipole mode.

Initial implementation by Harry Lane.