### PR TITLE
Functions to look up quadratic interactions from a system

### DIFF
--- a/src/Operators/Stevens.jl
+++ b/src/Operators/Stevens.jl
@@ -139,8 +139,8 @@ const stevens_αinv = map(inv, stevens_α)
 # OffsetArray c[k] with indices k = 0..6. Elements of c[k][:] are the Stevens
 # coefficients in descending order q = k..-k.
 function matrix_to_stevens_coefficients(A::HermitianC64)
-    N = size(A,1)
-    @assert N == size(A,2)
+    N = size(A, 1)
+    @assert N == size(A, 2)
 
     return map(OffsetArray(0:6, 0:6)) do k
         if k >= N

--- a/src/Reshaping.jl
+++ b/src/Reshaping.jl
@@ -79,9 +79,10 @@ function reshape_supercell_aux(sys::System{N}, new_cryst::Crystal, new_dims::NTu
     new_dipole_buffers   = Array{Vec3, 4}[]
     new_coherent_buffers = Array{CVec{N}, 4}[]
 
-    # Preserve origin for repeated reshapings. In other words, ensure that
-    # new_sys.origin === sys.origin
-    orig_sys = @something sys.origin sys
+    # The `origin` system always has dims=(1, 1, 1) and uses the original
+    # crystal. Perform a clone because mutable updates to interactions in the
+    # reshaped system will also update interactions in its `origin` system.
+    orig_sys = clone_system(@something sys.origin sys)
 
     new_sys = System(orig_sys, sys.mode, new_cryst, new_dims, new_Ns, new_κs, new_gs, new_ints, new_ewald,
         new_extfield, new_dipoles, new_coherents, new_dipole_buffers, new_coherent_buffers, copy(sys.rng))

--- a/test/test_interaction_setup.jl
+++ b/test/test_interaction_setup.jl
@@ -1,0 +1,37 @@
+@testitem "Interaction lookup" begin
+    using LinearAlgebra
+    latvecs = lattice_vectors(1, 1, 1, 90, 90, 90)
+    positions = [[0, 0, 0], [0.5, 0.5, 0.5]]
+    cryst = Crystal(latvecs, positions, 1)
+
+    function run_test(mode)
+        sys = System(cryst, [1 => Moment(s=1, g=2), 2 => Moment(s=1, g=2)], mode)
+        randomize_spins!(sys)
+
+        D1 = hermitianpart(randn(3, 3))
+        D2 = hermitianpart(randn(3, 3))
+        set_onsite_coupling!(sys, S -> S'*D1*S, 1)
+        set_onsite_coupling!(sys, S -> S'*D2*S, 2)
+
+        sys2 = reshape_supercell(sys, [1 1 0; 0 2 0; 0 0 1])
+        @test energy_per_site(sys) ≈ energy_per_site(sys2)
+
+        @test Sunny.get_quadratic_anisotropy(sys, 1) ≈ D1
+        @test Sunny.get_quadratic_anisotropy(sys, 2) ≈ D2
+        @test Sunny.get_quadratic_anisotropy(sys2, 1) ≈ D1
+        @test Sunny.get_quadratic_anisotropy(sys2, 2) ≈ D2
+
+        J1 = hermitianpart(randn(3, 3))
+        J2 = hermitianpart(randn(3, 3))
+        set_exchange!(sys2, J1, Bond(1, 2, [0, 0, 0]))
+        @test Sunny.get_exchange(sys2, Bond(1, 2, [0, 0, 0])) ≈ J1
+
+        sys3 = to_inhomogeneous(sys2)
+        set_exchange_at!(sys3, J2, (1, 1, 1, 1), (1, 1, 1, 2); offset=[0, 0, 0])
+
+        @test Sunny.get_exchange_at(sys3, (1, 1, 1, 1), (1, 1, 1, 3); offset=[0, 0, 0]) ≈ J1
+        @test Sunny.get_exchange_at(sys3, (1, 1, 1, 1), (1, 1, 1, 2); offset=[0, 0, 0]) ≈ J2
+    end
+
+    foreach(run_test, (:dipole, :dipole_uncorrected, :SUN))
+end

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -497,7 +497,6 @@ end
     @test Sunny.is_anisotropy_valid(cryst, 2, rotate_operator(𝒪[6,2], R))
 end
 
-
 @testitem "Renormalization" begin
     latvecs = lattice_vectors(1.0, 1.1, 1.0, 90, 90, 90)
     msg = "Found a nonconventional tetragonal unit cell. Consider using `lattice_vectors(a, a, c, 90, 90, 90)`."


### PR DESCRIPTION
Add `get_exchange`, `get_quadratic_anisotropy`, and related variants for inhomogeneous systems. We can wait for user-experience reports before adding them to the public API.

The functionality is exercised with this new test:

```jl
@testitem "Interaction lookup" begin
    using LinearAlgebra
    latvecs = lattice_vectors(1, 1, 1, 90, 90, 90)
    positions = [[0, 0, 0], [0.5, 0.5, 0.5]]
    cryst = Crystal(latvecs, positions, 1)

    function run_test(mode)
        sys = System(cryst, [1 => Moment(s=1, g=2), 2 => Moment(s=1, g=2)], mode)
        randomize_spins!(sys)

        D1 = hermitianpart(randn(3, 3))
        D2 = hermitianpart(randn(3, 3))
        set_onsite_coupling!(sys, S -> S'*D1*S, 1)
        set_onsite_coupling!(sys, S -> S'*D2*S, 2)

        sys2 = reshape_supercell(sys, [1 1 0; 0 2 0; 0 0 1])
        @test energy_per_site(sys) ≈ energy_per_site(sys2)

        @test Sunny.get_quadratic_anisotropy(sys, 1) ≈ D1
        @test Sunny.get_quadratic_anisotropy(sys, 2) ≈ D2
        @test Sunny.get_quadratic_anisotropy(sys2, 1) ≈ D1
        @test Sunny.get_quadratic_anisotropy(sys2, 2) ≈ D2

        J1 = hermitianpart(randn(3, 3))
        J2 = hermitianpart(randn(3, 3))
        set_exchange!(sys2, J1, Bond(1, 2, [0, 0, 0]))
        @test Sunny.get_exchange(sys2, Bond(1, 2, [0, 0, 0])) ≈ J1

        sys3 = to_inhomogeneous(sys2)
        set_exchange_at!(sys3, J2, (1, 1, 1, 1), (1, 1, 1, 2); offset=[0, 0, 0])

        @test Sunny.get_exchange_at(sys3, (1, 1, 1, 1), (1, 1, 1, 3); offset=[0, 0, 0]) ≈ J1
        @test Sunny.get_exchange_at(sys3, (1, 1, 1, 1), (1, 1, 1, 2); offset=[0, 0, 0]) ≈ J2
    end

    foreach(run_test, (:dipole, :dipole_uncorrected, :SUN))
end
```