### PR TITLE
Allow custom integrator in SampledCorrelations

### DIFF
--- a/src/EntangledUnits/EntangledSampledCorrelations.jl
+++ b/src/EntangledUnits/EntangledSampledCorrelations.jl
@@ -115,7 +115,7 @@ function SampledCorrelations(esys::EntangledSystem; measure, energies, dt, calcu
     crystal = esys.sys_origin.crystal
     origin_crystal = orig_crystal(esys.sys_origin)
     sc_new = SampledCorrelations(sc.data, sc.M, crystal, origin_crystal, sc.Δω, measure, observables, positions, source_idcs, measure.corr_pairs,
-                                 sc.measperiod, sc.dt, sc.nsamples, sc.samplebuf, sc.corrbuf, sc.space_fft!, sc.time_fft!, sc.corr_fft!, sc.corr_ifft!)
+                                 sc.integrator, sc.measperiod, sc.nsamples, sc.samplebuf, sc.corrbuf, sc.space_fft!, sc.time_fft!, sc.corr_fft!, sc.corr_ifft!)
 
     return EntangledSampledCorrelations(sc_new, esys)
 end

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -1,3 +1,5 @@
+abstract type AbstractIntegrator end
+
 """
     Langevin(dt::Float64; damping::Float64, kT::Float64)
 
@@ -51,7 +53,7 @@ the `damping` parameter varies subtly between `:dipole` and `:SUN` modes.
    states_, Phys. Rev. B **106**, 235154
    (2022)](https://doi.org/10.1103/PhysRevB.106.235154).
 """
-mutable struct Langevin
+mutable struct Langevin <: AbstractIntegrator
     dt      :: Float64
     damping :: Float64
     kT      :: Float64
@@ -106,7 +108,7 @@ arbitrarily long simulation trajectories.
    states_, Phys. Rev. B **104**, 104409
    (2021)](https://doi.org/10.1103/PhysRevB.104.104409).
 """
-mutable struct ImplicitMidpoint
+mutable struct ImplicitMidpoint <: AbstractIntegrator
     dt      :: Float64
     damping :: Float64
     kT      :: Float64
@@ -332,6 +334,7 @@ function step!(sys::System{0}, integrator::Langevin)
 
     return
 end
+
 
 function step!(sys::System{N}, integrator::Langevin) where N
     check_timestep_available(integrator)

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -128,6 +128,11 @@ mutable struct ImplicitMidpoint
 end
 ImplicitMidpoint(; atol) = ImplicitMidpoint(NaN; atol)
 
+function Base.copy(dyn::ImplicitMidpoint)
+    ImplicitMidpoint(dyn.dt; dyn.damping, dyn.kT, dyn.atol)
+end
+
+
 
 function check_timestep_available(integrator)
     isnan(integrator.dt) && error("Set integration timestep `dt`.")

--- a/src/Integrators.jl
+++ b/src/Integrators.jl
@@ -25,7 +25,7 @@ stochastic Landau-Lifshitz equation,
 where ``𝐁 = -dE/d𝐒`` is the effective field felt by the expected spin dipole
 ``𝐒``. The components of ``ξ`` are Gaussian white noise, with magnitude ``√(2
 k_B T λ)`` set by a fluctuation-dissipation theorem. The parameter `damping`
-sets the phenomenological coupling ``λ`` to the thermal bath. 
+sets the phenomenological coupling ``λ`` to the thermal bath.
 
 If the `System` has `mode = :SUN`, then this dynamics generalizes [1] to a
 stochastic nonlinear Schrödinger equation for SU(_N_) coherent states ``𝐙``,
@@ -58,7 +58,7 @@ mutable struct Langevin <: AbstractIntegrator
     damping :: Float64
     kT      :: Float64
 
-    function Langevin(dt; λ=nothing, damping=nothing, kT)
+    function Langevin(dt=NaN; λ=nothing, damping=nothing, kT)
         if !isnothing(λ)
             @warn "`λ` argument is deprecated! Use `damping` instead."
             damping = @something damping λ
@@ -71,10 +71,6 @@ mutable struct Langevin <: AbstractIntegrator
         damping <= 0    && error("Select positive damping")
         return new(dt, damping, kT)
     end
-end
-
-function Langevin(; λ=nothing, damping=nothing, kT)
-    Langevin(NaN; λ, damping, kT)
 end
 
 function Base.copy(dyn::Langevin)
@@ -114,7 +110,7 @@ mutable struct ImplicitMidpoint <: AbstractIntegrator
     kT      :: Float64
     atol    :: Float64
 
-    function ImplicitMidpoint(dt; damping=0, kT=0, atol=1e-12)
+    function ImplicitMidpoint(dt=NaN; damping=0, kT=0, atol=1e-12)
         dt <= 0      && error("Select positive dt")
         kT < 0       && error("Select nonnegative kT")
         damping < 0  && error("Select nonnegative damping")
@@ -126,14 +122,12 @@ mutable struct ImplicitMidpoint <: AbstractIntegrator
         iszero(kT) || error("ImplicitMidpoint with a Langevin thermostat is not currently supported.")
 
         return new(dt, damping, kT, atol)
-    end    
+    end
 end
-ImplicitMidpoint(; atol) = ImplicitMidpoint(NaN; atol)
 
 function Base.copy(dyn::ImplicitMidpoint)
     ImplicitMidpoint(dyn.dt; dyn.damping, dyn.kT, dyn.atol)
 end
-
 
 
 function check_timestep_available(integrator)
@@ -390,7 +384,7 @@ function step!(sys::System{0}, integrator::ImplicitMidpoint; max_iters=100)
     (ΔS, Ŝ, S′, S″, ξ, ∇E) = get_dipole_buffers(sys, 6)
 
     fill_noise!(sys.rng, ξ, integrator)
-    
+
     @. S′ = S
     @. S″ = S
 
@@ -429,12 +423,12 @@ function step!(sys::System{N}, integrator::ImplicitMidpoint; max_iters=100) wher
 
     Z = sys.coherents
     atol = integrator.atol * √length(Z)
-    
+
     (ΔZ, Z̄, Z′, Z″, ζ, HZ) = get_coherent_buffers(sys, 6)
     fill_noise!(sys.rng, ζ, integrator)
 
-    @. Z′ = Z 
-    @. Z″ = Z 
+    @. Z′ = Z
+    @. Z″ = Z
 
     for _ in 1:max_iters
         @. Z̄ = (Z + Z′)/2

--- a/src/SampledCorrelations/CorrelationSampling.jl
+++ b/src/SampledCorrelations/CorrelationSampling.jl
@@ -18,7 +18,7 @@ function observable_values!(buf, sys::System{N}, observables, atom_idcs) where N
     return nothing
 end
 
-function trajectory!(buf, sys, integrator, nsnaps, observables, atom_idcs; measperiod = 1)
+function trajectory!(buf, sys, integrator, nsnaps, observables, atom_idcs; measperiod=1)
     @assert size(observables, 1) == size(buf, 1)
     observable_values!(@view(buf[:,:,:,:,:,1]), sys, observables, atom_idcs)
     for n in 2:nsnaps
@@ -53,7 +53,7 @@ function accum_sample!(sc::SampledCorrelations; window)
 
     # Time offsets (in samples) Δt = [0,1,...,(T-1),-(T-1),...,-1] produced by 
     # the cross-correlation between two length-T signals
-    time_offsets = FFTW.fftfreq(num_time_offsets,num_time_offsets)
+    time_offsets = FFTW.fftfreq(num_time_offsets, num_time_offsets)
 
     # Transform A(q) = ∑ exp(iqr) A(r).
     # This is opposite to the FFTW convention, so we must conjugate
@@ -94,12 +94,16 @@ function accum_sample!(sc::SampledCorrelations; window)
         corr_ifft! * corrbuf
         corrbuf ./= n_contrib
 
+        @assert window in (:cosine, :rectangular)
         if window == :cosine
-          # Apply a cosine windowing to force the correlation at Δt=±(T-1) to be zero
-          # to force periodicity. In terms of the spectrum S(ω), this applys a smoothing
-          # with a characteristic lengthscale of O(1) frequency bins.
-          window_func = cos.(range(0,π,length = num_time_offsets + 1)[1:end-1]).^2
-          corrbuf .*= reshape(window_func,1,1,1,num_time_offsets)
+            # Multiply the real-time correlation data by a cosine window that
+            # smoothly goes to zero at offsets approaching the trajectory
+            # length, Δt → T. This smooth windowing mitigates ringing artifacts
+            # that appear when imposing periodicity on the real-space
+            # trajectory. Note, however, that windowing also broadens the signal
+            # S(ω) on the characteristic scale of one frequency bin Δω = 2π/T.
+            window_func = cos.(range(0, π, length=num_time_offsets+1)[1:end-1]).^2
+            corrbuf .*= reshape(window_func, 1, 1, 1, num_time_offsets)
         end
 
         corr_fft! * corrbuf
@@ -164,13 +168,8 @@ function add_sample!(sc::SampledCorrelations, sys::System; window=:cosine)
     # artifacts. See https://github.com/SunnySuite/Sunny.jl/pull/246 for more
     # discussion about the calculation of intensities from classical dynamics. 
     # 
-    # The `window` parameter to this function is *not* part of Sunny's public
-    # API, and is subject to change at any time. Passing an alternative value
-    # for `window` will replace the smooth cosine window with a rectangular
-    # window (sharp truncation at |t| = T). This experimental feature is
-    # provided so that expert users have the ability to extract real-time
-    # dynamical correlations. In the future, a public API will be designed to
-    # give more direct access to the real-time correlations.
+    # The hidden option `window=:rectangular` will disable smooth windowing.
+    # This may be of interest for extracting real-time dynamical correlations.
 
     new_sample!(sc, sys)
     accum_sample!(sc; window)

--- a/src/SampledCorrelations/CorrelationSampling.jl
+++ b/src/SampledCorrelations/CorrelationSampling.jl
@@ -18,9 +18,8 @@ function observable_values!(buf, sys::System{N}, observables, atom_idcs) where N
     return nothing
 end
 
-function trajectory!(buf, sys, dt, nsnaps, observables, atom_idcs; measperiod = 1)
+function trajectory!(buf, sys, integrator, nsnaps, observables, atom_idcs; measperiod = 1)
     @assert size(observables, 1) == size(buf, 1)
-    integrator = ImplicitMidpoint(dt)
     observable_values!(@view(buf[:,:,:,:,:,1]), sys, observables, atom_idcs)
     for n in 2:nsnaps
         for _ in 1:measperiod
@@ -32,7 +31,7 @@ function trajectory!(buf, sys, dt, nsnaps, observables, atom_idcs; measperiod = 
 end
 
 function new_sample!(sc::SampledCorrelations, sys::System)
-    (; dt, samplebuf, measperiod, observables, atom_idcs) = sc
+    (; integrator, samplebuf, measperiod, observables, atom_idcs) = sc
 
     # Only fill the sample buffer half way; the rest is zero-padding
     buf_size = size(samplebuf, 6)
@@ -41,7 +40,7 @@ function new_sample!(sc::SampledCorrelations, sys::System)
 
     # @assert size(sys.dipoles) == size(samplebuf)[2:5] "`System` size not compatible with given `SampledCorrelations`"
 
-    trajectory!(samplebuf, sys, dt, nsnaps, observables, atom_idcs; measperiod)
+    trajectory!(samplebuf, sys, integrator, nsnaps, observables, atom_idcs; measperiod)
 
     return nothing
 end

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -133,7 +133,7 @@ can can then be extracted as pair-correlation [`intensities`](@ref) with
 appropriate classical-to-quantum correction factors. See also
 [`intensities_static`](@ref), which integrates over energy.
 """
-function SampledCorrelations(sys::System; measure, energies, dt, calculate_errors=false, positions=nothing, integrator=nothing)
+function SampledCorrelations(sys::System; measure, energies, dt, calculate_errors=false, positions=nothing, integrator=ImplicitMidpoint())
     if isnothing(energies)
         n_all_ω = 1
         measperiod = 1
@@ -150,7 +150,7 @@ function SampledCorrelations(sys::System; measure, energies, dt, calculate_error
         Δω = ωmax/(nω-1)
     end
 
-    integrator = @something integrator ImplicitMidpoint(dt)
+    isnan(integrator.dt) || error("Timestep of `integrator` must be uninitialized.")
     integrator.dt = dt
 
     # Determine the positions of the observables in the MeasureSpec. By default,

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -14,7 +14,7 @@ mutable struct SampledCorrelations
     const corr_pairs   :: Vector{NTuple{2, Int}}                 # (ncorr)
 
     # Trajectory specs
-    const integrator   :: Union{ImplicitMidpoint, Langevin}      # Integrator for calculating sample trajectories.
+    const integrator   :: AbstractIntegrator                     # Integrator for calculating sample trajectories.
     const measperiod   :: Int                                    # Steps to skip between saving observables (i.e., downsampling factor for trajectories)
     nsamples           :: Int64                                  # Number of accumulated samples (single number saved as array for mutability)
 

--- a/src/SampledCorrelations/SampledCorrelations.jl
+++ b/src/SampledCorrelations/SampledCorrelations.jl
@@ -14,8 +14,8 @@ mutable struct SampledCorrelations
     const corr_pairs   :: Vector{NTuple{2, Int}}                 # (ncorr)
 
     # Trajectory specs
+    const integrator   :: Union{ImplicitMidpoint, Langevin}      # Integrator for calculating sample trajectories.
     const measperiod   :: Int                                    # Steps to skip between saving observables (i.e., downsampling factor for trajectories)
-    const dt           :: Float64                                # Step size for trajectory integration 
     nsamples           :: Int64                                  # Number of accumulated samples (single number saved as array for mutability)
 
     # Buffers and precomputed data 
@@ -57,7 +57,7 @@ function clone_correlations(sc::SampledCorrelations)
     return SampledCorrelations(
         copy(sc.data), M, sc.crystal, sc.origin_crystal, sc.Δω,
         deepcopy(sc.measure), copy(sc.observables), copy(sc.positions), copy(sc.atom_idcs), copy(sc.corr_pairs),
-        sc.measperiod, sc.dt, sc.nsamples,
+        copy(sc.integrator), sc.measperiod, sc.nsamples,
         copy(sc.samplebuf), copy(sc.corrbuf), space_fft!, time_fft!, corr_fft!, corr_ifft!
     )
 end
@@ -133,7 +133,7 @@ can can then be extracted as pair-correlation [`intensities`](@ref) with
 appropriate classical-to-quantum correction factors. See also
 [`intensities_static`](@ref), which integrates over energy.
 """
-function SampledCorrelations(sys::System; measure, energies, dt, calculate_errors=false, positions=nothing)
+function SampledCorrelations(sys::System; measure, energies, dt, calculate_errors=false, positions=nothing, integrator=nothing)
     if isnothing(energies)
         n_all_ω = 1
         measperiod = 1
@@ -149,6 +149,9 @@ function SampledCorrelations(sys::System; measure, energies, dt, calculate_error
         dt, measperiod = adjusted_dt_and_downsampling_factor(dt, nω, ωmax)
         Δω = ωmax/(nω-1)
     end
+
+    integrator = @something integrator ImplicitMidpoint(dt)
+    integrator.dt = dt
 
     # Determine the positions of the observables in the MeasureSpec. By default,
     # these will just be the atom indices. 
@@ -196,7 +199,7 @@ function SampledCorrelations(sys::System; measure, energies, dt, calculate_error
     origin_crystal = isnothing(sys.origin) ? nothing : sys.origin.crystal
     sc = SampledCorrelations(data, M, sys.crystal, origin_crystal, Δω,
                              measure, copy(measure.observables), positions, atom_idcs, copy(measure.corr_pairs),
-                             measperiod, dt, nsamples,
+                             integrator, measperiod, nsamples,
                              samplebuf, corrbuf, space_fft!, time_fft!, corr_fft!, corr_ifft!)
 
     return sc

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -262,8 +262,8 @@ end
 
 The total system [`energy`](@ref) divided by the number of sites.
 """
-function energy_per_site(sys::System{N}) where N
-    return energy(sys) / nsites(sys)
+function energy_per_site(sys::System{N}; check_normalization=true) where N
+    return energy(sys; check_normalization) / nsites(sys)
 end
 
 """

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -271,8 +271,10 @@ end
 
 The total system energy. See also [`energy_per_site`](@ref).
 """
-function energy(sys::System{N}) where N
-    validate_normalization(sys)
+function energy(sys::System{N}; check_normalization=true) where N
+    if check_normalization 
+        validate_normalization(sys)
+    end
     E = 0.0
 
     # Zeeman coupling to external field

--- a/test/test_intensities_setup.jl
+++ b/test/test_intensities_setup.jl
@@ -55,7 +55,7 @@ end
     sc = SampledCorrelations(sys; dt, energies=range(0.0, 10.0, 100), measure=ssf_perp(sys))
 
     ωs = Sunny.available_energies(sc; negative_energies=true)
-    dts = 0:(sc.dt * sc.measperiod):3
+    dts = 0:(sc.integrator.dt * sc.measperiod):3
     vals = sum(exp.(im .* ωs .* dts'), dims=1)[:]
 
     # Verify it made a delta function

--- a/test/test_rescaling.jl
+++ b/test/test_rescaling.jl
@@ -110,8 +110,8 @@ end
 
 @testitem "Anisotropy SU(N) equivalence" begin
     latvecs = lattice_vectors(1.0, 1.1, 1.0, 90, 90, 90)
-    warnstr = "Found a nonconventional tetragonal unit cell. Consider using `lattice_vectors(a, a, c, 90, 90, 90)`"
-    cryst = @test_warn warnstr Crystal(latvecs, [[0, 0, 0]])
+    msg = "Found a nonconventional tetragonal unit cell. Consider using `lattice_vectors(a, a, c, 90, 90, 90)`."
+    cryst = @test_logs (:warn, msg) Crystal(latvecs, [[0, 0, 0]])
 
     # Dipole system with renormalized anisotropy
     sys0 = System(cryst, [1 => Moment(s=3, g=2)], :dipole)


### PR DESCRIPTION
This PR allows the user to specify an integrator other than an `ImplicitMidpoint` when creating a `SampledCorrelations`. This allows the use of dissipative dynamics when creating sample trajectories.

The change is motivated by Joe Paddison's request for Langevin dynamics with longitudinal fluctuations. 