### PR TITLE
Powder averaging of static intensities

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,12 +3,13 @@
 ## v0.7.6
 (In development)
 
+* Extend [`powder_average`](@ref) to support static intensities.
 * Vacancies defined by [`set_vacancy_at!`](@ref) are supported in linear spin
   wave theory. Empty sites are modeled using bosons that do not excite.
-* Fix correctness of [`suggest_magnetic_supercell`](@ref) when multiple
-  wavevectors are provided.
 * The default implementation of [`SpinWaveTheoryKPM`](@ref) now uses Lanczos for
   higher accuracy.
+* Fix correctness of [`suggest_magnetic_supercell`](@ref) when multiple
+  wavevectors are provided.
 * Fix atom indexing when setting interactions for a reshaped system ([PR
   #359](https://github.com/SunnySuite/Sunny.jl/pull/359)).
 * Normalize `axis` argument to `SpinWaveTheorySpiral` for correctness.

--- a/examples/03_LSWT_SU3_FeI2.jl
+++ b/examples/03_LSWT_SU3_FeI2.jl
@@ -209,7 +209,7 @@ swt = SpinWaveTheory(sys_min; measure=ssf_perp(sys_min))
 qs = [[0,0,0], [1,0,0], [0,1,0], [1/2,0,0], [0,1,0], [0,0,0]]
 path = q_space_path(cryst, qs, 500)
 res = intensities_bands(swt, path)
-plot_intensities(res; units, title="Single Crystal Bands")
+plot_intensities(res; units, ylims=(0, 10), title="Single Crystal Bands")
 
 # To make direct comparison with inelastic neutron scattering (INS) data, we
 # must account for empirical broadening of the data. Model this using a

--- a/examples/04_GSD_FeI2.jl
+++ b/examples/04_GSD_FeI2.jl
@@ -155,7 +155,7 @@ end
 # statistical noise could be reduced by averaging over more thermal samples.
 
 res = intensities(sc, [[0, 0, 0], [0.5, 0.5, 0.5]]; energies, langevin.kT)
-fig = lines(res.energies, res.data[:, 1]; axis=(xlabel="meV", ylabel="Intensity"), label="(0,0,0)")
+fig = lines(res.energies, res.data[:, 1]; axis=(xlabel="Energy (meV)", ylabel="Intensity"), label="(0,0,0)")
 lines!(res.energies, res.data[:, 2]; label="(π,π,π)")
 axislegend()
 fig
@@ -174,7 +174,7 @@ qs = [[0,   0, 0],  # List of wave vectors that define a path
       [0,   0, 0]] 
 qpath = q_space_path(cryst, qs, 500)
 res = intensities(sc, qpath; energies, langevin.kT)
-plot_intensities(res; colorrange=(0.0, 1.0), title="Intensities at T = 2.3 K")
+plot_intensities(res; units, colorrange=(0.0, 1.0), title="Intensities at T = 2.3 K")
 
 # One can also view the intensity along a [`q_space_grid`](@ref) for a fixed
 # energy value. Alternatively, use [`intensities_static`](@ref) to integrate

--- a/examples/08_Momentum_Conventions.jl
+++ b/examples/08_Momentum_Conventions.jl
@@ -86,6 +86,6 @@ res2 = intensities_bands(swt, path)
 # elastic peak at ``𝐪 = [0,0,0]``, reflecting the ferromagnetic ground state.
 
 fig = Figure(size=(768, 300))
-plot_intensities!(fig[1, 1], res1; title="Classical dynamics")
-plot_intensities!(fig[1, 2], res2; title="Spin wave theory")
+plot_intensities!(fig[1, 1], res1; ylims=(0, 15D), title="Classical dynamics")
+plot_intensities!(fig[1, 2], res2; ylims=(0, 15D), title="Spin wave theory")
 fig

--- a/examples/spinw_tutorials/SW01_FM_Heseinberg_chain.jl
+++ b/examples/spinw_tutorials/SW01_FM_Heseinberg_chain.jl
@@ -92,7 +92,7 @@ plot_intensities(res; units)
 # sample points on each spherical shell.
 
 radii = range(0, 2.5, 200) # 1/Å
-energies = range(0, 5, 200) # meV
+energies = range(0, 4.5, 200) # meV
 kernel = gaussian(fwhm=0.1)
 res = powder_average(cryst, radii, 1000) do qs
     intensities(swt, qs; energies, kernel)

--- a/examples/spinw_tutorials/SW02_AFM_Heisenberg_chain.jl
+++ b/examples/spinw_tutorials/SW02_AFM_Heisenberg_chain.jl
@@ -49,5 +49,5 @@ isapprox(res.disp[1, :], res.disp[2, :])
 # `lines` function](https://docs.makie.org/stable/reference/plots/lines).
 
 xs = [q[1] for q in path.qs]
-ys = log10.(res.data[1, :] + res.data[2, :])
-lines(xs, ys; axis=(; xlabel="[H, 0, 0]", ylabel="Log intensity (dimensionless)"))
+ys = res.data[1, :] + res.data[2, :]
+lines(xs, ys; axis=(; xlabel="[H, 0, 0]", ylabel="Intensity", yscale=log10))

--- a/examples/spinw_tutorials/SW08_sqrt3_kagome_AFM.jl
+++ b/examples/spinw_tutorials/SW08_sqrt3_kagome_AFM.jl
@@ -62,7 +62,7 @@ fig
 # empirical `colorrange` that brings the lower-intensity features into focus.
 
 radii = range(0, 2.5, 200)
-energies = range(0, 3, 200)
+energies = range(0, 2.5, 200)
 kernel = gaussian(fwhm=0.05)
 res = powder_average(cryst, radii, 200) do qs
     intensities(swt, qs; energies, kernel)

--- a/examples/spinw_tutorials/SW11_La2CuO4.jl
+++ b/examples/spinw_tutorials/SW11_La2CuO4.jl
@@ -13,11 +13,11 @@ using Sunny, GLMakie
 # selected arbitrarily.
 
 units = Units(:meV, :angstrom)
-latvecs = lattice_vectors(1, 1, 10, 90, 90, 90)
+latvecs = lattice_vectors(3.85, 3.85, 12.25, 90, 90, 90)
 positions = [[0, 0, 0]]
 types = ["Cu"]
 cryst = Crystal(latvecs, positions, 139; types)
-view_crystal(cryst; ndims=2)
+view_crystal(cryst)
 
 # Build a spin system using the exchange parameters from [R. Coldea, Phys. Rev.
 # Lett. **86**, 5377 (2001)](https://doi.org/10.1103/PhysRevLett.86.5377).
@@ -35,7 +35,7 @@ set_exchange!(sys, Jpp, Bond(1, 1, [2, 0, 0]))
 
 randomize_spins!(sys)
 minimize_energy!(sys)
-plot_spins(sys; ndims=2)
+plot_spins(sys)
 
 # Plot the spin wave spectrum for a path through ``𝐪``-space. Apply a manual
 # "quantum correction" that adjusts energy scale by the factor 1.18.
@@ -52,4 +52,4 @@ plot_intensities(res; units)
 # Plot instantaneous itensities, integrated over ω.
 
 res = intensities_static(swt, path)
-plot_intensities(res; colorrange=(0,20), units)
+plot_intensities(res; ylims=(0, 20), units)

--- a/examples/spinw_tutorials/SW18_Distorted_kagome.jl
+++ b/examples/spinw_tutorials/SW18_Distorted_kagome.jl
@@ -91,7 +91,7 @@ plot_intensities(res; units)
 # Plot the powder-averaged intensities
 
 radii = range(0, 2, 100) # (1/Å)
-energies = range(0, 6, 200)
+energies = range(0, 5, 200)
 kernel = gaussian(fwhm=0.05)
 res = powder_average(cryst, radii, 400) do qs
     intensities(swt, qs; energies, kernel)

--- a/ext/PlottingExt/PlotIntensities.jl
+++ b/ext/PlottingExt/PlotIntensities.jl
@@ -69,10 +69,11 @@ function Sunny.plot_intensities!(panel, res::Sunny.BandIntensities{Float64}; col
 
         colorrange_suggest = colorrange_from_data(; broadened.data, saturation, sensitivity, allpositive)
         colormap = @something colormap (allpositive ? Makie.Reverse(:thermal) : :bwr)
-        colorrange = @something colorrange (colorrange_suggest .* 1.1)
+        colorrange = @something colorrange colorrange_suggest
 
         xticklabelrotation = maximum(length.(res.qpts.xticks[2])) > 3 ? π/6 : 0.0
-        ax = Makie.Axis(panel; xlabel="Momentum (r.l.u.)", ylabel, limits=(nothing, ylims ./ unit_energy), res.qpts.xticks, xticklabelrotation, axisopts...)
+        ax = Makie.Axis(panel; xlabel="Momentum (r.l.u.)", ylabel, res.qpts.xticks, xticklabelrotation, axisopts...)
+        Makie.ylims!(ax, ylims ./ unit_energy)
         Makie.heatmap!(ax, axes(res.data, 2), collect(energies / unit_energy), broadened.data'; colorrange, colormap, lowclip=:white)
         for i in axes(res.disp, 1)
             Makie.lines!(ax, res.disp[i,:] / unit_energy; color=:lightskyblue3)
@@ -169,11 +170,11 @@ function Sunny.plot_intensities!(panel, res::Sunny.StaticIntensities{Float64}; c
         Makie.Colorbar(panel[1, 2], hm)
         return ax
     elseif qpts isa Sunny.QPath
-        colorrange = @something colorrange (colorrange_suggest .* 1.1)
+        ylims = @something colorrange (colorrange_suggest .* 1.1)
         xticklabelrotation = maximum(length.(qpts.xticks[2])) > 3 ? π/6 : 0.0
         ax = Makie.Axis(panel; xlabel="Momentum (r.l.u.)", ylabel="Intensity", qpts.xticks, xticklabelrotation, axisopts...)
+        Makie.ylims!(ax, ylims)
         Makie.lines!(ax, data)
-        Makie.ylims!(ax, colorrange)
         return ax
     else
         error("Cannot yet plot $(typeof(res))")
@@ -201,11 +202,11 @@ function Sunny.plot_intensities!(panel, res::Sunny.PowderStaticIntensities{Float
     ylabel = "Intensity"
  
     colorrange_suggest = colorrange_from_data(; res.data, saturation, sensitivity=0, allpositive)
-    colorrange = @something colorrange (colorrange_suggest .* 1.1)
+    ylims = @something colorrange (colorrange_suggest .* 1.1)
 
     ax = Makie.Axis(panel[1, 1]; xlabel, ylabel, axisopts...)
+    Makie.ylims!(ax, ylims)
     Makie.lines!(ax, res.radii, res.data)
-    Makie.ylims!(ax, colorrange)
     return ax
 end
 

--- a/ext/PlottingExt/PlotIntensities.jl
+++ b/ext/PlottingExt/PlotIntensities.jl
@@ -60,7 +60,7 @@ function Sunny.plot_intensities!(panel, res::Sunny.BandIntensities{Float64}; col
  
     if res.qpts isa Sunny.QPath 
         mindisp, maxdisp = extrema(res.disp)
-        ylims = @something ylims (min(0, mindisp), 1.2*maxdisp)
+        ylims = @something ylims (min(0, mindisp), 1.1*maxdisp)
         energies = range(ylims[1], ylims[2], 512)
         fwhm = @something fwhm 0.02*(ylims[2]-ylims[1])
         σ = fwhm/2√(2log(2))

--- a/ext/PlottingExt/PlotIntensities.jl
+++ b/ext/PlottingExt/PlotIntensities.jl
@@ -69,7 +69,7 @@ function Sunny.plot_intensities!(panel, res::Sunny.BandIntensities{Float64}; col
 
         colorrange_suggest = colorrange_from_data(; broadened.data, saturation, sensitivity, allpositive)
         colormap = @something colormap (allpositive ? Makie.Reverse(:thermal) : :bwr)
-        colorrange = @something colorrange colorrange_suggest
+        colorrange = @something colorrange (colorrange_suggest .* 1.1)
 
         xticklabelrotation = maximum(length.(res.qpts.xticks[2])) > 3 ? π/6 : 0.0
         ax = Makie.Axis(panel; xlabel="Momentum (r.l.u.)", ylabel, limits=(nothing, ylims ./ unit_energy), res.qpts.xticks, xticklabelrotation, axisopts...)
@@ -158,9 +158,9 @@ function Sunny.plot_intensities!(panel, res::Sunny.StaticIntensities{Float64}; c
 
     colorrange_suggest = colorrange_from_data(; data, saturation, sensitivity=0, allpositive)
     colormap = @something colormap (allpositive ? :gnuplot2 : :bwr)
-    colorrange = @something colorrange (colorrange_suggest .* 1.1)
 
     if qpts isa Sunny.QGrid{2}
+        colorrange = @something colorrange colorrange_suggest
         aspect = grid_aspect_ratio(crystal, qpts)
         xlabel, ylabel = suggest_labels_for_grid(qpts)
         (xs, ys) = map(range, qpts.coefs_lo, qpts.coefs_hi, size(qpts.qs))
@@ -169,6 +169,7 @@ function Sunny.plot_intensities!(panel, res::Sunny.StaticIntensities{Float64}; c
         Makie.Colorbar(panel[1, 2], hm)
         return ax
     elseif qpts isa Sunny.QPath
+        colorrange = @something colorrange (colorrange_suggest .* 1.1)
         xticklabelrotation = maximum(length.(qpts.xticks[2])) > 3 ? π/6 : 0.0
         ax = Makie.Axis(panel; xlabel="Momentum (r.l.u.)", ylabel="Intensity", qpts.xticks, xticklabelrotation, axisopts...)
         Makie.lines!(ax, data)

--- a/src/Measurements/IntensitiesTypes.jl
+++ b/src/Measurements/IntensitiesTypes.jl
@@ -42,6 +42,15 @@ struct PowderIntensities{T} <: AbstractIntensities
     data :: Array{T, 2} # (nω × nradii)
 end
 
+struct PowderStaticIntensities{T} <: AbstractIntensities
+    # Original chemical cell
+    crystal :: Crystal
+    # q magnitudes in inverse length
+    radii :: Vector{Float64}
+    # Intensity data averaged over shells
+    data :: Vector{T} # (nradii)
+end
+
 function Base.show(io::IO, res::AbstractIntensities)
     sz = string(size(res.data, 1)) * "×" * sizestr(res.qpts)
     print(io, string(typeof(res)) * " ($sz elements)")
@@ -52,7 +61,7 @@ function Base.show(io::IO, res::StaticIntensities)
     print(io, string(typeof(res)) * " ($sz elements)")
 end
 
-function Base.show(io::IO, res::PowderIntensities)
+function Base.show(io::IO, res::Union{PowderIntensities, PowderStaticIntensities})
     sz = join(size(res.data), "×")
     print(io, string(typeof(res)) * " ($sz elements)")
 end

--- a/src/Measurements/QPoints.jl
+++ b/src/Measurements/QPoints.jl
@@ -10,15 +10,15 @@ struct QPath <: AbstractQPoints
     xticks :: Tuple{Vector{Int64}, Vector{String}}
 end
 
-struct QGrid{N} <: AbstractQPoints
-    qs :: Array{Vec3, N}
+struct QGrid{D} <: AbstractQPoints
+    qs :: Array{Vec3, D}
 
     ### Next three fields contain equivalent information:
     # Directions in RLU aligned with parallelpiped
-    axes :: NTuple{N, Vec3}
+    axes :: NTuple{D, Vec3}
     # Low and high coefficient values that scale axes
-    coefs_lo :: Vector{Float64}
-    coefs_hi :: Vector{Float64}
+    coefs_lo :: NTuple{D, Float64}
+    coefs_hi :: NTuple{D, Float64}
     # Overall parallelpiped offset in RLU
     offset :: Vec3
 end
@@ -155,8 +155,8 @@ function q_space_grid(cryst::Crystal, axis1, range1, axis2, range2; offset=zero(
     end
 
     axes = hcat(axis1, axis2)
-    coefs_lo = axes \ (q_lo - offset)
-    coefs_hi = axes \ (q_hi - offset)
+    coefs_lo = NTuple{2}(axes \ (q_lo - offset))
+    coefs_hi = NTuple{2}(axes \ (q_hi - offset))
     coefs_sz = (length1, length2)
     range1, range2 = map(range, coefs_lo, coefs_hi, coefs_sz)
     qs = [axes * [c1, c2] + offset for c1 in range1, c2 in range2]

--- a/src/Measurements/RotationalAverages.jl
+++ b/src/Measurements/RotationalAverages.jl
@@ -123,8 +123,8 @@ plot_intensities(res)
 function powder_average(f, cryst, radii, n::Int; seed=0)
     res = f([Vec3(0,0,0)]) # Dummy call to learn types
     if res isa Intensities
-        data = zeros(length(energies), length(radii))
-        ret = PowderIntensities(cryst, collect(radii), energies, data)
+        data = zeros(length(res.energies), length(radii))
+        ret = PowderIntensities(cryst, collect(radii), res.energies, data)
     elseif res isa StaticIntensities
         data = zeros(length(radii))
         ret = PowderStaticIntensities(cryst, collect(radii), data)


### PR DESCRIPTION
Allow to call `intensities_static` from within `powder_average`. For example:

```jl
using Sunny, GLMakie

units = Units(:meV, :angstrom)
a = 8.5031 # (Å)
latvecs = lattice_vectors(a, a, a, 90, 90, 90)
cryst = Crystal(latvecs, [[1/8, 1/8, 1/8]], 227)

sys = System(cryst, [1 => Moment(s=3/2, g=2)], :dipole)
J = 0.63 # (meV)
set_exchange!(sys, J, Bond(2, 3, [0, 0, 0]))
kT = 16*units.K

sys2 = repeat_periodically(sys, (10, 10, 10))
measure = ssf_trace(sys2)
sc = SampledCorrelationsStatic(sys2; measure)

langevin = Langevin(0.04; damping=0.2, kT)
for _ in 1:1000
    step!(sys2, langevin)
end
for _ in 1:100
    for _ in 1:100
        step!(sys2, langevin)
    end
    add_sample!(sc, sys2)
end

radii = range(0, 10, 200) # (1/Å)
res = powder_average(cryst, radii, 400) do qs
    intensities_static(sc, qs)
end

plot_intensities(res; units)
```

Note that at large $|q|$ the intensity plateaus at $s^2 g^2 N = 72$ for this system with $s=3/2$, $g=2$ and $N=8$ atoms per chemical unit cell.

<img width="592" alt="image" src="https://github.com/user-attachments/assets/a39e8c2f-d080-424b-bbc4-ddd0a0e580cb" />
