### PR TITLE
Clean `print_site` if allowed anisotropy operators are missing

### DIFF
--- a/src/Symmetry/Printing.jl
+++ b/src/Symmetry/Printing.jl
@@ -301,7 +301,9 @@ function allowed_anisotropy_string(cryst::Crystal, i_ref::Int; R_global::Mat3, R
                 push!(terms, "c" * int_to_underscore_string(cnt) * "*" * ops)
                 cnt += 1
             end
-            push!(lines, prefix * join(terms, " + "))
+            if !isempty(terms)
+                push!(lines, prefix * join(terms, " + "))
+            end
         end
     end
 


### PR DESCRIPTION
Fixes #357.