### PR TITLE
Fix `plot_intensities` for data on very large grids

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -7,7 +7,10 @@
   classical dipole magnitude to ``\sqrt{s (s + 1)}`` for each quantum spin-``s``
   moment.
 * Add module [`SCGA`](@ref) for calculating [`intensities_static`](@ref) within
-  the self-consistent Gaussian approximation.
+  the self-consistent Gaussian approximation ([PR
+  #355](https://github.com/SunnySuite/Sunny.jl/pull/355)).
+* Fix heatmaps in [`plot_intensities`](@ref) for very large grids ([PR
+  #379](https://github.com/SunnySuite/Sunny.jl/pull/379)).
 
 ## v0.7.6
 (May 1, 2025)
@@ -23,11 +26,11 @@
   #359](https://github.com/SunnySuite/Sunny.jl/pull/359)).
 * Normalize `axis` argument to [`SpinWaveTheorySpiral`](@ref) for correctness.
 * Fix thermal prefactor `kT` in spin wave theory ([Issue
-  370](https://github.com/SunnySuite/Sunny.jl/issues/370)).
+  #370](https://github.com/SunnySuite/Sunny.jl/issues/370)).
 * In `:dipole` or `:SUN` mode, functions [`set_onsite_coupling!`](@ref) and
   [`set_pair_coupling!`](@ref) throw an error when used with quantum spin 1/2.
   Construct [`System`](@ref) using mode `:dipole_uncorrected` for such models
-  ([Issue 376](https://github.com/SunnySuite/Sunny.jl/issues/376)).
+  ([Issue #376](https://github.com/SunnySuite/Sunny.jl/issues/376)).
 
 ## v0.7.5
 (Jan 20, 2025)

--- a/examples/07_Dipole_Dipole.jl
+++ b/examples/07_Dipole_Dipole.jl
@@ -79,8 +79,8 @@ res3 = intensities_bands(swt, path);
 # corrections to its third dispersion band.
 
 fig = Figure(size=(768, 300))
-plot_intensities!(fig[1, 1], res1; units, title="Without long-range dipole")
-ax = plot_intensities!(fig[1, 2], res2; units, title="With long-range dipole")
+plot_intensities!(fig[1, 1], res1; units, ylims=(0, 4), title="Without long-range dipole")
+ax = plot_intensities!(fig[1, 2], res2; units, ylims=(0, 6), title="With long-range dipole")
 for c in eachrow(res3.disp)
     lines!(ax, eachindex(c), c; linestyle=:dash, color=:black)
 end


### PR DESCRIPTION
A very large grid passed to `Makie.image` or `Makie.heatmap` causes certain OpenGL backends to fail. Consequently, `plot_intensities` will not render certain data.

As discussed in https://github.com/MakieOrg/Makie.jl/issues/4950, a workaround is to convert all uses of `Makie.image` to `Makie.heatmap`, and then wrap the grid data inside a `Makie.Resampler` object. That is implemented here.

Notes:

* Apart from this bug, `Makie.image` could be preferable over `Makie.heatmap` in other ways, e.g., data on a regular grid is faster to render. However, the two have some subtle rendering differences: axis ranges may change slightly, and `heatmap` does not interpolate between grid points like `image` seems to.
* No attempt is made to determine what grid sizes will cause rendering to fail for the given graphics hardware. We pick a conservative number, 2000 pixels along any axis, and create a `Makie.Resampler` if that threshold is reached.
* Caution is required around the `ylims` argument. With this PR, it is interpreted to apply _after_ any energy units conversions are performed.
* Conversion in the opposite direction (`heatmap` to `image`) happened in https://github.com/SunnySuite/Sunny.jl/pull/374, which this PR partially undoes.
