### PR TITLE
Dipole-dipole interactions incorporate demagnetization factor tensor

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -8,7 +8,7 @@
 * Add module [`SCGA`](@ref) for calculating [`intensities_static`](@ref) within
   the self-consistent Gaussian approximation ([PR
   #355](https://github.com/SunnySuite/Sunny.jl/pull/355)).
-* Extend [`enable_dipole_dipole!`](@ref) to accept a demagnetization factor
+* Extend [`enable_dipole_dipole!`](@ref) to accept a demagnetization factor or
   tensor `demag`. The new default is isotropic demagnetization, `demag = 1/3`,
   appropriate for a spherical sample in vacuum. Set `demag = 0` to disable
   demagnetization ([Issue

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -8,6 +8,11 @@
 * Add module [`SCGA`](@ref) for calculating [`intensities_static`](@ref) within
   the self-consistent Gaussian approximation ([PR
   #355](https://github.com/SunnySuite/Sunny.jl/pull/355)).
+* Extend [`enable_dipole_dipole!`](@ref) to accept a demagnetization factor
+  tensor `demag`. The new default is isotropic demagnetization, `demag = 1/3`,
+  appropriate for a spherical sample in vacuum. Set `demag = 0` to disable
+  demagnetization ([Issue
+  #380](https://github.com/SunnySuite/Sunny.jl/issues/380)).
 * Fix heatmaps in [`plot_intensities`](@ref) for very large grids ([PR
   #379](https://github.com/SunnySuite/Sunny.jl/pull/379)).
 

--- a/examples/07_Dipole_Dipole.jl
+++ b/examples/07_Dipole_Dipole.jl
@@ -75,8 +75,7 @@ res3 = intensities_bands(swt, path);
 # Create a panel corresponding to Fig. 2 of [Del Maestro and
 # Gingras](https://arxiv.org/abs/cond-mat/0403494). Dashed lines show the effect
 # of truncating dipole-dipole interactions at 5 Å. The Del Maestro and Gingras
-# paper underreported the energy scale by a factor of two, and requires slight
-# corrections to its third dispersion band.
+# paper underreported the energy scale by a factor of two.
 
 fig = Figure(size=(768, 300))
 plot_intensities!(fig[1, 1], res1; units, ylims=(0, 4), title="Without long-range dipole")

--- a/src/Reshaping.jl
+++ b/src/Reshaping.jl
@@ -106,7 +106,7 @@ function reshape_supercell_aux(sys::System{N}, new_cryst::Crystal, new_dims::NTu
     # Restore dipole-dipole interactions if present. This involves pre-computing
     # an interaction matrix that depends on `new_dims`.
     if !isnothing(sys.ewald)
-        enable_dipole_dipole!(new_sys, sys.ewald.μ0_μB²)
+        enable_dipole_dipole!(new_sys, sys.ewald.μ0_μB²; sys.ewald.demag)
     end
 
     return new_sys

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -100,23 +100,23 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
 
     # Add long-range dipole-dipole
     if !isnothing(sys.ewald)
+        (; demag, μ0_μB², A) = sys.ewald
         Rs = local_rotations
 
-        # Interaction matrix for wavevector q
-        A = precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), q_reshaped) * sys.ewald.μ0_μB²
-        A = reshape(A, L, L)
-
         # Interaction matrix for wavevector (0,0,0). It could be recalculated as:
-        # precompute_dipole_ewald(sys.crystal, (1,1,1)) * sys.ewald.μ0_μB²
-        A0 = sys.ewald.A
-        A0 = reshape(A0, L, L)
+        # precompute_dipole_ewald(sys.crystal, (1,1,1), demag) * μ0_μB²
+        A0 = reshape(A, L, L)
+
+        # Interaction matrix for wavevector q
+        Aq = precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), demag, q_reshaped) * μ0_μB²
+        Aq = reshape(Aq, L, L)
 
         # Loop over sublattice pairs
         for i in 1:L, j in 1:L
             # An ordered pair of magnetic moments contribute (μᵢ A μⱼ)/2 to the
             # energy. A symmetric contribution will appear for the bond reversal
             # (i, j) → (j, i).  Note that μ = -μB g S.
-            J = gs[i]' * A[i, j] * gs[j] / 2
+            J = gs[i]' * Aq[i, j] * gs[j] / 2
             J0 = gs[i]' * A0[i, j] * gs[j] / 2
 
             # Perform same transformation as appears in usual bilinear exchange.

--- a/src/SpinWaveTheory/HamiltonianSUN.jl
+++ b/src/SpinWaveTheory/HamiltonianSUN.jl
@@ -72,21 +72,22 @@ function swt_hamiltonian_SUN!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_resh
     end
 
     if !isnothing(sys.ewald)
+        (; demag, μ0_μB², A) = sys.ewald
         N = sys.Ns[1]
 
-        # Interaction matrix for wavevector q
-        A = precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), q_reshaped) * sys.ewald.μ0_μB²
-        A = reshape(A, Na, Na)
+        # Interaction matrix for wavevector (0,0,0). It could be recalculated as:
+        # precompute_dipole_ewald(sys.crystal, (1,1,1), demag) * μ0_μB²
+        A0 = reshape(A, Na, Na)
 
-        # Interaction matrix for wavevector (0,0,0)
-        A0 = sys.ewald.A
-        A0 = reshape(A0, Na, Na)
+        # Interaction matrix for wavevector q
+        Aq = precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), demag, q_reshaped) * μ0_μB²
+        Aq = reshape(Aq, Na, Na)
 
         for i in 1:Na, j in 1:Na
             # An ordered pair of magnetic moments contribute (μᵢ A μⱼ)/2 to the
             # energy, where μ = - g S. A symmetric contribution will appear for
             # the bond reversal (i, j) → (j, i).
-            J = gs[i]' * A[i, j] * gs[j] / 2
+            J = gs[i]' * Aq[i, j] * gs[j] / 2
             J0 = gs[i]' * A0[i, j] * gs[j] / 2
 
             for α in 1:3, β in 1:3

--- a/src/Spiral/SpiralEnergy.jl
+++ b/src/Spiral/SpiralEnergy.jl
@@ -133,12 +133,12 @@ function spiral_energy_and_gradient_aux!(dEds, sys::System{0}; k, axis)
 
     # See "spiral_energy.lyx" for derivation
     if !isnothing(sys.ewald)
+        (; demag, μ0_μB², A) = sys.ewald
         μ = [magnetic_moment(sys, site) for site in eachsite(sys)]
 
-        A0 = sys.ewald.A
-        A0 = reshape(A0, Na, Na)
+        A0 = reshape(A, Na, Na)
 
-        Ak = precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), k_reshaped) * sys.ewald.μ0_μB²
+        Ak = precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), demag, k_reshaped) * μ0_μB²
         Ak = reshape(Ak, Na, Na)
 
         k_case = spiral_propagation_case(k_reshaped)

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -120,9 +120,9 @@ function precompute_dipole_ewald_aux(cryst::Crystal, dims::NTuple{3,Int}, demag,
 
             ϵ² = 1e-16
             if k² <= ϵ²
-                # Surface term Eₛ = μ₀ M⋅ℕ M / 2V gives rise to demagnetization
+                # Surface term Eₛ = μ₀ M⋅N M / 2V gives rise to demagnetization
                 # effect. Net magnetization M is associated with mode k = 0.
-                # Demagnetization factor tensor ℕ, denoted `demag`, depends on
+                # Demagnetization factor tensor N, denoted `demag`, depends on
                 # sample geometry and has trace 1 in vacuum background. This
                 # Ewald correction was originally derived in S. W. DeLeeuw et
                 # al., Proc. R. Soc. Lond. A 373, 27-56 (1980). See Ballenegger,
@@ -252,9 +252,9 @@ Like [`enable_dipole_dipole!`](@ref), the purpose of this function is to
 introduce long-range dipole-dipole interactions between magnetic moments.
 Whereas `enable_dipole_dipole!` employs Ewald summation, this function instead
 employs real-space pair couplings with truncation at the specified `cutoff`
-distance. The implicit demagnetization factor is ``ℕ = 1/3``, appropriate for a
-spherical sample. If the cutoff is relatively small, then this function may be
-faster than `enable_dipole_dipole!`.
+distance. The implicit demagnetization factor is 1/3, as appropriate for a
+spherical sample in vacuum. If the cutoff is relatively small, then this
+function may be faster than `enable_dipole_dipole!`.
 
 !!! warning "Mutation of existing couplings"  
     This function will modify existing bilinear couplings between spins by

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -77,8 +77,8 @@ constant ``μ_0 μ_B^2``, which has dimensions of length³-energy. Obtain this
 constant for a given system of [`Units`](@ref) via its `vacuum_permeability`
 property.
 
-Geometry of the macroscopic sample enters through the demagnetization factor
-tensor ``ℕ``, denoted `demag`. Special cases are:
+Geometry of the macroscopic sample enters through the demagnetization factor or
+tensor `demag`. Special cases are:
 
   * `demag = 1/3` for isotropic demagnetization. This is the default and is
     valid for sphere and cube sample geometries.
@@ -102,41 +102,43 @@ See also [`modify_exchange_with_truncated_dipole_dipole!`](@ref).
 !!! tip "Demagnetization details"  
 
     Formal summation over the infinitely many dipole-dipole pair interactions
-    becomes mathematically ambiguous when the sample has a nonzero net magnetic
-    moment, ``𝐌 = ∑_i μ_i``. The traditional Ewald method resolves this ambiguity
-    by neglecting surface effects that would lead to demagnetization. For physical
-    correctness, however, the Ewald energy must be augmented with a surface energy
-    correction,
+    becomes mathematically ambiguous when the macroscopic sample has a nonzero net
+    magnetic moment, ``𝐌 = ∑_i μ_i``. The traditional Ewald method resolves this
+    ambiguity by neglecting surface effects that would lead to demagnetization. For
+    physical correctness, however, the Ewald energy must be augmented with a surface
+    energy term,
     ```math
-        E_s = \\frac{μ_0}{2V} 𝐌⋅ℕ 𝐌,
+        E_\\mathrm{surf} = \\frac{μ_0}{2V} 𝐌⋅\\mathcal{N} 𝐌,
     ```
-    where ``ℕ`` is the demagnetization factor tensor. Assuming vacuum background, it
-    can be expressed as an integral over the sample volume ``V``,
+    where ``\\mathcal{N}`` is the demagnetization tensor (`demag`). Assuming vacuum
+    background, it can be expressed as an integral over the sample volume ``V``,
     ```math
-        ℕ = - \\frac{1}{4π} ∫_V d𝐱 ∇ ∇ |𝐱|^{-1}.
+        \\mathcal{N}^{αβ} = - \\frac{1}{4π} ∫_V d𝐱 ∇^α ∇^β |𝐱|^{-1}.
     ```
-    Note that ``ℕ`` has trace 1 because ``∇^2|𝐱|^{-1} = -4πδ(𝐱)``.
+    Note that ``\\mathcal{N}`` has trace 1 because ``∇^2|𝐱|^{-1} = -4πδ(𝐱)``
+    when the integration domain contains the origin.
 
     This surface correction to the Ewald energy originally appeared in S. de Leeuw,
     J. Perram, and E. Smith, Proc. R. Soc. London A **373**, 27 (1980); **373**, 57
     (1980); **388**, 177 (1983). For a pedagogical review, see [V. Ballenegger, J.
     Chem. Phys. **140**, 161102 (2014)](https://doi.org/10.1063/1.4872019).
 
-    If the sample is embedded in another material, the surface correction ``E_s``
-    remains valid, but ``ℕ`` should be calculated differently. For example, a
-    spherical inclusion generally has ``ℕ = 1/(2μ'+1) ≤ 1/3`` where ``μ' ≥ 1``
-    denotes the relative permeability of the background medium.
+    If the sample is embedded in another material, the surface correction
+    ``E_\\mathrm{surf}`` still applies, but ``\\mathcal{N}`` should be calculated
+    differently. For example, a spherical inclusion generally has ``\\mathcal{N} =
+    1/(2μ'+1) ≤ 1/3`` where ``μ' ≥ 1`` denotes the relative permeability of the
+    background medium.
 
 !!! tip "Efficiency considerations"  
 
     Dipole-dipole interactions are very efficient in the context of spin dynamics
     simulation, e.g. [`Langevin`](@ref). Sunny applies the fast Fourier transform
     (FFT) to spins on each Bravais sublattice, such that the computational cost to
-    integrate one time-step scales like ``M^2 N \\ln N``, where ``N`` is the
-    number of cells in the system and ``M`` is the number of Bravais sublattices
-    per cell. Conversely, dipole-dipole interactions are highly _inefficient_ in
-    the context of a [`LocalSampler`](@ref). Each Monte Carlo update of a single
-    spin currently requires scanning over all other spins in the system.
+    integrate one time-step scales like ``M^2 N \\ln N``, where ``N`` is the number
+    of cells in the system and ``M`` is the number of Bravais sublattices per cell.
+    Conversely, dipole-dipole interactions are highly _inefficient_ in the context
+    of a [`LocalSampler`](@ref). Each Monte Carlo update of a single spin currently
+    requires scanning over all other spins in the system.
 """
 function enable_dipole_dipole!(sys::System, μ0_μB²=nothing; demag=1/3)
     if isnothing(μ0_μB²)

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -97,7 +97,7 @@ units = Units(:meV, :angstrom)
 enable_dipole_dipole!(sys, units.vacuum_permeability)
 ```
 
-!!! tip "Origin of demagnetization"  
+!!! tip "Demagnetization details"  
 
     Formal summation over the infinitely many dipole-dipole pair interactions
     becomes mathematically ambiguous when the sample has a net magnetic dipole,

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -78,8 +78,7 @@ constant for a given system of [`Units`](@ref) via its `vacuum_permeability`
 property.
 
 Geometry of the macroscopic sample enters through the demagnetization factor
-tensor ``ℕ``, denoted `demag`. In a vacuum background, `tr(demag) == 1`. Special
-cases are:
+tensor ``ℕ``, denoted `demag`. Special cases are:
 
   * `demag = 1/3` for isotropic demagnetization. This is the default and is
     valid for sphere and cube sample geometries.
@@ -88,7 +87,8 @@ cases are:
   * `demag = Diagonal([1/2, 1/2, 0])` for a needle-like geometry aligned with
     ``ẑ``.
 
-Set `demag = 0` to neglect demagnetization effects.
+In a vacuum background, the demagnetization tensor should have trace 1. Set
+`demag = 0` to artificially neglect demagnetization effects.
 
 # Example
 
@@ -120,8 +120,8 @@ enable_dipole_dipole!(sys, units.vacuum_permeability)
     ```
 
     Here, ``ℕ`` has trace 1. If the sample is embedded in another material with
-    relative permeability ``μ' > 1``, however, then ``ℕ`` may be reduced. For
-    example, a spherical inclusion has ``ℕ = 1/(2μ'+1)`` in the general case.
+    relative permeability ``μ' > 1`` then ``ℕ`` may be reduced. For example, a
+    spherical inclusion has ``ℕ = 1/(2μ'+1)``.
 
 !!! tip "Efficiency considerations"  
 

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -97,29 +97,35 @@ units = Units(:meV, :angstrom)
 enable_dipole_dipole!(sys, units.vacuum_permeability)
 ```
 
+See also [`modify_exchange_with_truncated_dipole_dipole!`](@ref).
+
 !!! tip "Demagnetization details"  
 
     Formal summation over the infinitely many dipole-dipole pair interactions
-    becomes mathematically ambiguous when the sample has a net magnetic dipole,
+    becomes mathematically ambiguous when the sample has a nonzero net magnetic
+    moment, ``𝐌 = ∑_i μ_i``. The traditional Ewald method resolves this ambiguity
+    by neglecting surface effects that would lead to demagnetization. For physical
+    correctness, however, the Ewald energy must be augmented with a surface energy
+    correction,
     ```math
-        𝐌 = ∑_i μ_i.
-    ```
-    The traditional Ewald method resolves this ambiguity by neglecting surface
-    effects that would lead to demagnetization. For physical correctness, however,
-    the Ewald energy should be augmented with a surface contribution to the total
-    energy,
-    ```math
-        E_s = μ_0 𝐌⋅ℕ 𝐌 / 2V,
+        E_s = \\frac{μ_0}{2V} 𝐌⋅ℕ 𝐌,
     ```
     where ``ℕ`` is the demagnetization factor tensor. Assuming vacuum background, it
     can be expressed as an integral over the sample volume ``V``,
     ```math
-        ℕ = - (1/4π) ∫_V d𝐱 ∇ ∇ |𝐱|^{-1}.
+        ℕ = - \\frac{1}{4π} ∫_V d𝐱 ∇ ∇ |𝐱|^{-1}.
     ```
-    Here, ``ℕ`` has trace 1. If the sample is embedded in another material, however,
-    then ``ℕ`` should be calculated differently. For example, a spherical inclusion
-    generally has ``ℕ = 1/(2μ'+1) ≤ 1/3`` where ``μ' ≥ 1`` denotes the relative
-    permeability of the background medium.
+    Note that ``ℕ`` has trace 1 because ``∇^2|𝐱|^{-1} = -4πδ(𝐱)``.
+
+    This surface correction to the Ewald energy originally appeared in S. de Leeuw,
+    J. Perram, and E. Smith, Proc. R. Soc. London A **373**, 27 (1980); **373**, 57
+    (1980); **388**, 177 (1983). For a pedagogical review, see [V. Ballenegger, J.
+    Chem. Phys. **140**, 161102 (2014)](https://doi.org/10.1063/1.4872019).
+
+    If the sample is embedded in another material, the surface correction ``E_s``
+    remains valid, but ``ℕ`` should be calculated differently. For example, a
+    spherical inclusion generally has ``ℕ = 1/(2μ'+1) ≤ 1/3`` where ``μ' ≥ 1``
+    denotes the relative permeability of the background medium.
 
 !!! tip "Efficiency considerations"  
 
@@ -131,8 +137,6 @@ enable_dipole_dipole!(sys, units.vacuum_permeability)
     per cell. Conversely, dipole-dipole interactions are highly _inefficient_ in
     the context of a [`LocalSampler`](@ref). Each Monte Carlo update of a single
     spin currently requires scanning over all other spins in the system.
-
-See also [`modify_exchange_with_truncated_dipole_dipole!`](@ref).
 """
 function enable_dipole_dipole!(sys::System, μ0_μB²=nothing; demag=1/3)
     if isnothing(μ0_μB²)

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -83,10 +83,10 @@ cases are:
 
   * `demag = 1/3` for isotropic demagnetization. This is the default and is
     valid for sphere and cube sample geometries.
-  * `demag = Diagonal([0, 0, 1])`` for a sheet-like geometry with surface normal
+  * `demag = Diagonal([0, 0, 1])` for a sheet-like geometry with surface normal
     in ``ẑ``.
   * `demag = Diagonal([1/2, 1/2, 0])` for a needle-like geometry aligned with
-    `ẑ``.
+    ``ẑ``.
 
 Set `demag = 0` to neglect demagnetization effects.
 
@@ -116,11 +116,11 @@ enable_dipole_dipole!(sys, units.vacuum_permeability)
     where ``ℕ`` is the demagnetization factor tensor. Assuming vacuum background,
     it can be expressed as an integral over the sample volume,
     ```math
-        ℕ = - (1 / 4π) ∫ d𝐱 ∇ ∇ (1 / |𝐱|).
+        ℕ = - (1 / 4π) ∫_\\mathrm{sample} d𝐱 ∇ ∇ |𝐱|^{-1}.
     ```
 
-    As constructed, ``ℕ`` has trace 1. If the sample is embedded in another
-    material with relative permeability ``μ' > 1``, then ``ℕ`` may be reduced. For
+    Here, ``ℕ`` has trace 1. If the sample is embedded in another material with
+    relative permeability ``μ' > 1``, however, then ``ℕ`` may be reduced. For
     example, a spherical inclusion has ``ℕ = 1/(2μ'+1)`` in the general case.
 
 !!! tip "Efficiency considerations"  

--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -104,7 +104,6 @@ enable_dipole_dipole!(sys, units.vacuum_permeability)
     ```math
         𝐌 = ∑_i μ_i.
     ```
-
     The traditional Ewald method resolves this ambiguity by neglecting surface
     effects that would lead to demagnetization. For physical correctness, however,
     the Ewald energy should be augmented with a surface contribution to the total
@@ -112,16 +111,15 @@ enable_dipole_dipole!(sys, units.vacuum_permeability)
     ```math
         E_s = μ_0 𝐌⋅ℕ 𝐌 / 2V,
     ```
-
-    where ``ℕ`` is the demagnetization factor tensor. Assuming vacuum background,
-    it can be expressed as an integral over the sample volume,
+    where ``ℕ`` is the demagnetization factor tensor. Assuming vacuum background, it
+    can be expressed as an integral over the sample volume ``V``,
     ```math
-        ℕ = - (1 / 4π) ∫_\\mathrm{sample} d𝐱 ∇ ∇ |𝐱|^{-1}.
+        ℕ = - (1/4π) ∫_V d𝐱 ∇ ∇ |𝐱|^{-1}.
     ```
-
-    Here, ``ℕ`` has trace 1. If the sample is embedded in another material with
-    relative permeability ``μ' > 1`` then ``ℕ`` may be reduced. For example, a
-    spherical inclusion has ``ℕ = 1/(2μ'+1)``.
+    Here, ``ℕ`` has trace 1. If the sample is embedded in another material, however,
+    then ``ℕ`` should be calculated differently. For example, a spherical inclusion
+    generally has ``ℕ = 1/(2μ'+1) ≤ 1/3`` where ``μ' ≥ 1`` denotes the relative
+    permeability of the background medium.
 
 !!! tip "Efficiency considerations"  
 

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -162,7 +162,7 @@ function clone_system(sys::System{N}) where N
         # At the moment, clone_ewald is unavailable, so instead rebuild the
         # Ewald data structures from scratch. This might be fixed eventually.
         # See https://github.com/JuliaMath/FFTW.jl/issues/261.
-        enable_dipole_dipole!(ret, ewald.μ0_μB²)
+        enable_dipole_dipole!(ret, ewald.μ0_μB²; ewald.demag)
     end
 
     return ret

--- a/src/System/Types.jl
+++ b/src/System/Types.jl
@@ -74,6 +74,7 @@ const rIFTPlan = FFTW.AbstractFFTs.ScaledPlan{ComplexF64, rBFTPlan, Float64}
 
 struct Ewald
     μ0_μB²   :: Float64               # Strength of dipole-dipole interactions
+    demag    :: Mat3                  # Demagnetization factor
     A        :: Array{Mat3, 5}        # Interaction matrices in real-space         [offset+1,i,j]
     μ        :: Array{Vec3, 4}        # Magnetic moments μ = g s                   [cell,i]
     ϕ        :: Array{Vec3, 4}        # Cross correlation, ϕ = A⋆μ                 [cell,i]

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -296,7 +296,7 @@ end
 
     for mode in (:dipole, :SUN)
         sys = System(cryst, [1 => Moment(s=1, g=1)], mode)
-        enable_dipole_dipole!(sys, 1.0)
+        enable_dipole_dipole!(sys, 1.0; demag=0)
 
         polarize_spins!(sys, (0,0,1))
         @test energy_per_site(sys) ≈ -0.1913132980155851
@@ -310,9 +310,10 @@ end
     end
 
     begin
+        units = Units(:meV, :angstrom)
         cryst = Sunny.bcc_crystal()
         sys = System(cryst, [1 => Moment(s=1, g=2)], :dipole, seed=2)
-        enable_dipole_dipole!(sys, Units(:meV, :angstrom).vacuum_permeability)
+        enable_dipole_dipole!(sys, units.vacuum_permeability; demag=0)
         polarize_spins!(sys, (1,2,3)) # arbitrary direction
 
         R = hcat([1,1,-1], [-1,1,1], [1,-1,1]) / 2

--- a/test/test_units.jl
+++ b/test/test_units.jl
@@ -3,7 +3,7 @@
         crystal = Sunny.diamond_crystal(; a=units.angstrom)
         sys = System(crystal, [1 => Moment(s=1, g=2)], :dipole; dims=(4, 4, 4), seed=0)
         randomize_spins!(sys)
-        set_exchange!(sys, 2 * units.K, Bond(1, 2, [0,0,0]))
+        set_exchange!(sys, 2 * units.K, Bond(1, 2, [0, 0, 0]))
         set_field!(sys, [0, 0, 1] * units.T)
         enable_dipole_dipole!(sys, units.vacuum_permeability)
         E = energy(sys) / units.meV


### PR DESCRIPTION
Extend `enable_dipole_dipole!` to accept an additional parameter `demag`. It defines the demagnetization factor tensor associated with the geometry of the macroscopic sample. The new default, `demag = 1/3`, is appropriate for a spherical sample in vacuum. More generally, `demag` can be an arbitrary 3×3 matrix, typically with trace 1.

Demagnetization originates through surface effects at the sample boundary. These are traditionally neglected in the Ewald summation method. The necessary correction was derived in S. W. DeLeeuw et al., Proc. R. Soc. Lond. A 373, 27-56 (1980). See  [Ballenegger, J. Chem. Phys. 140, 161102 (2014)](https://pubs.aip.org/aip/jcp/article/140/16/161102/841086/Communication-On-the-origin-of-the-surface-term-in) for a pedagogical review.

Fixes #380.
