### PR TITLE
Check reality of symbolic spin polynomial coefficients

### DIFF
--- a/src/System/OnsiteCoupling.jl
+++ b/src/System/OnsiteCoupling.jl
@@ -27,6 +27,11 @@ function onsite_coupling(sys, site, p::DP.AbstractPolynomialLike)
         error("Symbolic operator only valid for system with mode :dipole_uncorrected.")
     end
 
+    if !iszero(imag(p))
+        error("Operator is not Hermitian. Consider real(…) to transform spin polynomial coefficients.")
+    end
+    p = real(p)
+
     S² = sys.κs[site]^2
     c = operator_to_stevens_coefficients(p, S²)
 


### PR DESCRIPTION
The line below is illegal because the specified operator is non-Hermitian.
```jl
set_onsite_coupling!(sys, S -> im * S[3]^2, 1)
```

Sunny will now report an informative error message, unified across system modes. When working in `:dipole_uncorrected` mode, local operators are formally infinite dimensional, and are represented with symbolic spin polynomials. Any imaginary part in the polynomial coefficients indicates a non-Hermitian operator, and will be reported as such.

If the system mode is `:dipole` or `:SUN`, then local operators will have a finite-dimensional matrix representation, and the user can apply `hermitianpart`. In mode `:dipole_uncorrected`, the user will currently need to apply `real` to the symbolic polynomial representation, which maps the polynomial coefficients to their real parts. The error message now suggests this work-around. See https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/issues/325 for the feature request to support `hermitianpart` on symbolic polynomials.