### PR TITLE
Rename `set_spin_rescaling_for_static_sum_rule!`

### DIFF
--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -36,7 +36,7 @@ dmvec
 domain_average
 eachsite
 enable_dipole_dipole!
-enable_spin_rescaling_for_static_sum_rule!
+set_spin_rescaling_for_static_sum_rule!
 energy
 energy_per_site
 excitations

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,9 +3,8 @@
 ## v0.7.7
 (In development)
 
-* Add [`enable_spin_rescaling_for_static_sum_rule!`](@ref) which sets the
-  classical dipole magnitude to ``\sqrt{s (s + 1)}`` for each quantum spin-``s``
-  moment.
+* Add [`set_spin_rescaling_for_static_sum_rule!`](@ref) which sets the classical
+  dipole magnitude to ``\sqrt{s (s + 1)}`` for each quantum spin-``s`` moment.
 * Add module [`SCGA`](@ref) for calculating [`intensities_static`](@ref) within
   the self-consistent Gaussian approximation ([PR
   #355](https://github.com/SunnySuite/Sunny.jl/pull/355)).

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -59,9 +59,9 @@ include("System/PairExchange.jl")
 include("System/OnsiteCoupling.jl")
 include("System/Ewald.jl")
 include("System/Interactions.jl")
-export Moment, System, Site, clone_system, eachsite, position_to_site, global_position, magnetic_moment,
-    set_coherent!, set_dipole!, polarize_spins!, randomize_spins!, set_spin_rescaling!,
-    enable_spin_rescaling_for_static_sum_rule!, energy, energy_per_site,
+export Moment, System, Site, clone_system, eachsite, position_to_site, global_position,
+    magnetic_moment, set_coherent!, set_dipole!, polarize_spins!, randomize_spins!,
+    set_spin_rescaling!, set_spin_rescaling_for_static_sum_rule!, energy, energy_per_site,
     spin_label, set_onsite_coupling!, set_pair_coupling!, set_exchange!, dmvec, enable_dipole_dipole!,
     set_field!, to_inhomogeneous, set_field_at!, set_vacancy_at!, set_onsite_coupling_at!,
     set_exchange_at!, set_pair_coupling_at!, symmetry_equivalent_bonds, remove_periodicity!,

--- a/src/System/System.jl
+++ b/src/System/System.jl
@@ -546,7 +546,7 @@ function set_spin_rescaling!(sys::System{N}, κ) where N
 end
 
 """
-    enable_spin_rescaling_for_static_sum_rule!(sys)
+    set_spin_rescaling_for_static_sum_rule!(sys)
 
 Sets the classical dipole magnitude to ``\\sqrt{s(s+1)}`` rather than ``s`` for
 each quantum spin-``s`` moment. Valid only for systems in dipole mode.
@@ -581,7 +581,7 @@ rescaling.
    systems: Temperature-dependent spin dynamics of FeI₂_, Phys. Rev. B **109**,
    014427 (2024)](https://doi.org/10.1103/PhysRevB.109.014427).
 """
-function enable_spin_rescaling_for_static_sum_rule!(sys::System{N}) where N
+function set_spin_rescaling_for_static_sum_rule!(sys::System{N}) where N
     iszero(N) || error("Quantum dipole amplification requires :dipole or :dipole_uncorrected mode")
     for site in eachsite(sys)
         s = sys.κs[site]

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -47,7 +47,7 @@ end
     s = 3/2
     sys = System(cryst, [1 => Moment(; s, g=1)], :dipole)
     sys = reshape_supercell(sys, primitive_cell(cryst))
-    enable_spin_rescaling_for_static_sum_rule!(sys)
+    set_spin_rescaling_for_static_sum_rule!(sys)
     J1 = 3.27                                              # In meV, from Bai's PRL
     J_mgcro = [1.0, 0.0815, 0.1050, 0.0085] * J1           # Further exchanges for MgCr2O4
     set_exchange!(sys, J_mgcro[1], Bond(1, 2, [0, 0, 0]))  # J1


### PR DESCRIPTION
The name `set_spin_rescaling_for_static_sum_rule!` seems more natural than `enable_spin_rescaling_for_static_sum_rule` because subsequent calls to `set_spin_rescaling!` can be used to override rescaling factors.