### PR TITLE
Entangled units fix

### DIFF
--- a/src/EntangledUnits/EntangledSampledCorrelations.jl
+++ b/src/EntangledUnits/EntangledSampledCorrelations.jl
@@ -128,7 +128,7 @@ function SampledCorrelationsStatic(esys::EntangledSystem; measure, calculate_err
     crystal = esys.sys_origin.crystal
     origin_crystal = orig_crystal(esys.sys_origin)
     parent = SampledCorrelations(sc.data, sc.M, crystal, origin_crystal, sc.Δω, measure, observables, positions, source_idcs, measure.corr_pairs,
-                                 sc.measperiod, sc.dt, sc.nsamples, sc.samplebuf, sc.corrbuf, sc.space_fft!, sc.time_fft!, sc.corr_fft!, sc.corr_ifft!)
+                                 sc.integrator, sc.measperiod, sc.nsamples, sc.samplebuf, sc.corrbuf, sc.space_fft!, sc.time_fft!, sc.corr_fft!, sc.corr_ifft!)
 
     ssc = SampledCorrelationsStatic(parent)
     return EntangledSampledCorrelationsStatic(ssc, esys)

--- a/test/test_entangled_units.jl
+++ b/test/test_entangled_units.jl
@@ -104,6 +104,11 @@ end
 
     @test all(both -> isapprox(both[1], both[2]; atol=1e-12), zip(ωs_analytical, ωs_numerical))
 
+    # Test static structure factor is zero (dipolar sector)
+    ssf = SampledCorrelationsStatic(esys; measure=ssf_trace(esys))
+    add_sample!(ssf, esys)
+    @test all(x -> isapprox(x, 0.0; atol=1e-12), ssf.sc.parent.data)
+
     # Test classical dynamics and perform golden test.
     esys = repeat_periodically(esys, (8, 1, 1))
     energies = range(0, 2, 5)


### PR DESCRIPTION
Fix for the constructor of `SampledCorrelationsStatic` for entangled systems. I neglected to update this when putting the integrator (instead of dt) into the `SampledCorrelations` type.

Also added is a simple test using `SampledCorrelationsStatic` in the test suite (which would have revealed this problem).

Ultimately this code duplication should be avoidable.

