### PR TITLE
Transparency in `plot_intensities` for bands data

### DIFF
--- a/ext/PlottingExt/PlotIntensities.jl
+++ b/ext/PlottingExt/PlotIntensities.jl
@@ -83,7 +83,7 @@ function Sunny.plot_intensities!(panel, res::Sunny.BandIntensities{Float64}; col
 
         xticklabelrotation = maximum(length.(res.qpts.xticks[2])) > 3 ? π/6 : 0.0
         ax = Makie.Axis(panel; xlabel="Momentum (r.l.u.)", ylabel, res.qpts.xticks, xticklabelrotation, limits=(nothing, ylims), axis...)
-        Makie.heatmap!(ax, (1, size(data, 2)), ylims, maybe_resample(collect(data')); colorrange, colormap, lowclip=:white)
+        Makie.heatmap!(ax, (1, size(data, 2)), ylims, maybe_resample(collect(data')); colorrange, colormap, lowclip=:transparent)
         for i in axes(res.disp, 1)
             Makie.lines!(ax, res.disp[i,:]/unit_energy; color=:lightskyblue3)
         end


### PR DESCRIPTION
This transparency achieves consistency with other Makie lines plots. Additionally, it significantly reduces the file size for PDF exports using the CairoMakie backend.

I also experimented with `Makie.image` instead of `Makie.heatmap`. This change is another way to significantly reduce the output PDF file size, because it stores the image in a compressed format. Conversely, `Makie.heatmap` generates PDFs that include one rectangle glyph per grid point, making compression much more difficult. Unfortunately, `Makie.image` has two drawbacks:

1. It is not compatible with `Makie.Resampler`, which we need for to avoid crashes for very large grid dimensions (https://github.com/MakieOrg/Makie.jl/issues/4950).
2. It introduces interpolation between grid cells, which obscures the discretenes of the calculated grid.

As an attempt to work around (2), `Makie.image` has an option `interpolate=false`, but unfortunately, this setting defeats the purpose. If interpolation is disabled, then the exported PDFs for `Makie.image` and `Makie.heatmap` have identical sizes. After some digging, I realized that this is an inherent limitation of PDFs -- there isn't a universally adopted standard for disabling interpolation on embedded images.
