### PR TITLE
Improvements to CIF and mCIF loading

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -8,7 +8,7 @@
   always downfold to a standard chemical cell. As before, use
   [`set_dipoles_from_mcif!`](@ref) to set dipoles on a reshaped [`System`](@ref)
   ([PR #413](https://github.com/SunnySuite/Sunny.jl/pull/413)). 
-* Fix tolerance of Spglib symmetry inference ([PR
+* Scale `symprec` prior to symmetry inference as expected by Spglib ([PR
   #405](https://github.com/SunnySuite/Sunny.jl/pull/405)).
 
 ## v0.7.8

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,6 +3,11 @@
 ## v0.7.9
 (In development)
 
+* More robust loading of CIF files via [`Crystal`](@ref) constructor. Precision
+  parameter `symprec` is now inferred. The magnetic cell of an mCIF file will
+  always downfold to a standard chemical cell. As before, use
+  [`set_dipoles_from_mcif!`](@ref) to set dipoles on a reshaped [`System`](@ref)
+  ([PR #413](https://github.com/SunnySuite/Sunny.jl/pull/413)). 
 * Fix tolerance of Spglib symmetry inference ([PR
   #405](https://github.com/SunnySuite/Sunny.jl/pull/405)).
 

--- a/docs/src/why.md
+++ b/docs/src/why.md
@@ -5,10 +5,10 @@
 
 Feature highlights include:
 
-- Ability to [specify a crystal](@ref Crystal) from a `.cif` file, from its
+- Ability to [specify a crystal](@ref Crystal) from a CIF file, from its
   spacegroup number and Wyckoffs, or from a full chemical cell with
   automatically inferred symmetry operations. Magnetic structures [can be
-  read](@ref set_dipoles_from_mcif!) from `.mcif` files.
+  read](@ref set_dipoles_from_mcif!) from mCIF files.
 - Interactive visualization of [3D crystals](@ref view_crystal) and [magnetic
   structures](@ref plot_spins).
 - Symmetry analysis to determine [allowed anisotropies and interaction

--- a/src/MCIF.jl
+++ b/src/MCIF.jl
@@ -20,7 +20,7 @@ function set_dipoles_from_mcif!(sys::System, filename::AbstractString)
 
     # TODO: Tolerance to permutations (with sign flips) of lattice vectors
     if !isapprox(supervecs, supervecs2; rtol=sys.crystal.symprec)
-        tol = 0.1 * sys.crystal.symprec # Tolerance might need tuning
+        tol = sys.crystal.symprec # Tolerance might need tuning
         orig_cryst = orig_crystal(sys)
 
         primcell = @something primitive_cell(orig_cryst) Mat3(I)

--- a/src/MCIF.jl
+++ b/src/MCIF.jl
@@ -1,8 +1,9 @@
 """
     set_dipoles_from_mcif!(sys::System, filename::AbstractString)
 
-Load the magnetic supercell according to an mCIF file. System `sys` must already
-be resized to the correct supercell dimensions.
+Load the magnetic supercell from data in the mCIF at `filename`. If the shape of
+`sys` is not consistent with that of the magnetic supercell, an error message
+will be thrown that gives instructions for calling [`reshape_supercell`](@ref).
 """
 function set_dipoles_from_mcif!(sys::System, filename::AbstractString)
     cif = CIF.Cif(filename)

--- a/src/MathBasics.jl
+++ b/src/MathBasics.jl
@@ -32,6 +32,16 @@ function diffnorm2(a, b)
     return acc
 end
 
+function is_integer(x; atol)
+    return abs(x - round(x)) < atol
+end
+
+function all_integer(xs; atol)
+    return all(is_integer(x; atol) for x in xs)
+end
+
+# Periodic variant of Base.isapprox. When comparing lattice quantities like
+# positions or bonds, prefer is_periodic_copy because it works element-wise.
 function isapprox_mod1(x::AbstractArray, y::AbstractArray; opts...)
     @assert size(x) == size(y) "Non-matching dimensions"
     Δ = @. mod(x - y + 0.5, 1) - 0.5

--- a/src/Reshaping.jl
+++ b/src/Reshaping.jl
@@ -20,7 +20,7 @@ function reshape_supercell(sys::System, shape)
     check_shape_commensurate(orig, shape)
     prim_cell = @something primitive_cell(orig) Mat3(I)
     shape_in_prim = prim_cell \ shape
-    @assert all_integer(shape_in_prim; orig.symprec)
+    @assert all_integer(shape_in_prim; atol=orig.symprec)
     shape_in_prim = round.(Int, shape_in_prim)
 
     # Unit cell for new system, in units of original unit cell.

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -17,17 +17,21 @@ abstract type AbstractSpinWaveTheory end
 """
     SpinWaveTheory(sys::System; measure, regularization=1e-8)
 
-Constructs an object to perform linear spin wave theory. The system must be in
-an energy minimizing configuration. Enables calculation of [`dispersion`](@ref)
-bands. If pair correlations are specified with `correspec`, one can also
-calculate [`intensities_bands`](@ref) and broadened [`intensities`](@ref).
+Constructs an object to perform linear spin wave theory. The `measure` object
+specifies observable fields, ``𝐪``-dependent contractions, and form factors.
+Common choices are [`ssf_perp`](@ref), [`ssf_trace`](@ref), and
+[`ssf_custom`](@ref). The resulting `SpinWaveTheory` object can be used to
+calculate [`intensities_bands`](@ref) and broadened [`intensities`](@ref). If
+`measure=nothing`, it is still possible to calculate the [`dispersion`](@ref)
+curves. Eigenvectors describing the Bogoliubov bosons are available in
+[`excitations`](@ref).
 
-The spins in system must be energy-minimized, otherwise the Cholesky step of the
-Bogoliubov diagonalization procedure will fail. The parameter `regularization`
-adds a small positive shift to the diagonal of the dynamical matrix to avoid
-numerical issues with quasi-particle modes of vanishing energy. Physically, this
-shift can be interpreted as application of an inhomogeneous field aligned with
-the magnetic ordering.
+The magnetic structure in `sys` must be energy minimized, otherwise the Cholesky
+step of the Bogoliubov diagonalization procedure will fail. The parameter
+`regularization` adds a small positive shift to the diagonal of the dynamical
+matrix to avoid numerical issues with quasi-particle modes of vanishing energy.
+Physically, this shift can be interpreted as application of an inhomogeneous
+field aligned with the magnetic ordering.
 """
 struct SpinWaveTheory <: AbstractSpinWaveTheory
     sys            :: System

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -10,9 +10,9 @@ units of angstrom. In most cases, `symprec` can be omitted. If provided, it will
 specify the precision of the dimensionless site position data (commonly between
 1e-2 and 1e-5).
 
-For an mCIF, the magnetic cell will be converted to a conventional chemical
-cell, which will have an enlarged set of spacegroup symmetries. Site positions
-will be preserved for compatibility with subsequent calls to
+Given an mCIF, this constructor will convert the magnetic cell to an inferred
+conventional chemical cell. Use this crystal to construct an appropriately
+shaped [`System`](@ref) and then load the magnetic order with
 [`set_dipoles_from_mcif!`](@ref).
 
     Crystal(latvecs, positions; types=nothing, symprec=1e-5)

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -3,13 +3,12 @@
 An object describing a crystallographic unit cell and its space group symmetry.
 Constructors are as follows:
 
-    Crystal(filename, symprec=nothing)
+    Crystal(filename; symprec=nothing)
 
 Reads the crystal from a CIF or mCIF at `filename`. Lattice vectors will be in
-units of angstrom. In most cases, `symprec` can be inferred. In cases of
-inconsistency, however, an explicit `symprec` may be provided. It should specify
-the precision of the dimensionless site position data, commonly in the range of
-1e-2 to 1e-5.
+units of angstrom. In most cases, `symprec` can be omitted. If provided, it will
+specify the precision of the dimensionless site position data (commonly between
+1e-2 and 1e-5).
 
 For an mCIF, the magnetic cell will be converted to a conventional chemical
 cell, which will have an enlarged set of spacegroup symmetries. Site positions

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -205,13 +205,17 @@ function sort_sites!(cryst::Crystal)
         ri = cryst.positions[i]
         rj = cryst.positions[j]
         for k = 3:-1:1
+            # Factor of 10 included to err on the side of throwing a "too close"
+            # exception, below. TODO: Use is_periodic_copy instead, and make
+            # exactly consistent with crystallographic_orbit. Warning about
+            # closeness should appear there instead.
             if !isapprox(ri[k], rj[k], atol=10cryst.symprec)
                 return ri[k] < rj[k]
             end
         end
         str1, str2 = fractional_vec3_to_string.((ri, rj))
-        error("""Detected two very close atoms ($str1 and $str2).
-                 If positions inferred from spacegroup, try increasing `symprec` parameter to `Crystal`.""")
+        str3 = number_to_simple_string(cryst.symprec; digits=2)
+        error("Atoms $str1 and $str2 too close at symprec=$str3")
     end
     p = sort(eachindex(cryst.positions), lt=less_than)
     permute_sites!(cryst, p)

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -5,15 +5,15 @@ Constructors are as follows:
 
     Crystal(filename, symprec=nothing)
 
-Reads the crystal from a CIF or mCIF at `filename`. Lattice vectors of the
-returned `Crystal` will be in units of angstrom. In most cases, `symprec` can be
-inferred. If a consistency error is reported, however, then an explicit
-`symprec` may be provided to specify the precision of the dimensionless site
-position data (commonly between 1e-2 and 1e-5).
+Reads the crystal from a CIF or mCIF at `filename`. Lattice vectors will be in
+units of angstrom. In most cases, `symprec` can be inferred. In cases of
+inconsistency, however, an explicit `symprec` may be provided. It should specify
+the precision of the dimensionless site position data, commonly in the range of
+1e-2 to 1e-5.
 
-If reading an mCIF, the magnetic cell will be converted to a conventional
-chemical cell, which will have an enlarged set of spacegroup symmetries. Site
-positions will be preserved for compatibility with subsequent calls to
+For an mCIF, the magnetic cell will be converted to a conventional chemical
+cell, which will have an enlarged set of spacegroup symmetries. Site positions
+will be preserved for compatibility with subsequent calls to
 [`set_dipoles_from_mcif!`](@ref).
 
     Crystal(latvecs, positions; types=nothing, symprec=1e-5)

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -5,17 +5,17 @@ Constructors are as follows:
 
     Crystal(filename, symprec=nothing)
 
-Reads the crystal from a `.cif` or `.mcif` file located at the path `filename`.
-The `latvecs` field of the returned `Crystal` will be in units of angstrom. In
-most cases, `symprec` can be inferred correctly. If a consistency error is
-reported, however, then an explicit `symprec` may be selected, which should
-describe the precision of the dimensionless site position data (commonly between
-1e-2 and 1e-5).
+Reads the crystal from a CIF or mCIF file located at the path `filename`. The
+`latvecs` field of the returned `Crystal` will be in units of angstrom. In most
+cases, `symprec` can be inferred correctly. If a consistency error is reported,
+however, then an explicit `symprec` may be selected, which should describe the
+precision of the dimensionless site position data (commonly between 1e-2 and
+1e-5).
 
-If an `.mcif` file is provided, a conventional chemical cell will be inferred
-and returned. Its spacegroup symmetries will be a superset of the magnetic
-spacegroup symmetries. Site positions of the returned crystal will be compatible
-with subsequent calls to [`set_dipoles_from_mcif!`](@ref).
+For an mCIF file, the magnetic cell will be reduced to a conventional chemical
+cell. The magnetic spacegroup symmetries will be a subset of the inferred
+chemical spacecegroup symmetries. Site positions of the returned crystal will be
+compatible with subsequent calls to [`set_dipoles_from_mcif!`](@ref).
 
     Crystal(latvecs, positions; types=nothing, symprec=1e-5)
 

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -5,17 +5,16 @@ Constructors are as follows:
 
     Crystal(filename, symprec=nothing)
 
-Reads the crystal from a CIF or mCIF file located at the path `filename`. The
-`latvecs` field of the returned `Crystal` will be in units of angstrom. In most
-cases, `symprec` can be inferred correctly. If a consistency error is reported,
-however, then an explicit `symprec` may be selected, which should describe the
-precision of the dimensionless site position data (commonly between 1e-2 and
-1e-5).
+Reads the crystal from a CIF or mCIF at `filename`. Lattice vectors of the
+returned `Crystal` will be in units of angstrom. In most cases, `symprec` can be
+inferred. If a consistency error is reported, however, then an explicit
+`symprec` may be provided to specify the precision of the dimensionless site
+position data (commonly between 1e-2 and 1e-5).
 
-For an mCIF file, the magnetic cell will be reduced to a conventional chemical
-cell. The magnetic spacegroup symmetries will be a subset of the inferred
-chemical spacecegroup symmetries. Site positions of the returned crystal will be
-compatible with subsequent calls to [`set_dipoles_from_mcif!`](@ref).
+If reading an mCIF, the magnetic cell will be converted to a conventional
+chemical cell, which will have an enlarged set of spacegroup symmetries. Site
+positions will be preserved for compatibility with subsequent calls to
+[`set_dipoles_from_mcif!`](@ref).
 
     Crystal(latvecs, positions; types=nothing, symprec=1e-5)
 

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -10,9 +10,9 @@ units of angstrom. In most cases, `symprec` can be omitted. If provided, it will
 specify the precision of the dimensionless site position data (commonly between
 1e-2 and 1e-5).
 
-Given an mCIF, this constructor will convert the magnetic cell to an inferred
-conventional chemical cell. Use this crystal to construct an appropriately
-shaped [`System`](@ref) and then load the magnetic order with
+If reading an mCIF, the magnetic cell will be converted to an inferred
+conventional chemical cell and returned. Use this crystal to build an
+appropriately shaped [`System`](@ref) and then load the magnetic order with
 [`set_dipoles_from_mcif!`](@ref).
 
     Crystal(latvecs, positions; types=nothing, symprec=1e-5)

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -3,14 +3,18 @@
 An object describing a crystallographic unit cell and its space group symmetry.
 Constructors are as follows:
 
-    Crystal(filename)
+    Crystal(filename, symprec=nothing)
 
 Reads the crystal from a `.cif` or `.mcif` file located at the path `filename`.
-The `latvecs` field of the returned `Crystal` will be in units of angstrom.
+The `latvecs` field of the returned `Crystal` will be in units of angstrom. In
+most cases, `symprec` can be inferred correctly. If a consistency error is
+reported, however, then an explicit `symprec` may be selected, which should
+describe the precision of the dimensionless site position data (commonly between
+1e-2 and 1e-5).
 
 If an `.mcif` file is provided, a conventional chemical cell will be inferred
-and returned. The spacegroup symmetry of this crystal will be independent of the
-magnetic structure. This crystal will have site positions that are compatible
+and returned. Its spacegroup symmetries will be a superset of the magnetic
+spacegroup symmetries. Site positions of the returned crystal will be compatible
 with subsequent calls to [`set_dipoles_from_mcif!`](@ref).
 
     Crystal(latvecs, positions; types=nothing, symprec=1e-5)

--- a/src/Symmetry/Parsing.jl
+++ b/src/Symmetry/Parsing.jl
@@ -10,10 +10,10 @@ function parse_cif_float_with_err(str::String; maybe_fractional)
         # E.g., 0.2 has an assumed error bar of ±0.05
         err = 10.0^(-sigfigs) / 2
 
-        # Components of each Wyckoff position in an ITA standard cell may also
-        # be an exact multiple of {1/2, 1/3, 1/4, 1/6, 1/8}. For example, the
-        # position 0.125 = 1/8 is likely to be exact. Such strings should not
-        # contributed to the estimated error.
+        # Components of each Wyckoff position in an ITA standard cell may be an
+        # exact multiple of {1/2, 1/3, 1/4, 1/6, 1/8}. For example, the position
+        # 0.125 = 1/8 is likely to be exact. Such strings do not contribute to
+        # the estimated error when `maybe_fractional=true`.
         if maybe_fractional
             smallest_remainder = minimum(abs(rem(number * c, 1, RoundNearest)) / c for c in (2, 3, 4, 6, 8))
             if smallest_remainder < 1e-12
@@ -92,7 +92,7 @@ function parse_op(str::AbstractString) :: SymOp
 end
 
 
-# Reads the crystal from a `.cif` file located at the path `filename`. See
+# Reads the crystal from a CIF or mCIF located at the path `filename`. See
 # extended doc string in Crystal.jl.
 function Crystal(filename::AbstractString; keep_supercell=false, symprec=nothing, override_symmetry=nothing)
     if !isnothing(override_symmetry)
@@ -255,9 +255,9 @@ function Crystal(filename::AbstractString; keep_supercell=false, symprec=nothing
             # The inferred ret.sg data (setting and symops) may be slightly
             # perturbed from the ITA standard tables. This happens for
             # test/cifs/UPt3.cif, with spacegroup 194. Wyckoff 6h has a site at
-            # position (x,2x,1/4). The CIF file stores x and 2x using strings
-            # with truncated decimal expansions, 0.333 and 0.667. The ratio of
-            # these numbers slightly deviates from 2, causing Spglib to infer a
+            # position (x,2x,1/4). The CIF stores x and 2x using strings with
+            # truncated decimal expansions, 0.333 and 0.667. The ratio of these
+            # numbers slightly deviates from 2, causing Spglib to infer a
             # slightly perturbed setting. Get clean symmetry data using tables
             # for the inferred Hall number.
             sg = Spacegroup(hall_number_inferred)

--- a/src/Symmetry/Parsing.jl
+++ b/src/Symmetry/Parsing.jl
@@ -211,7 +211,7 @@ function Crystal(filename::AbstractString; keep_supercell=false, symprec=nothing
     end
 
     # If user-provided symprec0 is unavailable, use inferred symprec. The 10x
-    # fudge factor and 1e-8 lower bound give Spglib some safety margin.
+    # fudge factor and 1e-8 lower bound give some safety margin.
     symprec = @something symprec0 max(10*symprec, 1e-8)
 
     # Fill atom positions by symmetry and infer symmetry operations

--- a/src/Symmetry/Parsing.jl
+++ b/src/Symmetry/Parsing.jl
@@ -34,25 +34,6 @@ function parse_cif_float(str::String)
     return parse_cif_float_with_err(str; maybe_fractional=false)[1]
 end
 
-#=
-# Components x of each Wyckoff position will either be:
-# 1. An exact multiple of {1/2, 1/3, 1/4, 1/6, 1/8}, or
-# 2. An arbitrary real number  
-# In practice, the CIF will provide x as a decimal expansion. Work backwards to
-# make a conservative guess about the precision of x. For example, 0.125 = 1/8
-# could be exact, but 0.126 is likely ±0.0005
-function guess_precision(x)
-    # See if x closely matches any simple fraction
-    tol1 = minimum(abs(rem(x * c, 1, RoundNearest)) / c for c in (2, 3, 4, 6, 8))
-
-    # Count digits in a decimal expansion
-    x_decimal = round(x, digits=12)
-    fraction_digits = length(split(repr(x_decimal), ".")[2])
-    tol2 = 10.0^(-fraction_digits) / 2
-
-    min(tol1, tol2)
-end
-=#
 
 function parse_number_or_fraction(s)
     # Parse a number or fraction

--- a/src/Symmetry/Parsing.jl
+++ b/src/Symmetry/Parsing.jl
@@ -247,10 +247,10 @@ function Crystal(filename::AbstractString; keep_supercell=false, symprec=nothing
 
         hall_number_inferred = hall_number_from_symops(ret.sg.number, ret.sg.symops; atol=symprec)
         if isnothing(hall_number_inferred)
-            @warn "This CIF employs a non-standard spacegroup setting for which symmetry \
-                   analysis may be unreliable! Use `standardize(cryst)` to obtain the \
-                   standard chemical cell and then `reshape_supercell(sys, shape)` for \
-                   calculations on an arbitrarily shaped system."
+            @warn "This CIF uses a non-standard spacegroup setting, making symmetry \
+                   analysis unreliable! Use `standardize(cryst)` to obtain the \
+                   standard chemical cell. Then use `reshape_supercell(sys, shape)` \
+                   for calculations on an arbitrarily shaped system."
         else
             # The inferred ret.sg data (setting and symops) may be slightly
             # perturbed from the ITA standard tables. This happens for

--- a/src/Symmetry/Parsing.jl
+++ b/src/Symmetry/Parsing.jl
@@ -215,7 +215,8 @@ function Crystal(filename::AbstractString; keep_supercell=false, symprec=nothing
     symprec = @something symprec0 max(10*symprec, 1e-8)
 
     # Fill atom positions by symmetry and infer symmetry operations
-    orbits = crystallographic_orbits_distinct(symops, positions; symprec)
+    orbits = crystallographic_orbit.(positions; symops, symprec)
+    validate_orbits(positions, orbits; symprec)
     all_positions = reduce(vcat, orbits)
     all_types = repeat_multiple(classes, length.(orbits))
 

--- a/src/Symmetry/Printing.jl
+++ b/src/Symmetry/Printing.jl
@@ -171,13 +171,6 @@ function print_bond(cryst::Crystal, b::Bond; b_ref=b, io=stdout)
     println(io)
 end
 
-function validate_crystal(cryst::Crystal)
-    if isempty(cryst.sg.symops)
-        error("""No symmetry information available for crystal. This likely indicates that
-                 the crystal has been reshaped. Perform symmetry analysis on the original
-                 crystal instead.""")
-    end
-end
 
 """
     print_symmetry_table(cryst::Crystal, max_dist)
@@ -188,7 +181,6 @@ b)` for every bond `b` in `reference_bonds(cryst, max_dist)`, where
 `Bond(i, i, [0,0,0])` refers to a single site `i`.
 """
 function print_symmetry_table(cryst::Crystal, max_dist; io=stdout)
-    validate_crystal(cryst)
     for b in reference_bonds(cryst, max_dist)
         print_bond(cryst, b; io)
     end

--- a/src/Symmetry/SpacegroupData.jl
+++ b/src/Symmetry/SpacegroupData.jl
@@ -323,19 +323,11 @@ const standard_primitive_basis = Dict(
     'R' => SA[2/3 -1/3 -1/3; 1/3 1/3 -2/3; 1/3 1/3 1/3],
 )
 
-# Let setting=(P, p) transform from a custom setting to the standard one:  
-#   xₛ = P x + p.  
-# A symop (Rₛ, Tₛ) in the standard setting maps positions as xₛ' = Rₛ xₛ + Tₛ.
-# The corresponding map in the custom setting x' = R x + T requires  
-#   R = P⁻¹ Rₛ P  
-#   T = P⁻¹ (Rₛ p + Tₛ - p)  
-# Given symop (Rₛ, Tₛ), return the symop (R, T) that acts in the custom setting.
+# Let `setting` denote the transformation from a custom setting to the standard
+# one: xₛ = transform(setting, x). Given a `symop` that acts in the standard
+# setting, return the transformed symop that acts in the custom setting.
 function map_symop_to_setting(symop; setting)
-    P = setting.R
-    p = setting.T
-    R = P \ symop.R * P
-    T = P \ (symop.R * p + symop.T - p)
-    return SymOp(R, T)
+    return inv(setting) * symop * setting
 end
 
 struct Spacegroup

--- a/src/Symmetry/SymOp.jl
+++ b/src/Symmetry/SymOp.jl
@@ -42,7 +42,7 @@ end
 
 function Base.isapprox(s1::SymOp, s2::SymOp; atol=1e-8)
     T1, T2 = wrap_to_unit_cell.((s1.T, s2.T); symprec=atol)
-    return isapprox(s1.R, s2.R; atol) && isapprox(T1, T2; atol)
+    return isapprox(s1.R, s2.R; atol=atol*√9) && isapprox(T1, T2; atol=atol*√3)
 end
 
 # Approximate group subset relation

--- a/src/Symmetry/SymmetryAnalysis.jl
+++ b/src/Symmetry/SymmetryAnalysis.jl
@@ -1,15 +1,15 @@
-# Wrap each coordinate of position r into the range [0,1). To account for finite
-# precision, wrap 1-ϵ to -ϵ, where ϵ=symprec is a tolerance parameter.
-function wrap_to_unit_cell(r::Vec3; symprec)
-    return @. mod(r+symprec, 1) - symprec
+# Wrap x into the range [0,1). To account for finite precision, wrap 1-ϵ to -ϵ,
+# where ϵ=symprec is a tolerance parameter.
+function wrap_to_unit_cell(x::Float64; symprec)
+    return mod(x+symprec, 1) - symprec
 end
 
-function all_integer(x; symprec)
-    return norm(x - round.(x)) < symprec
+function wrap_to_unit_cell(r::Vec3; symprec)
+    return wrap_to_unit_cell.(r; symprec)
 end
 
 function is_periodic_copy(r1::Vec3, r2::Vec3; symprec)
-    all_integer(r1-r2; symprec)
+    return all_integer(r1-r2; atol=symprec)
 end
 
 function is_periodic_copy(b1::BondPos, b2::BondPos; symprec)

--- a/src/Symmetry/WyckoffData.jl
+++ b/src/Symmetry/WyckoffData.jl
@@ -31,7 +31,7 @@ end
 # that F = F′ and c = c′ mod 1.
 function is_periodic_copy(w1::WyckoffExpr, w2::WyckoffExpr)
     atol = 1e-12 # FP precision because all coefficients are perfect fractions
-    return isapprox(w1.F, w2.F; atol) && all_integer(w2.c - w1.c; symprec=atol)
+    return isapprox(w1.F, w2.F; atol) && is_periodic_copy(w1.c, w2.c; symprec=atol)
 end
 
 function crystallographic_orbit(symops::Vector{SymOp}, w::WyckoffExpr)

--- a/src/Symmetry/WyckoffData.jl
+++ b/src/Symmetry/WyckoffData.jl
@@ -34,7 +34,7 @@ function is_periodic_copy(w1::WyckoffExpr, w2::WyckoffExpr)
     return isapprox(w1.F, w2.F; atol) && is_periodic_copy(w1.c, w2.c; symprec=atol)
 end
 
-function crystallographic_orbit(symops::Vector{SymOp}, w::WyckoffExpr)
+function crystallographic_orbit(w::WyckoffExpr; symops::Vector{SymOp})
     orbit = WyckoffExpr[]
     for s in symops
         w2 = transform(s, w)
@@ -75,7 +75,7 @@ function find_wyckoff_for_position(sgnum::Int, r::Vec3; symprec)
     symops = SymOp.(Rs, Ts)
 
     for (multiplicity, letter, sitesym, pos) in reverse(wyckoff_table[sgnum])
-        for w in crystallographic_orbit(symops, WyckoffExpr(pos))
+        for w in crystallographic_orbit(WyckoffExpr(pos); symops)
             θ = position_to_wyckoff_params(r, w; symprec)
             if !isnothing(θ)
                 return Wyckoff(multiplicity, letter, sitesym)

--- a/test/cifs/FeI2_orth.cif
+++ b/test/cifs/FeI2_orth.cif
@@ -1,0 +1,55 @@
+
+#======================================================================
+# CRYSTAL DATA
+#----------------------------------------------------------------------
+data_VESTA_phase_1
+
+_chemical_name_common                  'Iron iodide'
+_cell_length_a                         4.050000
+_cell_length_b                         7.014806
+_cell_length_c                         6.760000
+_cell_angle_alpha                      90.000000
+_cell_angle_beta                       90.000000
+_cell_angle_gamma                      90.000000
+_cell_volume                           192.051369
+_space_group_name_H-M_alt              'P -3 m 1'
+_space_group_IT_number                 164
+
+loop_
+_space_group_symop_operation_xyz
+'x,y,z                            '
+'-1/2x-3/2y,1/2x-1/2y,z           '
+'-1/2x+3/2y,-1/2x-1/2y,z          '
+'-1/2x+3/2y,1/2x+1/2y,-z          '
+'x,-y,-z                          '
+'-1/2x-3/2y,-1/2x+1/2y,-z         '
+'-x,-y,-z                         '
+'1/2x+3/2y,-1/2x+1/2y,-z          '
+'1/2x-3/2y,1/2x+1/2y,-z           '
+' 1/2x-3/2y,-1/2x-1/2y,z          '
+' -x,y,z                          '
+' 1/2x+3/2y,1/2x-1/2y,z           '
+' x-1/2,y+1/2,z                   '
+' -1/2x-3/2y-1/2,1/2x-1/2y+1/2,z  '
+' -1/2x+3/2y-1/2,-1/2x-1/2y+1/2,z '
+' -1/2x+3/2y-1/2,1/2x+1/2y+1/2,-z '
+' x-1/2,-y+1/2,-z                 '
+' -1/2x-3/2y-1/2,-1/2x+1/2y+1/2,-z'
+' -x-1/2,-y+1/2,-z                '
+' 1/2x+3/2y-1/2,-1/2x+1/2y+1/2,-z '
+' 1/2x-3/2y-1/2,1/2x+1/2y+1/2,-z  '
+' 1/2x-3/2y-1/2,-1/2x-1/2y+1/2,z  '
+' -x-1/2,y+1/2,z                  '
+' 1/2x+3/2y-1/2,1/2x-1/2y+1/2,z   '
+
+loop_
+   _atom_site_label
+   _atom_site_occupancy
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_adp_type
+   _atom_site_B_iso_or_equiv
+   _atom_site_type_symbol
+   Fe1        1.0     0.000000     0.000000     0.000000    Biso  ? Fe
+   I1         1.0     0.000000     0.333333     0.250000    Biso  ? I

--- a/test/cifs/UPt3.cif
+++ b/test/cifs/UPt3.cif
@@ -1,0 +1,46 @@
+data_UPt3
+
+_cell_length_a 5.8
+_cell_length_b 5.8
+_cell_length_c 4.9
+_cell_angle_alpha 90.
+_cell_angle_beta 90.
+_cell_angle_gamma 120.
+_space_group_IT_number 194
+
+loop_
+_space_group_symop_operation_xyz
+'x, x-y, -z+1/2'
+'-x+y, y, -z+1/2'
+'-y, -x, -z+1/2'
+'-x+y, -x, -z+1/2'
+'-y, x-y, -z+1/2'
+'x, y, -z+1/2'
+'-x, -x+y, z+1/2'
+'x-y, -y, z+1/2'
+'y, x, z+1/2'
+'x-y, x, z+1/2'
+'y, -x+y, z+1/2'
+'-x, -y, z+1/2'
+'-x, -x+y, -z'
+'x-y, -y, -z'
+'y, x, -z'
+'x-y, x, -z'
+'y, -x+y, -z'
+'-x, -y, -z'
+'x, x-y, z'
+'-x+y, y, z'
+'-y, -x, z'
+'-x+y, -x, z'
+'-y, x-y, z'
+'x, y, z'
+
+loop_
+_atom_site_label
+_atom_site_symmetry_multiplicity
+_atom_site_Wyckoff_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+Pt1 6 h 0.8333 0.6667 0.25
+U1 2 c 0.3334 0.6667 0.25

--- a/test/cifs/alpha_quartz.cif
+++ b/test/cifs/alpha_quartz.cif
@@ -1,0 +1,56 @@
+data_global
+_chemical_name_mineral 'Quartz'
+loop_
+_publ_author_name
+'Levien L'
+'Prewitt C T'
+'Weidner D J'
+_journal_name_full 'American Mineralogist'
+_journal_volume 65 
+_journal_year 1980
+_journal_page_first 920
+_journal_page_last 930
+_publ_section_title
+;
+ Structure and elastic properties of quartz at pressure
+ P = 1 atm
+;
+_database_code_amcsd 0000789
+_chemical_formula_sum 'Si O2'
+_cell_length_a 4.916
+_cell_length_b 4.916
+_cell_length_c 5.4054
+_cell_angle_alpha 90
+_cell_angle_beta 90
+_cell_angle_gamma 120
+_cell_volume 113.131
+_exptl_crystal_density_diffrn      2.646
+_symmetry_space_group_name_H-M 'P 32 2 1'
+_space_group_IT_number 154
+
+loop_
+_space_group_symop_operation_xyz
+  'x,y,z'
+  'y,x,2/3-z'
+  '-y,x-y,2/3+z'
+  '-x,-x+y,1/3-z'
+  '-x+y,-x,1/3+z'
+  'x-y,-y,-z'
+loop_
+_atom_site_label
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+Si   0.46970   0.00000   0.00000
+O   0.41350   0.26690   0.11910
+loop_
+_atom_site_aniso_label
+_atom_site_aniso_U_11
+_atom_site_aniso_U_22
+_atom_site_aniso_U_33
+_atom_site_aniso_U_12
+_atom_site_aniso_U_13
+_atom_site_aniso_U_23
+Si 0.00854 0.00716 0.00725 0.00358 -0.00001 -0.00002
+O 0.01745 0.01322 0.01229 0.00973 -0.00291 -0.00408
+

--- a/test/test_cif.jl
+++ b/test/test_cif.jl
@@ -16,23 +16,20 @@ end
 
 @testitem "FeI2_orth" begin
     filename = joinpath(@__DIR__, "cifs", "FeI2_orth.cif")
-
-    msg = "This CIF uses a non-standard spacegroup setting, making symmetry \
-        analysis unreliable! Use `standardize(cryst)` to obtain the \
-        standard chemical cell. Then use `reshape_supercell(sys, shape)` \
-        for calculations on an arbitrarily shaped system."
+    msg = "Inconsistent symmetry operations! This may occur with an incomplete CIF, \
+           a non-standard setting, or failed inference. Try overriding `symprec` \
+           (inferred 5e-06)."
     cryst = @test_logs (:warn, msg) Crystal(filename)
     @test Sunny.get_wyckoff(cryst, 1).letter == 'a'
     @test Sunny.get_wyckoff(cryst, 3).letter == 'd'
 end
 
 @testitem "Alpha quartz" begin
-    msg = "This CIF uses a non-standard spacegroup setting, making symmetry \
-           analysis unreliable! Use `standardize(cryst)` to obtain the \
-           standard chemical cell. Then use `reshape_supercell(sys, shape)` \
-           for calculations on an arbitrarily shaped system."
     filename = joinpath(@__DIR__, "cifs", "alpha_quartz.cif")
-    cryst = @test_logs (:warn, msg) Crystal(filename)
+    msg = "Cell appears non-standard. Consider `standardize(cryst)` and then \
+           `reshape_supercell(sys, shape)` for calculations on an arbitrarily shaped \
+           system."
+    cryst = @test_logs (:info, msg) Crystal(filename)
     @test cryst.sg.number == 154
     @test Sunny.get_wyckoff(cryst, 1).letter == 'a'
     @test Sunny.get_wyckoff(cryst, 4).letter == 'c'

--- a/test/test_cif.jl
+++ b/test/test_cif.jl
@@ -6,6 +6,26 @@
     @test Sunny.get_wyckoff(cryst, 5).letter == 'c'
 end
 
+@testitem "UPt3" begin
+    filename = joinpath(@__DIR__, "cifs", "UPt3.cif")
+    cryst = Crystal(filename)
+    @test cryst.sg.setting == one(Sunny.SymOp)
+    @test Sunny.get_wyckoff(cryst, 1).letter == 'h'
+    @test Sunny.get_wyckoff(cryst, 7).letter == 'c'
+end
+
+@testitem "Alpha quartz" begin
+    msg = "This CIF uses a non-standard spacegroup setting, making symmetry \
+           analysis unreliable! Use `standardize(cryst)` to obtain the \
+           standard chemical cell. Then use `reshape_supercell(sys, shape)` \
+           for calculations on an arbitrarily shaped system."
+    filename = joinpath(@__DIR__, "cifs", "alpha_quartz.cif")
+    cryst = @test_logs (:warn, msg) Crystal(filename)
+    @test cryst.sg.number == 154
+    @test Sunny.get_wyckoff(cryst, 1).letter == 'a'
+    @test Sunny.get_wyckoff(cryst, 4).letter == 'c'
+end
+
 @testitem "mCIF ZnFe2O4" begin
     filename = joinpath(@__DIR__, "cifs", "ZnFe2O4_jana.cif")
 
@@ -43,12 +63,12 @@ end
     cryst2 = Crystal(filename)
     cryst2 = subcrystal(cryst2, "Tb3+")
     sys2 = System(cryst2, [1 => Moment(s=3/2, g=-2)], :dipole)
-    msg = "Use `reshape_supercell(sys, [1/2 0 2; 0 1/2 -2; -1/2 1/2 2])` to get compatible system"
+    msg = "Use `reshape_supercell(sys, [1/2 -1/2 -2; 0 1/2 -2; 1/2 0 2])` to get compatible system"
     @test_throws msg set_dipoles_from_mcif!(sys2, filename)
-    sys2 = reshape_supercell(sys2, [1/2 0 2; 0 1/2 -2; -1/2 1/2 2])
+    sys2 = reshape_supercell(sys2, [1/2 -1/2 -2; 0 1/2 -2; 1/2 0 2])
     set_dipoles_from_mcif!(sys2, filename)
 
     S0 = [0, 0, 3/2]
     @test vec(sys1.dipoles) ≈ [-S0, +S0, -S0, +S0, -S0, +S0]
-    @test vec(sys2.dipoles) ≈ [-S0, +S0, +S0, -S0, -S0, +S0]
+    @test vec(sys2.dipoles) ≈ [-S0, +S0, -S0, +S0, +S0, -S0]
 end

--- a/test/test_cif.jl
+++ b/test/test_cif.jl
@@ -1,6 +1,6 @@
 @testitem "ErOBr" begin
     filename = joinpath(@__DIR__, "cifs", "ErOBr.cif")
-    cryst = Crystal(filename; symprec=1e-3)
+    cryst = Crystal(filename)
     @test Sunny.get_wyckoff(cryst, 1).letter == 'c'
     @test Sunny.get_wyckoff(cryst, 3).letter == 'a'
     @test Sunny.get_wyckoff(cryst, 5).letter == 'c'
@@ -10,12 +10,12 @@ end
     filename = joinpath(@__DIR__, "cifs", "ZnFe2O4_jana.cif")
 
     msg = "Use `keep_supercell=true` for testing purposes only! Inferred symmetries are unreliable."
-    cryst1 = @test_logs (:warn, msg) Crystal(filename; symprec=1e-2, keep_supercell=true)
+    cryst1 = @test_logs (:warn, msg) Crystal(filename; keep_supercell=true)
     cryst1 = subcrystal(cryst1, "Fe")
     sys1 = System(cryst1, [1 => Moment(s=3/2, g=-2)], :dipole)
     set_dipoles_from_mcif!(sys1, filename)
 
-    cryst2 = Crystal(filename; symprec=1e-2)
+    cryst2 = Crystal(filename)
     cryst2 = subcrystal(cryst2, "Fe")
     sys2 = System(cryst2, [1 => Moment(s=3/2, g=-2)], :dipole)
     msg = "Use `resize_supercell(sys, (1, 1, 2))` to get compatible system"    
@@ -35,12 +35,12 @@ end
     filename = joinpath(@__DIR__, "cifs", "TbSb_isodistort.mcif")
 
     msg = "Use `keep_supercell=true` for testing purposes only! Inferred symmetries are unreliable."
-    cryst1 = @test_logs (:warn, msg) Crystal(filename; symprec=1e-3, keep_supercell=true)
+    cryst1 = @test_logs (:warn, msg) Crystal(filename; keep_supercell=true)
     cryst1 = subcrystal(cryst1, "Tb3+")
     sys1 = System(cryst1, [1 => Moment(s=3/2, g=-2)], :dipole)
     set_dipoles_from_mcif!(sys1, filename)
 
-    cryst2 = Crystal(filename; symprec=1e-3)
+    cryst2 = Crystal(filename)
     cryst2 = subcrystal(cryst2, "Tb3+")
     sys2 = System(cryst2, [1 => Moment(s=3/2, g=-2)], :dipole)
     msg = "Use `reshape_supercell(sys, [1/2 0 2; 0 1/2 -2; -1/2 1/2 2])` to get compatible system"

--- a/test/test_cif.jl
+++ b/test/test_cif.jl
@@ -9,22 +9,20 @@ end
 @testitem "mCIF ZnFe2O4" begin
     filename = joinpath(@__DIR__, "cifs", "ZnFe2O4_jana.cif")
 
-    msg = """Loading the magnetic cell as chemical cell for TESTING PURPOSES only.
-             Set the option `override_symmetry=true` to infer the standard chemical
-             cell and its spacegroup symmetries."""
-    cryst1 = @test_logs (:warn, msg) Crystal(filename; symprec=1e-2)
-    cryst1 = subcrystal(cryst1, "Fe_1", "Fe_4")
-    sys1 = System(cryst1, [1 => Moment(s=3/2, g=-2), 17 => Moment(s=3/2, g=-2)], :dipole)
+    msg = "Use `keep_supercell=true` for testing purposes only! Inferred symmetries are unreliable."
+    cryst1 = @test_logs (:warn, msg) Crystal(filename; symprec=1e-2, keep_supercell=true)
+    cryst1 = subcrystal(cryst1, "Fe")
+    sys1 = System(cryst1, [1 => Moment(s=3/2, g=-2)], :dipole)
     set_dipoles_from_mcif!(sys1, filename)
-    
-    cryst2 = Crystal(filename; override_symmetry=true, symprec=1e-2)
+
+    cryst2 = Crystal(filename; symprec=1e-2)
     cryst2 = subcrystal(cryst2, "Fe")
     sys2 = System(cryst2, [1 => Moment(s=3/2, g=-2)], :dipole)
     msg = "Use `resize_supercell(sys, (1, 1, 2))` to get compatible system"    
     @test_throws msg set_dipoles_from_mcif!(sys2, filename)
     sys2 = resize_supercell(sys2, (1, 1, 2))
     set_dipoles_from_mcif!(sys2, filename)
-    
+
     for site1 in eachsite(sys1)
         # Note that lattice units vary for sys1 and sys2, so we must explicit
         # reference the lattice vectors for a given system.
@@ -36,15 +34,13 @@ end
 @testitem "mCIF TbSb" begin
     filename = joinpath(@__DIR__, "cifs", "TbSb_isodistort.mcif")
 
-    msg = """Loading the magnetic cell as chemical cell for TESTING PURPOSES only.
-             Set the option `override_symmetry=true` to infer the standard chemical
-             cell and its spacegroup symmetries."""
-    cryst1 = @test_logs (:warn, msg) Crystal(filename; symprec=1e-3)
-    cryst1 = subcrystal(cryst1, "Tb1_1")
+    msg = "Use `keep_supercell=true` for testing purposes only! Inferred symmetries are unreliable."
+    cryst1 = @test_logs (:warn, msg) Crystal(filename; symprec=1e-3, keep_supercell=true)
+    cryst1 = subcrystal(cryst1, "Tb3+")
     sys1 = System(cryst1, [1 => Moment(s=3/2, g=-2)], :dipole)
     set_dipoles_from_mcif!(sys1, filename)
 
-    cryst2 = Crystal(filename; override_symmetry=true, symprec=1e-3)
+    cryst2 = Crystal(filename; symprec=1e-3)
     cryst2 = subcrystal(cryst2, "Tb3+")
     sys2 = System(cryst2, [1 => Moment(s=3/2, g=-2)], :dipole)
     msg = "Use `reshape_supercell(sys, [1/2 0 2; 0 1/2 -2; -1/2 1/2 2])` to get compatible system"

--- a/test/test_cif.jl
+++ b/test/test_cif.jl
@@ -14,6 +14,18 @@ end
     @test Sunny.get_wyckoff(cryst, 7).letter == 'c'
 end
 
+@testitem "FeI2_orth" begin
+    filename = joinpath(@__DIR__, "cifs", "FeI2_orth.cif")
+
+    msg = "This CIF uses a non-standard spacegroup setting, making symmetry \
+        analysis unreliable! Use `standardize(cryst)` to obtain the \
+        standard chemical cell. Then use `reshape_supercell(sys, shape)` \
+        for calculations on an arbitrarily shaped system."
+    cryst = @test_logs (:warn, msg) Crystal(filename)
+    @test Sunny.get_wyckoff(cryst, 1).letter == 'a'
+    @test Sunny.get_wyckoff(cryst, 3).letter == 'd'
+end
+
 @testitem "Alpha quartz" begin
     msg = "This CIF uses a non-standard spacegroup setting, making symmetry \
            analysis unreliable! Use `standardize(cryst)` to obtain the \

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -173,12 +173,12 @@ end
     import Spglib
 
     # Check conversions between settings for different Hall numbers
-    for hall1 in 1:530
-        hall2 = Sunny.standard_setting_for_hall_number(hall1)
-        P = Sunny.mapping_to_standard_setting(hall1)
-        g1 = Sunny.SymOp.(Spglib.get_symmetry_from_database(hall1)...)
-        g2 = Sunny.SymOp.(Spglib.get_symmetry_from_database(hall2)...)
-        @test [inv(P) * s * P for s in g2] ≈ g1
+    for hall_c in 1:530
+        hall_s = Sunny.standard_setting_for_hall_number(hall_c)
+        setting = Sunny.mapping_to_standard_setting(hall_c)
+        g_c = Sunny.SymOp.(Spglib.get_symmetry_from_database(hall_c)...)
+        g_s = Sunny.SymOp.(Spglib.get_symmetry_from_database(hall_s)...)
+        @test Sunny.map_symop_to_setting.(g_s; setting) ≈ g_c
     end
 
     ### Check settings for trigonal spacegroup

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -172,17 +172,29 @@ end
     latvecs = lattice_vectors(1, 1, 1.5, 90, 90, 120)
     x = 0.15
 
-    positions = [[x, 2x, 1/4], [-x, -2x, 3/4]]
-    msg = "Symmetry equivalent positions [0.15, 3/10, 1/4] and [-0.15, -3/10, 3/4] in Wyckoff 6h at symprec=0.001"
+    positions = [[x, 2x, 1/4], [-x, -2x, 3/4 + 1e-3]]
+    msg = "Equivalent positions [0.15, 3/10, 1/4] and [-0.15, -3/10, 0.751] in Wyckoff 6h at symprec=0.001"
     @test_throws msg Crystal(latvecs, positions, 194; symprec=1e-3)
 
-    positions = [[x, 2x, 1/4], [-x, -2x, 3/4 + 0.01]]
-    msg = "Nearly symmetry equivalent positions [0.15, 3/10, 1/4] and [-0.15, -3/10, 0.76] in Wyckoff 6h at symprec=0.001"
-    @test_logs (:warn, msg) Crystal(latvecs, positions, 194; symprec=1e-3)
+    positions = [[x, 2x, 1/4], [-x, -2x, 3/4 + 2e-3]]
+    msg = "Near-equivalent positions [0.15, 3/10, 1/4] and [-0.15, -3/10, 0.752] in Wyckoff 6h at symprec=0.001"
+    @test_throws msg Crystal(latvecs, positions, 194; symprec=1e-3)
 
-    positions = [[x, 2x, 1/4], [-x, -2x, 3/4 + 0.1]]
-    @test_logs Crystal(latvecs, positions, 194; symprec=1e-3) # No warning
+    positions = [[x, 2x, 1/4], [-x, -2x, 3/4 + 5e-3]]
+    Crystal(latvecs, positions, 194; symprec=1e-3) # No error
+
+    positions = [[-x, -2x, 3/4], [-x, -2x, 3/4 + 1e-3]]
+    msg = "Overlapping positions [0.85, 7/10, 3/4] and [0.85, 7/10, 0.751] at symprec=0.001"
+    @test_throws msg Crystal(latvecs, positions; symprec=1e-3)
+
+    positions = [[-x, -2x, 3/4], [-x, -2x, 3/4 + 2e-3]]
+    msg = "Near-overlapping positions [0.85, 7/10, 3/4] and [0.85, 7/10, 0.752] at symprec=0.001"
+    @test_throws msg Crystal(latvecs, positions; symprec=1e-3)
+
+    positions = [[-x, -2x, 3/4], [-x, -2x, 3/4 + 5e-3]]
+    Crystal(latvecs, positions; symprec=1e-3)
 end
+
 
 @testitem "Spacegroup settings" begin
     using LinearAlgebra

--- a/test/test_symmetry.jl
+++ b/test/test_symmetry.jl
@@ -30,7 +30,7 @@
     for sgnum in 1:230
         sg = Sunny.Spacegroup(Sunny.standard_setting[sgnum])
         for (mult, letter, sitesym, pos) in Sunny.wyckoff_table[sgnum]
-            orbit = Sunny.crystallographic_orbit(sg.symops, Sunny.WyckoffExpr(pos))
+            orbit = Sunny.crystallographic_orbit(Sunny.WyckoffExpr(pos); sg.symops)
             @test length(orbit) == mult
         end
     end
@@ -167,6 +167,22 @@ end
     @test count(==(2), cryst.classes) == 4
 end
 
+
+@testitem "Crystal errors" begin
+    latvecs = lattice_vectors(1, 1, 1.5, 90, 90, 120)
+    x = 0.15
+
+    positions = [[x, 2x, 1/4], [-x, -2x, 3/4]]
+    msg = "Symmetry equivalent positions [0.15, 3/10, 1/4] and [-0.15, -3/10, 3/4] in Wyckoff 6h at symprec=0.001"
+    @test_throws msg Crystal(latvecs, positions, 194; symprec=1e-3)
+
+    positions = [[x, 2x, 1/4], [-x, -2x, 3/4 + 0.01]]
+    msg = "Nearly symmetry equivalent positions [0.15, 3/10, 1/4] and [-0.15, -3/10, 0.76] in Wyckoff 6h at symprec=0.001"
+    @test_logs (:warn, msg) Crystal(latvecs, positions, 194; symprec=1e-3)
+
+    positions = [[x, 2x, 1/4], [-x, -2x, 3/4 + 0.1]]
+    @test_logs Crystal(latvecs, positions, 194; symprec=1e-3) # No warning
+end
 
 @testitem "Spacegroup settings" begin
     using LinearAlgebra
@@ -325,6 +341,7 @@ end
         end
     end
 end
+
 
 @testitem "Symmetry table" begin
     using LinearAlgebra
@@ -496,6 +513,7 @@ end
     @test Sunny.is_anisotropy_valid(cryst, 2, 𝒪[6,-1]+0.997385420𝒪[6,1])
     @test Sunny.is_anisotropy_valid(cryst, 2, rotate_operator(𝒪[6,2], R))
 end
+
 
 @testitem "Renormalization" begin
     latvecs = lattice_vectors(1.0, 1.1, 1.0, 90, 90, 90)


### PR DESCRIPTION
More robust loading of CIF files. Dimensionless precision `symprec` is now inferred. Loading an mCIF file will automatically convert to a standard chemical cell compatible with `set_dipoles_from_mcif!`. Various other internal robustness improvements. Fixes #409 and #225.