### PR TITLE
struct EnergyMinimizationResult to store result from minimize_energy!

### DIFF
--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -31,7 +31,6 @@ Units
 add_sample!
 clone_correlations
 clone_system
-converged
 dispersion
 dmvec
 domain_average

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -18,8 +18,8 @@ This is a **major release** with breaking interface changes.
   cell will error rather than give a wrong result.
 * When loading a CIF or mCIF, the precision parameter `symprec` becomes optional
   ([PR #413](https://github.com/SunnySuite/Sunny.jl/pull/413)).
-* The return value of [`minimize_energy!`](@ref) becomes a rich struct. Use
-  [`converged`](@ref) to check for convergence ([PR
+* The return value of [`minimize_energy!`](@ref) becomes a struct that stores
+  optimization statistics ([PR
   #430](https://github.com/SunnySuite/Sunny.jl/pull/430)).
 * Fixes to [`load_nxs`](@ref) ([PR
   #420](https://github.com/SunnySuite/Sunny.jl/pull/420)).

--- a/examples/03_LSWT_SU3_FeI2.jl
+++ b/examples/03_LSWT_SU3_FeI2.jl
@@ -156,8 +156,8 @@ sys = resize_supercell(sys, (4, 4, 4))
 randomize_spins!(sys)
 minimize_energy!(sys)
 
-# Despite successful convergence to a local energy minimum, defects are visually
-# apparent.
+# Despite successful convergence to a local energy minimum, defects in the spin
+# configuration are visually apparent.
 
 plot_spins(sys; color=[S[3] for S in sys.dipoles])
 

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -6,23 +6,14 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", res::MinimizationResult)
     (; converged, iterations, data) = res
-    Δx = number_to_simple_string(Optim.x_abschange(data); digits=2)
-    g_res = number_to_simple_string(Optim.g_residual(data); digits=2)
+    Δx = number_to_simple_string(Optim.x_abschange(data); digits=3)
+    g_res = number_to_simple_string(Optim.g_residual(data); digits=3)
     if converged
         println(io, "Converged in $iterations iterations")
     else
-        printstyled(io, "Non-converged", underline=true)
-        println(io, " after $iterations iterations: |Δx|=$Δx, |∂E/∂x|=$g_res")
+        println(io, "Non-converged after $iterations iterations: |Δx|=$Δx, |∂E/∂x|=$g_res")
     end
 end
-
-"""
-    converged(res::MinimizationResult)
-
-Checks for convergence as marked by the return value of
-[`minimize_energy!`](@ref). For more detail, see the field `res.data`.
-"""
-Optim.converged(res::MinimizationResult) = res.converged
 
 
 # Returns the stereographic projection u(α) = (2v + (1-v²)n)/(1+v²), which
@@ -127,8 +118,8 @@ the `optimize` function of the [Optim.jl
 package](https://github.com/JuliaNLSolvers/Optim.jl). Any remaining `kwargs`
 will be included in the `Options` constructor of Optim.jl.
 
-The return value stores optimization statistics. Use [`converged`](@ref) to
-check for convergence.
+Convergence status is stored in the field `ret.converged` of the return value
+`ret`. Additional optimization statistics are stored in the field `ret.data`.
 """
 function minimize_energy!(sys::System{N}; maxiters=1000, subiters=10, method=Optim.ConjugateGradient(),
                           kwargs...) where N
@@ -180,5 +171,7 @@ function minimize_energy!(sys::System{N}; maxiters=1000, subiters=10, method=Opt
         αs .*= 0
     end
 
-    return MinimizationResult(false, maxiters, res)
+    mr = MinimizationResult(false, maxiters, res)
+    @warn repr("text/plain", mr)
+    return mr
 end

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -10,7 +10,7 @@ import FFTW
 import DynamicPolynomials as DP
 import Printf: Printf, @printf, @sprintf
 import Random: Random, randn!
-import Optim: Optim, converged
+import Optim
 import JLD2
 import HCubature: hcubature
 
@@ -78,7 +78,7 @@ include("Integrators.jl")
 export Langevin, ImplicitMidpoint, step!, suggest_timestep
 
 include("Optimization.jl")
-export minimize_energy!, converged
+export minimize_energy!
 
 include("MCIF.jl")
 export set_dipoles_from_mcif!

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -86,7 +86,7 @@ end
     A = [1 1 1; -1 1 0; 0 0 1]
     sys = reshape_supercell(sys, A)
     randomize_spins!(sys)
-    @test converged(minimize_energy!(sys))
+    @test minimize_energy!(sys).converged
 
     q = rand(Float64, 3)
     swt = SpinWaveTheory(sys; measure=nothing)

--- a/test/test_optimization.jl
+++ b/test/test_optimization.jl
@@ -49,8 +49,8 @@ end
         step!(sys_dip, integrator)
         step!(sys_sun, integrator)
     end
-    @test converged(minimize_energy!(sys_dip))
-    @test converged(minimize_energy!(sys_sun))
+    @test minimize_energy!(sys_dip).converged
+    @test minimize_energy!(sys_sun).converged
 
     @test is_z_polarized(sys_dip)
     @test is_z_polarized(sys_sun)
@@ -59,8 +59,8 @@ end
     randomize_spins!(sys_dip)
     randomize_spins!(sys_sun)
 
-    @test converged(minimize_energy!(sys_dip))
-    @test converged(minimize_energy!(sys_sun))
+    @test minimize_energy!(sys_dip).converged
+    @test minimize_energy!(sys_sun).converged
 
     @test is_z_polarized(sys_dip)
     @test is_z_polarized(sys_sun)
@@ -85,8 +85,8 @@ end
     randomize_spins!(sys_dip)
     randomize_spins!(sys_sun)
 
-    @test converged(minimize_energy!(sys_dip))
-    @test converged(minimize_energy!(sys_sun))
+    @test minimize_energy!(sys_dip).converged
+    @test minimize_energy!(sys_sun).converged
 end
 
 


### PR DESCRIPTION
Fixes #407 

This modifies `minimize_energy!` to return a struct `EnergyMinimizationResult` instead. 
The fields it contains are based on what was being computed in case of a non-convergence previously. 

I have also included an interface function `has_converged` to replace the previous check in the tests i.e. patterns such as `minimize_energy!(sys) > 0` are replaced by `has_converged(minimize_energy!(sys))`. 

Finally, this modification is *breaking* because the return type of `minimize_energy!` has changed, but this was expected to address this issue. 

Since this is my first PR to this project, please let me know if I have made a mistake somewhere and what I can do to correct it. 