### PR TITLE
Print digits rather than spurious "0/1" and "√0"

### DIFF
--- a/src/Symmetry/Printing.jl
+++ b/src/Symmetry/Printing.jl
@@ -35,7 +35,7 @@ function number_to_math_string(x::Real; digits=4, tol=1e-12, max_denom=1000)
     end
 
     # Give up and print digits of floating point number
-    number_to_simple_string(x; digits, tol)
+    return number_to_simple_string(x; digits, tol)
 end
 
 # Special handling for denominators (2, 3, 4, 6, 8) appearing in Wyckoff


### PR DESCRIPTION
Add a check for small but nonzero inputs to `number_to_math_string`. Fixes #433.

New behavior:
```
julia> Sunny.number_to_math_string(0.5e-6)
"5.000e-07"

julia> Sunny.number_to_math_string(1e-8)
"1.000e-08"

julia> Sunny.number_to_math_string(1e-12)
"1.000e-12"

julia> Sunny.number_to_math_string(1e-13)
"0"
```