### PR TITLE
Proper scaling of Optim `x_abstol` parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sunny"
 uuid = "2b4a2ac8-8f8b-43e8-abf4-3cb0c45e8736"
 authors = ["The Sunny team"]
-version = "0.7.9"
+version = "0.8.0"
 
 [deps]
 Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -1,22 +1,23 @@
 # Version History
 
-## v0.7.9
+## v0.8.0
 (In development)
 
-* Enhancements to crystal construction and symmetry analysis ([PRs
-  #405](https://github.com/SunnySuite/Sunny.jl/pull/405),
-  [#413](https://github.com/SunnySuite/Sunny.jl/pull/413),
-  [#421](https://github.com/SunnySuite/Sunny.jl/pull/421)). In particular, see
-  [PR #421](https://github.com/SunnySuite/Sunny.jl/pull/421) for **breaking
-  changes** regarding atom and site indexing conventions. When loading an CIF or
-  mCIF, precision parameter `symprec` is now inferred. Loading an mCIF as a
-  chemical cell now employs a standardized Cartesian coordinate system, as would
-  be obtained from [`lattice_vectors`](@ref). Crystal lattice vectors and
-  positions are now idealized according to spacegroup data. Indexing conventions
-  of certain reshaped systems have changed; use [`position_to_site`](@ref) for
-  robust indexing of reshaped systems. Attempting to perform symmetry analysis
-  on a crystal with a larger-than-standard chemical cell will now error rather
-  than give a wrong result.
+This is a **major release** with breaking interface changes.
+
+* Significant enhancements to crystal construction and symmetry analysis, which
+  may **reorder certain atom and site indices** ([PR
+  #405](https://github.com/SunnySuite/Sunny.jl/pull/405)). Crystal lattice
+  vectors and positions are now idealized according to spacegroup data. In rare
+  cases, this will cause re-indexing of atoms in the crystal. Site indexing
+  conventions for certain reshaped systems may also change; use
+  [`position_to_site`](@ref) for robust indexing of reshaped systems. Loading an
+  mCIF as a chemical cell now employs a standardized Cartesian coordinate
+  system, as would be obtained from [`lattice_vectors`](@ref). Attempting to
+  perform symmetry analysis on a crystal with a larger-than-standard chemical
+  cell will error rather than give a wrong result.
+* When loading a CIF or mCIF, the precision parameter `symprec` becomes optional
+  ([PR #413](https://github.com/SunnySuite/Sunny.jl/pull/413)).
 * Fixes to [`load_nxs`](@ref) ([PR
   #420](https://github.com/SunnySuite/Sunny.jl/pull/420)).
 

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -132,9 +132,8 @@ function minimize_energy!(sys::System{N}; maxiters=1000, subiters=10, method=Opt
     # a natural energy scale. Disable check on `x_reltol` because `x = [zeros]`
     # is a valid configuration (all spins aligned with the stereographic
     # projection axes). This leaves only the check on `x_abstol`. Since Optim.jl
-    # uses the default (p=2) norm, the acceptable x-tolerance scales like the
-    # square root of the number of optimization parameters.
-    x_abstol = 1e-14 * √length(αs)
+    # uses the p=Inf norm, the x-tolerance is a dimensionless number.
+    x_abstol = 1e-12
     options = Optim.Options(; iterations=subiters, x_abstol, x_reltol=NaN, g_abstol=NaN, f_reltol=NaN, f_abstol=NaN, kwargs...)
     local res
     for iter in 1 : div(maxiters, subiters, RoundUp)

--- a/src/Spiral/SpiralEnergy.jl
+++ b/src/Spiral/SpiralEnergy.jl
@@ -245,7 +245,7 @@ function minimize_spiral_energy!(sys, axis; maxiters=10_000, k_guess=randn(sys.r
     g!(G, params) = spiral_g!(G, sys, axis, params, λ)
 
     # See `minimize_energy!` for discussion of the tolerance settings.
-    x_abstol = 1e-14 * √length(params)
+    x_abstol = 1e-12
     options = Optim.Options(; iterations=maxiters, x_abstol, x_reltol=NaN, g_abstol=NaN, f_reltol=NaN, f_abstol=NaN)
 
     # First, optimize with regularization λ that pushes spins away from


### PR DESCRIPTION
Optim uses the p=Inf norm for its tolerance parameters, so `x_abstol` should be specified as a dimensionless number _independent_ of the number of optimization variables.

Also expand the text in `versions.md` and bump the version to v0.8.0, as appropriate to the breaking changes in development.
