### PR TITLE
Avoid spurious error in SCGA ferrimagnetic chain test

### DIFF
--- a/src/MathBasics.jl
+++ b/src/MathBasics.jl
@@ -32,6 +32,16 @@ function diffnorm2(a, b)
     return acc
 end
 
+# Calculates norm(a - b, Inf) without allocating
+function maxdiff(a, b)
+    @assert size(a) == size(b) "Non-matching dimensions"
+    ret = 0.0
+    for i in eachindex(a)
+        ret = max(abs(a[i] - b[i]), ret)
+    end
+    return ret
+end
+
 function is_integer(x; tol)
     return abs(x - round(x)) < tol
 end

--- a/src/SCGA/NewtonBacktracking.jl
+++ b/src/SCGA/NewtonBacktracking.jl
@@ -10,12 +10,12 @@ function newton_with_backtracking(fgh!, x0; f_reltol=NaN, x_reltol=NaN, g_abstol
 
     # Evaluate objective function f, gradient, and Hessian.
     f = fgh!(0.0, g, H, x)
-    norm(g) < g_abstol && return x
+    maximum(abs, g) < g_abstol && return x
 
     function has_converged(x, candidate_x, f, candidate_f, g)
         return (!isnan(x_reltol) && isapprox(x, candidate_x; rtol=x_reltol)) ||
                (!isnan(f_reltol) && isapprox(f, candidate_f; rtol=f_reltol)) ||
-               (!isnan(g_abstol) && norm(g) < g_abstol)
+               (!isnan(g_abstol) && maximum(abs, g) < g_abstol)
     end
 
     for k in 1:maxiters

--- a/test/test_scga.jl
+++ b/test/test_scga.jl
@@ -118,7 +118,7 @@ end
     positions = [[0, 0, 0], [0.5, 0, 0]]
     types = ["Ni2", "Fe3"]
     cryst = Crystal(latvecs, positions; types)
-    moments = [1 => Moment(; s=1, g=1),2 => Moment(; s=5/2, g=1)]
+    moments = [1 => Moment(; s=1, g=1), 2 => Moment(; s=5/2, g=1)]
     sys = System(cryst, moments, :dipole)
     J1 = 1
     set_exchange!(sys, J1, Bond(1, 2, [0, 0, 0]))
@@ -129,7 +129,7 @@ end
     res = Sunny.intensities_static(scga, qs)
     # println(round.(res.data; digits=10))
     golden_data = [5.2798224086, 4.8642933106, 16.3317444291, 4.8642933106, 5.2798224086]
-    @test isapprox(golden_data, res.data; rtol=1e-8)
+    @test isapprox(golden_data, res.data; rtol=1e-7)
 end
 
 @testitem "SCGA Kitchen sink" begin


### PR DESCRIPTION
The SCGA ferrimagnetic chain test intermittently fails at `rtol=1e-8` but seems to reliably pass at `rtol=1e-7`. Weakening this check is probably reasonable. The discrepancy likely creeps in during the optimization of SCGA Lagrange multipliers λ. This step involves matrix diagonalization, which is platform-dependent. Although Sunny optimizes λ to an accuracy of `x_reltol=1e-10`, maybe there is some mechanism that amplifies error in the measured intensities.

This PR also fixes a mistake where `g_abstol` was interpreted in the p=2 norm. Instead, following Optim.jl conventions, it should be in the p=Inf norm. See also related fixes in #436.
