### PR TITLE
Custom generators of rotations in `set_pair_coupling!`

### DIFF
--- a/src/Symmetry/AllowedCouplings.jl
+++ b/src/Symmetry/AllowedCouplings.jl
@@ -136,7 +136,7 @@ end
 # Check whether a coupling matrix J is consistent with symmetries of a bond
 function is_coupling_valid(cryst::Crystal, b::BondPos, J)
     J isa Number && return true
-    
+
     for (symop, parity) in symmetries_between_bonds(cryst, b, b)
         R = cryst.latvecs * symop.R * inv(cryst.latvecs)
         J′ = transform_coupling_by_symmetry(J, R*det(R), parity)


### PR DESCRIPTION
To support custom spin representations on each site, the user must be able to specify the generators of rotation. For example, to work with explicit spin and orbital angular momenta, one should work in a tensor product space representation. But some models might also employ a direct sum of spin multiplets, and it's nice to give power users this level of control.

The proper, eventual solution will be a variant of `Moment` that can be passed to the system constructor. That might take a while, so this PR provides partial support, where the generators of rotation can be provided in the call to `set_pair_coupling!`. This new feature is _not_ exposed in the public API.

What's correct in this PR:
* The symmetry consistency check on the pair coupling operator.
* Symmetry propagation of the coupling to other bonds.

What's missing and dangerous:
* No capability to specify a custom local magnetic moment dipole. In particular, this means that Zeeman coupling and dipole-dipole interactions will be **wrong** (don't try to use them). Also, spin-spin structure factor intensites will require the user to build a custom MeasureSpec object.
* Support only for `set_pair_coupling!`. Generators cannot yet be passed to `set_onsite_coupling!`.

Because of these limitations, there is an intentional choice to hide the new keyword argument `gen` from the public docs.