### PR TITLE
Use cis(z) or cispi(z) when possible

### DIFF
--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -176,7 +176,7 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)
 
         for i in 1:nunits
-            Avec_pref[i] = exp(- im * dot(q_global, rs_global[i]))
+            Avec_pref[i] = cis(-dot(q_global, rs_global[i]))
         end
 
         Avec = zeros(ComplexF64, Nobs)
@@ -194,7 +194,7 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
                     for (subsite, inverse_info) in enumerate(inverse_infos)
                         site_original, offset = inverse_info.site, inverse_info.offset
                         ff = get_swt_formfactor(measure, 1, site_original)
-                        prefactor = exp(-2π*im*(q_reshaped ⋅ offset)) * compute_form_factor(ff, norm2(q_global))
+                        prefactor = cispi(-2 * (q_reshaped ⋅ offset)) * compute_form_factor(ff, norm2(q_global))
                         O += prefactor * data.observables_localized[subsite, μ, i]
                     end
                     for α in 1:N-1
@@ -327,7 +327,7 @@ function swt_hamiltonian_SUN!(H::Matrix{ComplexF64}, swt::EntangledSpinWaveTheor
             @assert i == bond.i
             j = bond.j
 
-            phase = exp(2π*im * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
+            phase = cispi(2 * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
 
             # Set "general" pair interactions of the form Aᵢ⊗Bⱼ. Note that Aᵢ
             # and Bᵢ have already been transformed according to the local frames

--- a/src/KPM/Chebyshev.jl
+++ b/src/KPM/Chebyshev.jl
@@ -6,7 +6,7 @@ function apply_jackson_kernel!(coefs)
     Mp = lastindex(coefs) + 2
     for i in eachindex(coefs)
         m = i-1
-        coefs[i] *= (1/Mp)*((Mp-m)cos(m*π/Mp) + sin(m*π/Mp)/tan(π/Mp))
+        coefs[i] *= (1/Mp)*((Mp-m)cospi(m/Mp) + sinpi(m/Mp)/tanpi(1/Mp))
     end
     return coefs
 end
@@ -15,7 +15,7 @@ end
 function cheb_coefs!(M, func, bounds; buf, plan)
     N = length(buf)
     for i in eachindex(buf)
-        x_i = cos((i-0.5)π / N)
+        x_i = cospi((i-0.5) / N)
         buf[i] = func(cheb_unscale(x_i, bounds))
     end
 
@@ -75,7 +75,7 @@ function cheb_moments_to_density(μs, N; γ=1)
 
     for i in 1:N
         n = i-1
-        x = cos((π/N) * (n+1/2))
+        x = cospi((n+1/2) / N)
         push!(xs, x)
         w = 1 / sqrt(1 - x^2)
         ρs[i] *= w / π

--- a/src/SCGA/SCGA.jl
+++ b/src/SCGA/SCGA.jl
@@ -305,7 +305,7 @@ function intensities_static(scga::SCGA, qpts; measure=nothing)
         for i in 1:Na, μ in 1:Nobs
             r_global = rs_global[i] # + offsets[μ, i]
             ff = get_swt_formfactor(measure, μ, i)
-            c = exp(+ im * dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
+            c = cis(dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
             for α in 1:3
                 pref_reshaped[α, i, μ] = c * O[μ, i][α]
             end
@@ -506,7 +506,7 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
             for i in 1:Na, μ in 1:Nobs
                 r_global = rs_global[i] # + offsets[μ, i]
                 ff = get_swt_formfactor(measure, μ, i)
-                c = exp(+ im * dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
+                c = cis(dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
                 for α in 1:3
                     pref_reshaped[α, i, μ] = c * O[μ, i][α]
                 end

--- a/src/SampledCorrelations/PhaseAveraging.jl
+++ b/src/SampledCorrelations/PhaseAveraging.jl
@@ -5,7 +5,7 @@ function prefactors_for_phase_averaging(q_absolute::Vec3, recipvecs, positions, 
     # Overall phase factor for each site
     q = recipvecs \ q_absolute
     r = positions
-    prefactor = ntuple(i -> ffs[i] * exp(- 2π*im * (q ⋅ r[i])), Val{NAtoms}())
+    prefactor = ntuple(i -> ffs[i] * cispi(-2 * (q ⋅ r[i])), Val{NAtoms}())
 
     return prefactor 
 end

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -184,7 +184,7 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
         for i in 1:Na, μ in 1:Nobs
             r_global = rs_global[i] # + offsets[μ, i]
             ff = get_swt_formfactor(measure, μ, i)
-            Avec_pref[μ, i] = exp(- im * dot(q_global, r_global))
+            Avec_pref[μ, i] = cis(-dot(q_global, r_global))
             Avec_pref[μ, i] *= compute_form_factor(ff, norm2(q_global))
         end
 

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -40,7 +40,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
             @assert i == bond.i
             j = bond.j
 
-            phase = exp(2π*im * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
+            phase = cispi(2 * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
 
             si = sqrtS[i]^2
             sj = sqrtS[j]^2
@@ -206,7 +206,7 @@ function multiply_by_hamiltonian_dipole!(y::AbstractMatrix{ComplexF64}, x::Abstr
             j = bond.j
 
             map!(phases, qs_reshaped) do q
-                cis(2π*dot(q, bond.n))
+                cispi(2*dot(q, bond.n))
             end
 
             si = sqrtS[i]^2

--- a/src/SpinWaveTheory/HamiltonianSUN.jl
+++ b/src/SpinWaveTheory/HamiltonianSUN.jl
@@ -38,7 +38,7 @@ function swt_hamiltonian_SUN!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_resh
             @assert i == bond.i
             j = bond.j
 
-            phase = exp(2π*im * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
+            phase = cispi(2 * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
 
             # Set "general" pair interactions of the form Aᵢ⊗Bⱼ. Note that Aᵢ
             # and Bᵢ have already been transformed according to the local frames
@@ -175,7 +175,7 @@ function multiply_by_hamiltonian_SUN!(y::AbstractMatrix{ComplexF64}, x::Abstract
             j = bond.j
 
             map!(phases, qs_reshaped) do q
-                cis(2π*dot(q, bond.n))
+                cispi(2*dot(q, bond.n))
             end
 
             # General pair interactions

--- a/src/Spiral/LuttingerTisza.jl
+++ b/src/Spiral/LuttingerTisza.jl
@@ -16,7 +16,7 @@ function fourier_exchange_matrix!(Jq::Matrix{ComplexF64}, sys::System; q)
             @assert i == bond.i
             j = bond.j
 
-            J = exp(2π * im * dot(q_reshaped, bond.n)) * Mat3(bilin*I)
+            J = cispi(2 * dot(q_reshaped, bond.n)) * Mat3(bilin*I)
             view(Jq, :, i, :, j) .+= J
             view(Jq, :, j, :, i) .+= J'
         end
@@ -65,7 +65,7 @@ function fourier_exchange_matrix_sensitivity!(Jq, sys, label; q)
 
         (; i, j, n) = bond
 
-        J = exp(2π * im * dot(q_reshaped, n)) * Mat3(bilin*I)
+        J = cispi(2 * dot(q_reshaped, n)) * Mat3(bilin*I)
         view(Jq, :, i, :, j) .+= J
         view(Jq, :, j, :, i) .+= J'
     end

--- a/src/Spiral/SpinWaveTheorySpiral.jl
+++ b/src/Spiral/SpinWaveTheorySpiral.jl
@@ -69,7 +69,7 @@ function fourier_bilinear_interaction!(Jq, swt::SpinWaveTheory, q_reshaped)
             j = bond.j
 
             J_lab = Rs[i] * Mat3(bilin*I) * Rs[j]' # Undo transformation in `swt_data`
-            J = exp(-2π * im * dot(q_reshaped, bond.n)) * J_lab
+            J = cispi(-2 * dot(q_reshaped, bond.n)) * J_lab
             Jq[i, j] += J
             Jq[j, i] += J'
         end
@@ -303,7 +303,7 @@ function intensities_bands(sswt::SpinWaveTheorySpiral, qpts; kT=0) # TODO: branc
 
         for i in 1:Na
             ff = get_swt_formfactor(measure, 1, i)
-            Avec_pref[i] = exp(- im * dot(q_global, rs_global[i]))
+            Avec_pref[i] = cis(- dot(q_global, rs_global[i]))
             Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
         end
 

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -38,11 +38,11 @@ end
 
 
 function precompute_dipole_ewald(cryst::Crystal, dims::NTuple{3,Int}, demag::Mat3)
-    precompute_dipole_ewald_aux(cryst, dims, demag, Vec3(0,0,0), cos, Val{Float64}())
+    precompute_dipole_ewald_aux(cryst, dims, demag, Vec3(0,0,0), cos, cospi, Val{Float64}())
 end
 
 function precompute_dipole_ewald_at_wavevector(cryst::Crystal, dims::NTuple{3,Int}, demag::Mat3, q_reshaped::Vec3)
-    precompute_dipole_ewald_aux(cryst, dims, demag, q_reshaped, cis, Val{ComplexF64}())
+    precompute_dipole_ewald_aux(cryst, dims, demag, q_reshaped, cis, cispi, Val{ComplexF64}())
 end
 
 # Precompute the pairwise interaction matrix A between magnetic moments μ. For
@@ -58,7 +58,7 @@ end
 # part cancels in the symmetric sum over ±k. Specifically, replace `cis(x) ≡
 # exp(i x) = cos(x) + i sin(x)` with just `cos(x)` for efficiency. The parameter
 # `T ∈ {Float64, ComplexF64}` controls the return type in a type-stable way.
-function precompute_dipole_ewald_aux(cryst::Crystal, dims::NTuple{3,Int}, demag, q_reshaped, cis, ::Val{T}) where T
+function precompute_dipole_ewald_aux(cryst::Crystal, dims::NTuple{3,Int}, demag, q_reshaped, cis, cispi, ::Val{T}) where T
     na = natoms(cryst)
     A = zeros(SMatrix{3, 3, T, 9}, dims..., na, na)
 
@@ -106,7 +106,7 @@ function precompute_dipole_ewald_aux(cryst::Crystal, dims::NTuple{3,Int}, demag,
                 rhat = rvec/r
                 erfc0 = erfc(r/(√2*σ))
                 gauss0 = √(2/π) * (r/σ) * exp(-r²/2σ²)
-                phase = cis(2π * dot(q_reshaped, n))
+                phase = cispi(2 * dot(q_reshaped, n))
                 acc += phase * (1/4π) * ((I₃/r³) * (erfc0 + gauss0) - (3(rhat⊗rhat)/r³) * (erfc0 + (1+r²/3σ²) * gauss0))
             end
         end

--- a/test/test_chirality.jl
+++ b/test/test_chirality.jl
@@ -44,7 +44,7 @@ end
     qs = [[0, 0, -1/2], [0, 0, 1/3]]
     swt = SpinWaveTheory(sys; measure=ssf_trace(sys))
     res = intensities_bands(swt, qs)
-    disp_ref = [B + 2D*sin(2π*q[3]) for q in qs]
+    disp_ref = [B + 2D*sinpi(2*q[3]) for q in qs]
     intens_ref = [1.0 for _ in qs]
     @test res.disp[1,:] ≈ disp_ref
     @test res.data[1,:] ≈ intens_ref
@@ -53,7 +53,7 @@ end
 
     swt = SpinWaveTheorySpiral(sys; measure=ssf_trace(sys; apply_g=false), k=[0,0,0], axis=[0,0,1])
     res = intensities_bands(swt, qs)
-    @test res.disp[1, :] ≈ res.disp[2, :] ≈ res.disp[3, :] ≈ [B + 2D*sin(2π*q[3]) for q in qs]
+    @test res.disp[1, :] ≈ res.disp[2, :] ≈ res.disp[3, :] ≈ [B + 2D*sinpi(2*q[3]) for q in qs]
     @test res.data ≈ [1 1; 1 1; 1 1] / 3
 
     # Below the saturation field, the ground state is a canted spiral

--- a/test/test_lswt.jl
+++ b/test/test_lswt.jl
@@ -161,9 +161,9 @@ end
     function test_biquad(mode, q, s)
         # System
         sys = System(cryst, [1 => Moment(; s, g=2)], mode; dims=(2, 2, 2))
-        α = -0.4π
+        α = -0.4
         J = 1.0
-        JL, JQ = J * cos(α), J * sin(α) / s^2
+        JL, JQ = J * cospi(α), J * sinpi(α) / s^2
         set_pair_coupling!(sys, (Si, Sj) -> Si'*JL*Sj + JQ*(Si'*Sj)^2, Bond(1, 1, [1, 0, 0]))
 
         # Initialize Néel order
@@ -176,8 +176,8 @@ end
         disp = dispersion(swt, [q])
 
         # Analytical result
-        γq = 2 * (cos(2π*q[1]) + cos(2π*q[2]) + cos(2π*q[3]))
-        disp_ref = J * (s*cos(α) - (2*s-2+1/s) * sin(α)) * √(36 - γq^2)
+        γq = 2 * (cospi(2*q[1]) + cospi(2*q[2]) + cospi(2*q[3]))
+        disp_ref = J * (s*cospi(α) - (2*s-2+1/s) * sinpi(α)) * √(36 - γq^2)
 
         @test disp[end-1] ≈ disp[end] ≈ disp_ref
     end
@@ -348,8 +348,8 @@ end
     set_exchange!(sys, 0.24,  Bond(3, 2, [1,1,1]))   # J5
 
     for i in 1:3
-        θ = -2π*(i-1)/3
-        set_dipole!(sys, [cos(θ),sin(θ),0], (1,1,1,i))
+        θ = -2*(i-1)/3
+        set_dipole!(sys, [cospi(θ),sinpi(θ),0], (1,1,1,i))
     end
 
     sys = repeat_periodically_as_spiral(sys, (1, 1, 7); k=[0,0,1/7], axis=[0,0,1])

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -131,8 +131,8 @@ end
             # A random axis-angle
             θ = randn(3)
             # Different representations of the same physical rotation
-            D = exp(-im * θ' * K)
-            U = exp(-im * θ' * S)
+            D = cis(- θ' * K)
+            U = cis(- θ' * S)
 
             for q in -k:k
                 # Racah's commutation relations

--- a/test/test_spiral.jl
+++ b/test/test_spiral.jl
@@ -88,7 +88,7 @@ end
     # Analytical check on dispersion
 
     θ = acos(h / (2s*(4J+D)))
-    Jq = 2J*(cos(2π*q[1])+cos(2π*q[2]))
+    Jq = 2J*(cospi(2*q[1])+cospi(2*q[2]))
     disp_ref = real(√Complex(4J*s*(4J*s+2D*s*sin(θ)^2) + cos(2θ)*(Jq*s)^2 + 2s*Jq*(4J*s*cos(θ)^2 + D*s*sin(θ)^2)))
     @test res.disp[1] ≈ res.disp[2] ≈ disp_ref
 
@@ -190,11 +190,11 @@ end
     J7 = -0.00461
 
     # Constrain J6 and J2 to make k_ref exact
-    J6 = (sin((-2*ka+kc)*pi)*J7+sin(kc*pi)*J4)/(-sin((2*ka+kc)*pi))
-    J2 = (2*sin((2*ka+kc)*pi)*J6-sin(ka*pi)*(J1+J5)-3*sin(3*ka*pi)*J3-(sin(2*pi*(ka-kc/2+1/2))-sin(2*pi*(-ka+kc/2+1/2)))*J7)/(-2*sin(2*ka*pi))
+    J6 = (sinpi(-2*ka+kc)*J7+sinpi(kc)*J4)/(-sinpi(2*ka+kc))
+    J2 = (2*sinpi(2*ka+kc)*J6-sinpi(ka)*(J1+J5)-3*sinpi(3*ka)*J3-(sinpi(2*(ka-kc/2+1/2))-sinpi(2*(-ka+kc/2+1/2)))*J7)/(-2*sinpi(2*ka))
 
     # Exact energy reference
-    E_ref = (-((J1+J5)*cos(pi*ka))+J2*cos(2*pi*ka)-J3*cos(3*pi*ka)+J4*cos(pi*kc)+J6*cos(pi*(2*ka+kc))+J7*cos(pi*(2*ka-kc)))*5/2*(5/2)*4
+    E_ref = (-((J1+J5)*cospi(ka))+J2*cospi(2*ka)-J3*cospi(3*ka)+J4*cospi(kc)+J6*cospi(2*ka+kc)+J7*cospi(2*ka-kc))*5/2*(5/2)*4
 
     sys = System(cryst, [1 => Moment(s=5/2, g=2)], :dipole, seed=0)
     set_exchange!(sys, J1, bond1)


### PR DESCRIPTION
```
Replace sin(π*<expr>) with sinpi(<expr>), cos(π*<expr>) with cospi(<expr>), and sincos(π*<expr>) with 
sincospi(<expr>). This is advantageous with regard to both accuracy and performance. As a particular example, to 
evaluate the sine function in degrees instead of radians, use sinpi(x/180.0). Similarly, the single-precision functions 
sinpif(), cospif(), and sincospif() should replace calls to sinf(), cosf(), and sincosf() when the function argument is of 
the form π*<expr>. (The performance advantage sinpi() has over sin() is due to simplified argument reduction; the 
accuracy advantage is because sinpi() multiplies by π only implicitly, effectively using an infinitely precise 
mathematical π rather than a single- or double-precision approximation thereof.)
```
https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/#math-libraries