### PR TITLE
Various fitting updates

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -13,10 +13,10 @@
   ([#482](@ref)). 
 * Add Pr⁴⁺ form factor as Ce³⁺ form factor with length-scale contraction
   ([#483](@ref)).
-* Replace `squared_error_with_rescaling` with [`squared_error_fitted`](@ref).
-  The latter optionally infers a `shift` as well as a `scale` ([#484](@ref)).
-* Modify [`squared error_bands`](@ref) to expect target data first and
-  model-predicted data second ([#484](@ref)).
+* Modify squared-error functions to expect target data first and model
+  predictions second. Normalization factor depends only on target data. Replace
+  `squared_error_with_rescaling` with [`squared_error_fitted`](@ref). The latter
+  optionally infers a `shift` as well as a `scale` ([#484](@ref)).
 * Matrix ``U`` returned by [`uncertainty_matrix`](@ref) increases by a factor of
   2. Then ``U / ν`` can be interpreted as statistical covariance, with ``ν`` the
   reduced degrees of freedom ([#484](@ref)).

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -16,8 +16,8 @@
 * Modify squared-error functions to expect target data first and model
   predictions second. Normalization factor depends only on target data, and can
   be disabled with `normalize=false`. Replace `squared_error_with_rescaling`
-  with [`squared_error_fitted`](@ref). The latter optionally infers a `shift` as
-  well as a `scale` ([#484](@ref)).
+  with [`squared_error_fitted`](@ref). The latter returns a named tuple with the
+  `err` value and an optionally inferred `shift` and `scale` ([#484](@ref)).
 * Matrix ``U`` returned by [`uncertainty_matrix`](@ref) increases by a factor of
   2. Then ``U / ν`` can be interpreted as statistical covariance, with ``ν`` the
   reduced degrees of freedom ([#484](@ref)).

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -14,8 +14,7 @@
 * Add Pr⁴⁺ form factor as Ce³⁺ form factor with length-scale contraction
   ([#483](@ref)).
 * Replace `squared_error_with_rescaling` with [`squared_error_fitted`](@ref).
-  The latter can infer both a `scale` and `shift` for the target data
-  ([#484](@ref)).
+  The latter optionally infers a `shift` as well as a `scale` ([#484](@ref)).
 * Modify [`squared error_bands`](@ref) to expect target data first and
   model-predicted data second ([#484](@ref)).
 * Matrix ``U`` returned by [`uncertainty_matrix`](@ref) increases by a factor of

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -17,7 +17,7 @@
   predictions second. Normalization factor depends only on target data, and can
   be disabled with `normalize=false`. Replace `squared_error_with_rescaling`
   with [`squared_error_fitted`](@ref). The latter returns a named tuple with the
-  `err` value and an optionally inferred `shift` and `scale` ([#484](@ref)).
+  `err` value and an optionally inferred `scale` and `shift` ([#484](@ref)).
 * Matrix ``U`` returned by [`uncertainty_matrix`](@ref) increases by a factor of
   2. Then ``U / ν`` can be interpreted as statistical covariance, with ``ν`` the
   reduced degrees of freedom ([#484](@ref)).

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -14,9 +14,10 @@
 * Add Pr⁴⁺ form factor as Ce³⁺ form factor with length-scale contraction
   ([#483](@ref)).
 * Modify squared-error functions to expect target data first and model
-  predictions second. Normalization factor depends only on target data. Replace
-  `squared_error_with_rescaling` with [`squared_error_fitted`](@ref). The latter
-  optionally infers a `shift` as well as a `scale` ([#484](@ref)).
+  predictions second. Normalization factor depends only on target data, and can
+  be disabled with `normalize=false`. Replace `squared_error_with_rescaling`
+  with [`squared_error_fitted`](@ref). The latter optionally infers a `shift` as
+  well as a `scale` ([#484](@ref)).
 * Matrix ``U`` returned by [`uncertainty_matrix`](@ref) increases by a factor of
   2. Then ``U / ν`` can be interpreted as statistical covariance, with ``ν`` the
   reduced degrees of freedom ([#484](@ref)).

--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -14,12 +14,13 @@
 * Add Pr⁴⁺ form factor as Ce³⁺ form factor with length-scale contraction
   ([#483](@ref)).
 * Replace `squared_error_with_rescaling` with [`squared_error_fitted`](@ref).
-  The latter can infer both a `scale` and `shift` for the target data. Adopt the
-  convention that all "squared error" functions are called with target data
-  first and model-predicted data second ([#484](@ref)).
+  The latter can infer both a `scale` and `shift` for the target data
+  ([#484](@ref)).
+* Modify [`squared error_bands`](@ref) to expect target data first and
+  model-predicted data second ([#484](@ref)).
 * Matrix ``U`` returned by [`uncertainty_matrix`](@ref) increases by a factor of
   2. Then ``U / ν`` can be interpreted as statistical covariance, with ``ν`` the
-  reduced degrees of freedom. ([#484](@ref)).
+  reduced degrees of freedom ([#484](@ref)).
 
 ## v0.9.0
 (Mar 4, 2026)

--- a/examples/10_SCGA_fitting.jl
+++ b/examples/10_SCGA_fitting.jl
@@ -128,7 +128,6 @@ options = Optim.Options(
     show_every = 5,
 )
 fit = Optim.optimize(loss, guess, Optim.LBFGS(), options)
-@show fit.minimizer ./ units.K
 @assert isapprox(fit.minimizer ./ units.K, [32.7000, 5.5775, 6.4796, 0.3990]; rtol=1e-5) #hide
 fit.minimizer ./ units.K # [J1, J2, J3a, J3b]
 

--- a/examples/10_SCGA_fitting.jl
+++ b/examples/10_SCGA_fitting.jl
@@ -127,6 +127,7 @@ options = Optim.Options(
     show_every = 5,
 )
 fit = Optim.optimize(loss, guess, Optim.LBFGS(), options)
+@show fit.minimizer ./ units.K
 @assert isapprox(fit.minimizer ./ units.K, [32.2856, 5.4953, 6.4005, 0.3961]; rtol=1e-5) #hide
 fit.minimizer ./ units.K # [J1, J2, J3a, J3b]
 

--- a/examples/10_SCGA_fitting.jl
+++ b/examples/10_SCGA_fitting.jl
@@ -106,8 +106,8 @@ end
 
 # The loss function can be evaluated at any parameter values. As an initial
 # guess, select a model with only nearest-neighbor exchange. The Curie-Weiss
-# constant is measured to be about 400 K, which sets a scale for ``J_1`` of
-# about 50 K.
+# constant is measured to be about 400 K, which sets a ``J_1`` scale of about 50
+# K.
 
 guess = [50.0, 0.0, 0.0, 0.0]
 loss(guess)
@@ -117,7 +117,7 @@ loss(guess)
 # try are `Optim.LBFGS()` (requires gradient estimation) and
 # `Optim.NelderMead()` (gradient free). A good stopping criterion is that all
 # components of the loss gradient are below some threshold. The choice `g_tol =
-# 1e-6 / K` yields about 6 digits of precision in kelvin.
+# 1e-6 / K` aims for about 6 digits of precision in kelvin.
 
 import Optim
 

--- a/examples/10_SCGA_fitting.jl
+++ b/examples/10_SCGA_fitting.jl
@@ -101,22 +101,23 @@ loss = make_loss_fn(sys, labels) do sys
     Sq = intensities_static(scga, grid_ref)
     Sq_error = squared_error_fitted(Sq_ref, Sq.data; scale=true).error
 
-    return χ_error + 4 * Sq_error # More emphasis on S(q)
+    return χ_error + 2*Sq_error
 end
 
 # The loss function can be evaluated at any parameter values. As an initial
-# guess, select a null model without any exchange coupling.
+# guess, select a model with only nearest-neighbor exchange. The Curie-Weiss
+# constant is measured to be about 400 K, which sets a scale for ``J_1`` of
+# about 50 K.
 
-guess = [0.0, 0.0, 0.0, 0.0]
+guess = [50.0, 0.0, 0.0, 0.0]
 loss(guess)
 
 # Fit ``[J_1, J_2, J_{3a}, J_{3b}]`` to minimize the loss using the
 # [Optim](https://github.com/JuliaNLSolvers/Optim.jl) package. Good methods to
-# try are `Optim.LBFGS()` (requires gradients, possibly faster) and
-# `Optim.NelderMead()` (gradient free, possibly more robust). A good stopping
-# criterion is that all components of the loss gradient are below some
-# threshold. The choice `g_tol = 1e-6 / K` yields about 6 digits of precision in
-# kelvin.
+# try are `Optim.LBFGS()` (requires gradient estimation) and
+# `Optim.NelderMead()` (gradient free). A good stopping criterion is that all
+# components of the loss gradient are below some threshold. The choice `g_tol =
+# 1e-6 / K` yields about 6 digits of precision in kelvin.
 
 import Optim
 
@@ -128,7 +129,7 @@ options = Optim.Options(
 )
 fit = Optim.optimize(loss, guess, Optim.LBFGS(), options)
 @show fit.minimizer ./ units.K
-@assert isapprox(fit.minimizer ./ units.K, [32.2856, 5.4953, 6.4005, 0.3961]; rtol=1e-5) #hide
+@assert isapprox(fit.minimizer ./ units.K, [32.7000, 5.5775, 6.4796, 0.3990]; rtol=1e-5) #hide
 fit.minimizer ./ units.K # [J1, J2, J3a, J3b]
 
 # Optim defaults to finite differences for its gradient estimation. An
@@ -145,7 +146,7 @@ import Zygote
 import DifferentiationInterface as DI
 
 fit = Optim.optimize(loss, guess, Optim.LBFGS(), options; autodiff=DI.AutoZygote())
-@assert isapprox(fit.minimizer ./ units.K, [32.2856, 5.4953, 6.4005, 0.3961]; rtol=1e-5) #hide
+@assert isapprox(fit.minimizer ./ units.K, [32.7000, 5.5775, 6.4796, 0.3990]; rtol=1e-5) #hide
 fit.minimizer ./ units.K
 
 # Compare ``\mathcal{S}(𝐪)`` in the low-resolution ``[H, K, 0]`` slice that was
@@ -205,9 +206,9 @@ sqrt.(diag(U) / 2) / units.K # [ΔJ1, ΔJ2, ΔJ3a, ΔJ3b]
 #
 # | Parameter | This study (K) | Bai et al. (K) |
 # |:----------|---------------:|---------------:|
-# | J1        | 32.3 ± 9.6     | 38.1           |
-# | J2        | 5.5  ± 2.3     | 3.1            |
-# | J3a       | 6.4  ± 2.7     | 4.0            |
+# | J1        | 32.7 ± 7.5     | 38.1           |
+# | J2        | 5.6  ± 2.0     | 3.1            |
+# | J3a       | 6.5  ± 2.5     | 4.0            |
 # | J3b       | 0.40 ± 1.1     | 0.32           |
 #
 # The fits by Bai et al. are more accurate because they incorporate first moment

--- a/examples/10_SCGA_fitting.jl
+++ b/examples/10_SCGA_fitting.jl
@@ -99,7 +99,7 @@ loss = make_loss_fn(sys, labels) do sys
 
     scga = SCGA(sys; measure, kT=20*units.K, dq)
     Sq = intensities_static(scga, grid_ref)
-    Sq_error = squared_error_fitted(Sq_ref, Sq.data; scale=true).error
+    Sq_error = squared_error_fitted(Sq_ref, Sq.data; scale=true).err
 
     return χ_error + 2*Sq_error
 end

--- a/examples/10_SCGA_fitting.jl
+++ b/examples/10_SCGA_fitting.jl
@@ -85,7 +85,7 @@ kTs = [100, 200, 300] * units.K
 # Measure deviation from experimental data using [`squared_error`](@ref) and
 # [`squared_error_fitted`](@ref). The latter fits the unknown relative intensity
 # scale of ``\mathcal{S}(𝐪)``. Both error terms are normalized by default, so
-# adding them with equal weights is a reasonable default (tune as needed).
+# they can be added with a dimensionless weighting factor (tune as needed).
 
 labels = [:J1, :J2, :J3a, :J3b]
 
@@ -101,7 +101,7 @@ loss = make_loss_fn(sys, labels) do sys
     Sq = intensities_static(scga, grid_ref)
     Sq_error = squared_error_fitted(Sq_ref, Sq.data; scale=true).error
 
-    return 0.5 * χ_error + 0.5 * Sq_error
+    return χ_error + 4 * Sq_error # More emphasis on S(q)
 end
 
 # The loss function can be evaluated at any parameter values. As an initial
@@ -127,7 +127,7 @@ options = Optim.Options(
     show_every = 5,
 )
 fit = Optim.optimize(loss, guess, Optim.LBFGS(), options)
-@assert isapprox(fit.minimizer ./ units.K, [32.6922, 5.576, 6.4781, 0.3989]; rtol=1e-5) #hide
+@assert isapprox(fit.minimizer ./ units.K, [32.2856, 5.4953, 6.4005, 0.3961]; rtol=1e-5) #hide
 fit.minimizer ./ units.K # [J1, J2, J3a, J3b]
 
 # Optim defaults to finite differences for its gradient estimation. An
@@ -144,7 +144,7 @@ import Zygote
 import DifferentiationInterface as DI
 
 fit = Optim.optimize(loss, guess, Optim.LBFGS(), options; autodiff=DI.AutoZygote())
-@assert isapprox(fit.minimizer ./ units.K, [32.6922, 5.576, 6.4781, 0.3989]; rtol=1e-5) #hide
+@assert isapprox(fit.minimizer ./ units.K, [32.2856, 5.4953, 6.4005, 0.3961]; rtol=1e-5) #hide
 fit.minimizer ./ units.K
 
 # Compare ``\mathcal{S}(𝐪)`` in the low-resolution ``[H, K, 0]`` slice that was
@@ -204,9 +204,9 @@ sqrt.(diag(U) / 2) / units.K # [ΔJ1, ΔJ2, ΔJ3a, ΔJ3b]
 #
 # | Parameter | This study (K) | Bai et al. (K) |
 # |:----------|---------------:|---------------:|
-# | J1        | 32.7 ± 7.6     | 38.1           |
-# | J2        | 5.6  ± 2.0     | 3.1            |
-# | J3a       | 6.5  ± 2.6     | 4.0            |
+# | J1        | 32.3 ± 9.6     | 38.1           |
+# | J2        | 5.5  ± 2.3     | 3.1            |
+# | J3a       | 6.4  ± 2.7     | 4.0            |
 # | J3b       | 0.40 ± 1.1     | 0.32           |
 #
 # The fits by Bai et al. are more accurate because they incorporate first moment

--- a/examples/10_SCGA_fitting.jl
+++ b/examples/10_SCGA_fitting.jl
@@ -83,9 +83,9 @@ kTs = [100, 200, 300] * units.K
 # mismatch. Use the [`SCGA`](@ref) calculator to simulate
 # [`magnetic_susceptibility_per_site`](@ref) and [`intensities_static`](@ref).
 # Measure deviation from experimental data using [`squared_error`](@ref) and
-# [`squared_error_fitted`](@ref). The latter accounts for the unknown intensity
-# scale of ``\mathcal{S}(𝐪)``. Both error terms are of order one, so adding
-# them with equal weights is a reasonable default (tune as needed).
+# [`squared_error_fitted`](@ref). The latter fits the unknown relative intensity
+# scale of ``\mathcal{S}(𝐪)``. Both error terms are normalized by default, so
+# adding them with equal weights is a reasonable default (tune as needed).
 
 labels = [:J1, :J2, :J3a, :J3b]
 

--- a/examples/11_Powder_fitting.jl
+++ b/examples/11_Powder_fitting.jl
@@ -104,8 +104,8 @@ energies = range(0.0, 2.45; length=100)
 # `minimize_energy!` only needs to refine the canting angle for a cloned system
 # with updated parameter values.
 #
-# The function [`squared_error_fitted`](@ref) automatically fits the overall
-# scale of the experimental intensities.
+# The function [`squared_error_fitted`](@ref) with `scale=true` automatically
+# fits the unknown relative intensity scale.
 #
 # The squared error can become misleading if some model intensity "leaks" beyond
 # the energy bounds of the experimental measurement. To combat this, we include
@@ -196,7 +196,7 @@ res.data[findall(isnan, ref_data)] .= NaN
 plot_intensities!(fig[2, 1], res; colormap=:jet1, colorrange=(0, 10.0),
                   title="Optimized model fit", units)
 
-res.data .= ref_data * scale
+res.data .= ref_data / scale
 plot_intensities!(fig[1, 1], res; colormap=:jet1, colorrange=(0, 10.0),
                   title="Experimental data (coarsened)", units)
 fig

--- a/examples/11_Powder_fitting.jl
+++ b/examples/11_Powder_fitting.jl
@@ -126,7 +126,7 @@ loss = make_loss_fn(sys, labels) do sys
 
     leakage_penalty = 1e-2 * energies[end]^2 * norm(res.data[end, :])^2 / length(radii)
 
-    return squared_error_fitted(ref_data, res.data; scale=true).error + leakage_penalty
+    return squared_error_fitted(ref_data, res.data; scale=true).err + leakage_penalty
 end
 
 # The loss can be evaluated at arbitrary parameter values. Lower is better.

--- a/examples/spinw_tutorials/SW35_LuVO3-fitting.jl
+++ b/examples/spinw_tutorials/SW35_LuVO3-fitting.jl
@@ -107,9 +107,9 @@ loss(guess)
 import Optim
 
 method = Optim.NelderMead()
-options = Optim.Options(; g_tol=1e-6)
+options = Optim.Options(; g_tol=1e-8)
 fit = Optim.optimize(loss, guess, method, options)
-@assert isapprox(fit.minimizer, [6.1057, 3.9897, -0.6266, -0.0899]; rtol=1e-5) #hide
+@assert isapprox(fit.minimizer, [6.1037, 3.9892, -0.6294, -0.0902]; rtol=1e-3) #hide
 fit.minimizer # [Jab, Jc, Kxx, Kyy]
 
 # Report misfit tolerances derived from [`uncertainty_matrix`](@ref). This is a
@@ -117,14 +117,14 @@ fit.minimizer # [Jab, Jc, Kxx, Kyy]
 # systematic modeling errors.
 
 U = uncertainty_matrix(loss, fit.minimizer)
-@assert isapprox(sqrt.(diag(U) / 2), [0.2121, 0.1924, 0.081, 0.0423]; rtol=1e-3) #hide
-sqrt.(diag(U)) # [ΔJab, ΔJc, ΔKxx, ΔKyy]
+@assert isapprox(sqrt.(diag(U) / 2), [0.2121, 0.1924, 0.0812, 0.0424]; rtol=1e-3) #hide
+sqrt.(diag(U) / 2) # [ΔJab, ΔJc, ΔKxx, ΔKyy]
 
 # The parameter fits are in reasonable agreement with previous work:
 #
 # | Parameter  | This study (meV) | Skoulatos et al. (meV) |
 # |:-----------|-----------------:|-----------------------:|
-# | ``J_{ab}`` | 6.11 ± 0.21      | 5.95                   |
+# | ``J_{ab}`` | 6.10 ± 0.21      | 5.95                   |
 # | ``J_c``    | 3.99 ± 0.19      | 4.24                   |
 # | ``K_{xx}`` | -0.63 ± 0.08     | -0.48                  |
 # | ``K_{yy}`` | -0.09 ± 0.04     | -0.06                  |

--- a/examples/spinw_tutorials/SW35_LuVO3-fitting.jl
+++ b/examples/spinw_tutorials/SW35_LuVO3-fitting.jl
@@ -107,7 +107,7 @@ loss(guess)
 import Optim
 
 method = Optim.NelderMead()
-options = Optim.Options(; g_tol=1e-8)
+options = Optim.Options(; g_tol=1e-6)
 fit = Optim.optimize(loss, guess, method, options)
 @assert isapprox(fit.minimizer, [6.1037, 3.9892, -0.6294, -0.0902]; rtol=1e-3) #hide
 fit.minimizer # [Jab, Jc, Kxx, Kyy]

--- a/examples/spinw_tutorials/SW35_LuVO3-fitting.jl
+++ b/examples/spinw_tutorials/SW35_LuVO3-fitting.jl
@@ -102,14 +102,17 @@ loss(guess)
 # The [Optim](https://github.com/JuliaNLSolvers/Optim.jl) package provides a
 # variety of powerful optimization methods. For example, it supports particle
 # swarm as was used by the original SpinW tutorial. For our purposes, however,
-# the simpler Nelder-Mead method is sufficient to find the optimal model.
+# the simpler Nelder-Mead method is sufficient. Here, one should avoid
+# gradient-based optimization methods, such as LBFGS, due to the possibility of
+# discontinuous jumps in the peak-to-mode assignments of
+# [`squared_error_bands`](@ref).
 
 import Optim
 
 method = Optim.NelderMead()
-options = Optim.Options(; g_tol=1e-6)
+options = Optim.Options(; g_tol=1e-8)
 fit = Optim.optimize(loss, guess, method, options)
-@assert isapprox(fit.minimizer, [6.1037, 3.9892, -0.6294, -0.0902]; rtol=1e-3) #hide
+@assert isapprox(fit.minimizer, [6.1035, 3.9893, -0.6294, -0.0899]; rtol=1e-3) #hide
 fit.minimizer # [Jab, Jc, Kxx, Kyy]
 
 # Report misfit tolerances derived from [`uncertainty_matrix`](@ref). This is a
@@ -117,7 +120,7 @@ fit.minimizer # [Jab, Jc, Kxx, Kyy]
 # systematic modeling errors.
 
 U = uncertainty_matrix(loss, fit.minimizer)
-@assert isapprox(sqrt.(diag(U) / 2), [0.2121, 0.1924, 0.0812, 0.0424]; rtol=1e-3) #hide
+@assert isapprox(sqrt.(diag(U) / 2), [0.2120, 0.1924, 0.0812, 0.0425]; rtol=1e-3) #hide
 sqrt.(diag(U) / 2) # [ΔJab, ΔJc, ΔKxx, ΔKyy]
 
 # The parameter fits are in reasonable agreement with previous work:

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -156,15 +156,14 @@ L = \\frac{1}{c} ∑_i w_i |d_i - (α m_i + β)|^2.
 
 By default, ``α = 1`` and ``β = 0``. If `scale=true`, then determine ``α`` by
 minimizing ``L``. If `shift=true`, then optimize ``β`` analogously. The return
-value is a named tuple with fields `(; error, scale, shift)` for ``(L, α, β)``,
+value is a named tuple with fields `(; err, scale, shift)` for ``(L, α, β)``,
 respectively.
 
 Any `NaN` elements ``d_i`` or ``m_i`` will be interpreted as missing data and
 omitted from the sum. Weights ``w_i`` must be nonnegative and default to one.
 
-The default normalization is ``c = \\sum_i w_i |d_i|^2``. If `shift=true`,
-``c`` has the same form but with the data vector reduced by its weighted mean.
-Set `normalize=false` for ``c = 1``.
+The default normalization is ``c = \\sum_i w_i |d_i|^2``. Set `normalize=false`
+for ``c = 1``.
 
 !!! tip "Closed-form expressions"
 
@@ -197,10 +196,11 @@ Set `normalize=false` for ``c = 1``.
     α = \\frac{⟨\\tilde m, \\tilde d⟩}{\\|\\tilde m\\|^2}.
     ```
 
-    When `scale=true` and `normalize=true`, this yields the cosine-squared loss,
+    If `scale=true`, `shift=false`, and `normalize=true` then the minimized loss
+    becomes the usual cosine-squared loss,
 
     ```math
-    L = 1 - \\frac{|⟨\\tilde d, \\tilde m⟩|^2}{\\|\\tilde d\\|^2\\,\\|\\tilde m\\|^2}.
+    L = 1 - \\frac{|⟨d, m⟩|^2}{\\|d\\|^2 \\, \\|m\\|^2}.
     ```
 
     For complex inputs, note that the optimal ``α`` absorbs an arbitrary scale _and_
@@ -234,7 +234,8 @@ function squared_error_fitted(d, m; scale=false, shift=false, weights=nothing, n
 
     # Raw weighted moments
     W = Diagonal(w)
-    d2 = real(dot(d, W, d))
+    raw_d2 = real(dot(d, W, d))
+    d2 = raw_d2
     m2 = real(dot(m, W, m))
     md = dot(m, W, d)
 
@@ -252,30 +253,16 @@ function squared_error_fitted(d, m; scale=false, shift=false, weights=nothing, n
         md -= wsum * conj(mbar) * dbar
     end
 
-    # If both centered inputs vanish, then return zero loss
-    if iszero(d2) && iszero(m2)
-        return (; error=zero(rty), scale=one(rty), shift=(dbar-mbar))
-    end
-
-    # If `normalize` and first centered input vanishes (but second doesn't),
-    # then return maximal loss
-    if normalize && iszero(d2)
-        if scale
-            return (; error=one(rty), scale=zero(rty), shift=dbar)
-        else
-            return (; error=rty(Inf), scale=one(rty), shift=(dbar-mbar))
-        end
-    end
-
     α = (scale && !iszero(m2)) ? md / m2 : one(ty)
     β = dbar - α * mbar
 
-    error = real(abs2(α) * m2 + d2 - 2 * conj(α) * md)
+    err = rty(max(real(abs2(α) * m2 + d2 - 2 * conj(α) * md), 0.0))
     if normalize
-        error /= d2
+        iszero(raw_d2) && error("Cannot normalize when weighted norm of d is zero")
+        err /= raw_d2
     end
 
-    return (; error, scale=α, shift=β)
+    return (; err, scale=α, shift=β)
 end
 
 
@@ -297,7 +284,7 @@ for ``c = 1``.
 See [`squared_error_fitted`](@ref) for a generalization that can infer an
 unknown scale and shift between the inputs.
 """
-squared_error(d, m; weights=nothing, normalize=true) = squared_error_fitted(d, m; weights, normalize).error
+squared_error(d, m; weights=nothing, normalize=true) = squared_error_fitted(d, m; weights, normalize).err
 
 
 """

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -561,6 +561,9 @@ function squared_error_bands(Es :: Vector{Vector{Float64}}, res :: Sunny.BandInt
     length(Es) == length(E0s) || error("Mismatch in bands vs data q-length ($(length(E0s))) ≠ $(length(Es))")
     intensity_cutoff >= 0 || error("Intensity cutoff must be non-negative")
 
+    maxpeaks = maximum(length(E) for E in Es)
+    nbands >= maxpeaks || error("$nbands SWT modes are insufficient to match $maxpeaks labeled peaks")
+
     Ws = if isnothing(weights)
         [one.(E) for E in Es]
     else
@@ -570,13 +573,33 @@ function squared_error_bands(Es :: Vector{Vector{Float64}}, res :: Sunny.BandInt
     all(isreal(wk) && real(wk) >= 0 for W in Ws for wk in W) || error("Weights must be non-negative")
 
     err = sum(map(Es, Ws, E0s, X0s) do E, W, E0, X0
-        strengths = norm.(X0)
-        E0 = E0[strengths .>= intensity_cutoff]
+        npeaks = length(E)
+        @assert nbands >= npeaks
 
-        M, K = length(E0), length(E)
-        M >= K || error("$M SWT modes are insufficient to match $K labeled peaks")
-        C = [W[k] * (E0[m] - E[k])^2 for m in 1:M, k in 1:K]
-        hungarian(C)[2]
+        # Bare M×K cost matrix
+        C_bare = [W[k] * (E0[m] - E[k])^2 for m in 1:nbands, k in 1:npeaks]
+
+        # Immediately return squared error for optimal assignments if there is
+        # no intensity threshold.
+        iszero(intensity_cutoff) && return hungarian(C_bare)[2]
+
+        # Any "dark" modes below the intensity threshold should be assigned to a
+        # peak only if not enough "bright" modes are available. Achieve this by
+        # adding a strong penalty ΔC for dark mode assignment.
+        ΔC = sum(maximum(C_bare[:, k]) - minimum(C_bare[:, k]) for k in 1:npeaks)
+
+        C = copy(C_bare)
+        for m in 1:nbands
+            intensity = norm(X0[m])
+            if intensity < intensity_cutoff
+                C[m, :] .+= ΔC
+            end
+        end
+
+        # Report squared errors for assignments without the penalty term
+        assignment, cost = hungarian(C)
+        @assert sum(C[i, j] for (i, j) in enumerate(assignment) if !iszero(j)) ≈ cost
+        return sum(C_bare[i, j] for (i, j) in enumerate(assignment) if !iszero(j))
     end)
 
     if normalize

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -155,14 +155,14 @@ L = \\frac{1}{c} ∑_i w_i |d_i - (α m_i + β)|^2.
 ```
 
 By default, ``α = 1`` and ``β = 0``. If `scale=true`, then determine ``α`` by
-minimizing ``L``. If `shift=true`, then optimize ``β`` as well. The return value
-is a named tuple with fields `(; error, scale, shift)` for ``(L, α, β)``,
+minimizing ``L``. If `shift=true`, then optimize ``β`` analogously. The return
+value is a named tuple with fields `(; error, scale, shift)` for ``(L, α, β)``,
 respectively.
 
 Any `NaN` elements ``d_i`` or ``m_i`` will be interpreted as missing data and
 omitted from the sum. Weights ``w_i`` must be nonnegative and default to one.
 
-The default normalization is ``c = \\sum_i w_i \\|d_i\\|^2``. If `shift=true`,
+The default normalization is ``c = \\sum_i w_i |d_i|^2``. If `shift=true`,
 ``c`` has the same form but with the data vector reduced by its weighted mean.
 Set `normalize=false` for ``c = 1``.
 
@@ -285,14 +285,14 @@ end
 Sum of squared errors between target data ``d`` and model predictions ``m``,
 
 ```math
-L = \\frac{1}{c} \\sum_i w_i \\|d_i - m_i\\|^2.
+L = \\frac{1}{c} \\sum_i w_i |d_i - m_i|^2.
 ```
 
 Any `NaN` elements ``d_i`` or ``m_i`` will be interpreted as missing data and
 omitted from the sum. Weights ``w_i`` must be nonnegative and default to one.
 
-The default normalization is ``c = \\sum_i w_i \\|d_i\\|^2``. Set
-`normalize=false` for ``c = 1``.
+The default normalization is ``c = \\sum_i w_i |d_i|^2``. Set `normalize=false`
+for ``c = 1``.
 
 See [`squared_error_fitted`](@ref) for a generalization that can infer an
 unknown scale and shift between the inputs.

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -540,16 +540,15 @@ Squared error between experimentally labeled intensity peaks (`Es`) and the
 discrete energies of an [`intensities_bands`](@ref) calculation (`res`) for the
 same ``𝐪``-points. Each element `Es[i]` is a list of labeled intensity peaks
 for the `i`th ``𝐪``-point. Every labeled peak will be assigned to a unique spin
-wave band in `res`, but the converse is not true; any extra spin wave bands may
-be unmatched, and do not contribute to the total error.
+wave band in `res`, but the converse is not true; some spin wave bands may be
+unassigned and do not contribute to the total error.
 
 If `weights` are provided, these must be in one-to-one correspondence with the
 `Es` data, and will be used to scale the squared error terms. Default weights
 are one.
 
-If `normalize`, the return value is normalized by the weighted squared magnitude
-of `Es`. For example, if the predicted modes are uniformly zero, then the return
-value is exactly 1.
+By default, the return value is normalized by the weighted squared magnitude of
+`Es`. Set `normalize=false` to disable this normalization.
 
 Internally, this function uses the [Hungarian
 algorithm](https://github.com/Gnimuc/Hungarian.jl) for optimal assignment of

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -151,7 +151,7 @@ end
 Returns the normalized sum of squared errors,
 
 ```math
-L = \\frac{1}{c} ∑_i w_i | v_i - (α u_i + β)|^2.
+L = \\frac{1}{c} ∑_i w_i |(α v_i + β) - u_i|^2.
 ```
 
 By default, ``α = 1`` and ``β = 0``. If `scale=true`, then determine ``α`` by
@@ -184,11 +184,11 @@ disagree strongly.
     and ``\\tilde v ≡ v - \\bar v``. Otherwise, define ``\\tilde u ≡ u`` and
     ``\\tilde v ≡ v``.
 
-    When optimized, the shift is ``β = \\bar v - α \\bar u``. Otherwise,
+    When optimized, the shift is ``β = \\bar u - α \\bar v``. Otherwise,
     ``β = 0``. In either case,
 
     ```math
-    L = \\frac{1}{c} \\|\\tilde v - α \\tilde u\\|^2.
+    L = \\frac{1}{c} \\|α \\tilde v - \\tilde u\\|^2.
     ```
 
     The final expression for ``L`` depends on whether the scale is optimized.
@@ -202,10 +202,10 @@ disagree strongly.
     **Case 2, `scale=true`**: Here the optimal scale factor is
 
     ```math
-    α = \\frac{⟨\\tilde u, \\tilde v⟩}{\\|\\tilde u\\|^2}.
+    α = \\frac{⟨\\tilde v, \\tilde u⟩}{\\|\\tilde v\\|^2}.
     ```
 
-    Choosing ``c = ∑_i w_i \\|\\tilde v_i\\|^2`` gives
+    Choosing ``c = ∑_i w_i \\|\\tilde u_i\\|^2`` gives
 
     ```math
     L = 1 - \\frac{|⟨\\tilde u, \\tilde v⟩|^2}{\\|\\tilde u\\|^2\\,\\|\\tilde v\\|^2}.
@@ -242,10 +242,10 @@ function squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
     W = Diagonal(w)
     u2 = dot(u, W, u)
     v2 = dot(v, W, v)
-    uv = dot(u, W, v)
+    vu = dot(v, W, u)
 
     # Effective moments of ũ, ṽ
-    u2t, v2t, uvt, ubar, vbar = if shift
+    u2t, v2t, vut, ubar, vbar = if shift
         wsum = sum(w)
         iszero(wsum) && error("Sum of valid weights must be positive")
 
@@ -255,12 +255,12 @@ function squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
         (
             u2 - wsum * abs2(ubar),
             v2 - wsum * abs2(vbar),
-            uv - wsum * conj(ubar) * vbar,
+            vu - wsum * conj(vbar) * ubar,
             ubar,
             vbar,
         )
     else
-        (u2, v2, uv, zero(ty), zero(ty))
+        (u2, v2, vu, zero(ty), zero(ty))
     end
 
     α, L = if scale
@@ -269,19 +269,19 @@ function squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
         elseif iszero(u2t) || iszero(v2t)
             (zero(ty), one(rty)) # One centered input vanishes; define cos² loss as 1
         else
-            α = uvt / u2t
-            L = real(1 - abs2(uvt) / (u2t * v2t))
+            α = vut / v2t
+            L = real(1 - abs2(vut) / (u2t * v2t))
             (α, L)
         end
     else
         α = one(ty)
         denom = u2t + v2t
-        L = iszero(denom) ? zero(rty) : real((v2t + u2t - 2real(uvt)) / denom)
+        L = iszero(denom) ? zero(rty) : real((v2t + u2t - 2real(vut)) / denom)
         (α, L)
     end
 
     L = clamp(L, 0, 1)
-    β = shift ? vbar - α * ubar : zero(ty)
+    β = shift ? ubar - α * vbar : zero(ty)
     return (; error=L, scale=α, shift=β)
 end
 

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -146,12 +146,12 @@ end
 
 
 """
-    squared_error_fitted(u, v; scale=false, shift=false, weights=nothing, normalize=true)
+    squared_error_fitted(d, m; scale=false, shift=false, weights=nothing, normalize=true)
 
-Returns the sum of squared errors,
+Sum of squared errors between target data ``d`` and model predictions ``m``,
 
 ```math
-L = \\frac{1}{c} ∑_i w_i |(α v_i + β) - u_i|^2.
+L = \\frac{1}{c} ∑_i w_i |d_i - (α m_i + β)|^2.
 ```
 
 By default, ``α = 1`` and ``β = 0``. If `scale=true`, then determine ``α`` by
@@ -159,170 +159,145 @@ minimizing ``L``. If `shift=true`, then optimize ``β`` as well. The return valu
 is a named tuple with fields `(; error, scale, shift)` for ``(L, α, β)``,
 respectively.
 
-Any `NaN` elements ``u_i`` or ``v_i`` will be interpreted as missing data and
+Any `NaN` elements ``d_i`` or ``m_i`` will be interpreted as missing data and
 omitted from the sum. Weights ``w_i`` must be nonnegative and default to one.
 
-If `normalize=false`, then set ``c = 1`` and return the raw squared error.
-Otherwise, ``c`` will be selected such that the minimized ``L`` is symmetric in
-``(u, v)`` and is of order one when the inputs disagree strongly.
+The default normalization is ``c = \\sum_i w_i \\|d_i\\|^2``. If `shift=true`,
+``c`` has the same form but with the data vector reduced by its weighted mean.
+Set `normalize=false` for ``c = 1``.
 
 !!! tip "Closed-form expressions"
 
-    For arbitrary vectors ``a`` and ``b``, define the weighted inner product,
+    For generic ``u`` and ``v``, define the weighted inner product,
 
     ```math
-        ⟨a, b⟩ = ∑_i w_i a_i^* b_i,
+        ⟨u, v⟩ = ∑_i w_i u_i^* v_i,
     ```
 
-    and associated norm ``\\|a\\|^2 = ⟨a, a⟩``. Also define the weighted mean,
+    and associated norm ``\\|u\\|^2 = ⟨u, u⟩``. Also define the weighted mean,
 
     ```math
-    \\bar a = \\frac{∑_i w_i a_i}{∑_i w_i}.
+    \\bar u = \\frac{∑_i w_i u_i}{∑_i w_i}.
     ```
 
-    Introduce a notation to optionally subtract the weighted mean from each input
-    vector. If `shift=true`, define centered variables ``\\tilde u ≡ u - \\bar u``
-    and ``\\tilde v ≡ v - \\bar v``. Otherwise, define ``\\tilde u ≡ u`` and
-    ``\\tilde v ≡ v``.
+    Introduce a notation to optionally subtract the weighted mean from each input.
+    If `shift=true`, define ``\\tilde d = d - \\bar d`` and ``\\tilde m = m - \\bar
+    m``. Otherwise, keep ``\\tilde d = d`` and ``\\tilde m = m``.
 
-    When optimized, the shift is ``β = \\bar u - α \\bar v``. Otherwise,
+    When optimized, the shift is ``β = \\bar d - α \\bar m``. Otherwise,
     ``β = 0``. In either case,
 
     ```math
-    L = \\frac{1}{c} \\|α \\tilde v - \\tilde u\\|^2.
+    L = \\frac{1}{c} \\|\\tilde d - α \\tilde m\\|^2.
     ```
 
-    The final expression for ``L`` depends on whether the scale is optimized.
-
-    **Case 1, `scale=false`**: Here ``α = 1``. If `normalize=true`, choose
+    If `scale=false`, then ``α = 1``. Otherwise, the optimal scale factor is
 
     ```math
-    c = (\\|\\tilde u\\|^2 + \\|\\tilde v\\|^2) / 2.
+    α = \\frac{⟨\\tilde m, \\tilde d⟩}{\\|\\tilde m\\|^2}.
     ```
 
-    **Case 2, `scale=true`**: Here the optimal scale factor is
+    When `scale=true` and `normalize=true`, this yields the cosine-squared loss,
 
     ```math
-    α = \\frac{⟨\\tilde v, \\tilde u⟩}{\\|\\tilde v\\|^2}.
-    ```
-
-    If `normalize=true`, choose
-
-    ```math
-    c = \\|\\tilde u\\|^2,
-    ```
-
-    which yields the cosine-squared loss,
-
-    ```math
-    L = 1 - \\frac{|⟨\\tilde u, \\tilde v⟩|^2}{\\|\\tilde u\\|^2\\,\\|\\tilde v\\|^2}.
+    L = 1 - \\frac{|⟨\\tilde d, \\tilde m⟩|^2}{\\|\\tilde d\\|^2\\,\\|\\tilde m\\|^2}.
     ```
 
     For complex inputs, note that the optimal ``α`` absorbs an arbitrary scale _and_
     complex phase.
 """
-function squared_error_fitted(u, v; scale=false, shift=false, weights=nothing, normalize=true)
-    same_shape(u, v) || error("Mismatched input dimensions")
+function squared_error_fitted(d, m; scale=false, shift=false, weights=nothing, normalize=true)
+    same_shape(d, m) || error("Mismatched input dimensions")
     if !isnothing(weights)
-        same_shape(u, weights) || error("Mismatched weight dimensions")
+        same_shape(d, weights) || error("Mismatched weight dimensions")
     end
-    (u, v) = flatten_to_vec.((u, v))
-    ty = promote_type(eltype(u), eltype(v))
-    rty = real(ty)
+    (d, m) = flatten_to_vec.((d, m))
+    ty = promote_type(eltype(d), eltype(m))
+    rty = float(real(ty))
 
     w = if isnothing(weights)
-        fill(one(rty), length(u))
+        fill(one(rty), length(d))
     else
         flatten_to_vec(weights)
     end
 
     # Shadow the inputs by their non-NaN subarrays
-    inds = findall(i -> !isnan(u[i]) && !isnan(v[i]), eachindex(u))
+    inds = findall(i -> !isnan(d[i]) && !isnan(m[i]), eachindex(d))
     isempty(inds) && error("No valid data after removing NaNs")
     @views begin
         w = w[inds]
-        u = u[inds]
-        v = v[inds]
+        d = d[inds]
+        m = m[inds]
     end
 
     all(wi -> isreal(wi) && real(wi) >= 0, w) || error("Weights must be non-negative")
 
     # Raw weighted moments
     W = Diagonal(w)
-    u2 = dot(u, W, u)
-    v2 = dot(v, W, v)
-    vu = dot(v, W, u)
+    d2 = real(dot(d, W, d))
+    m2 = real(dot(m, W, m))
+    md = dot(m, W, d)
 
     # If `shift`, replace moments by their centered variances
-    ubar = vbar = zero(ty)
+    dbar = mbar = zero(ty)
     if shift
         wsum = sum(w)
         iszero(wsum) && error("Sum of valid weights must be positive")
 
-        ubar = dot(w, u) / wsum
-        vbar = dot(w, v) / wsum
+        dbar = dot(w, d) / wsum
+        mbar = dot(w, m) / wsum
 
-        u2 -= wsum * abs2(ubar)
-        v2 -= wsum * abs2(vbar)
-        vu -= wsum * conj(vbar) * ubar
+        d2 -= wsum * abs2(dbar)
+        m2 -= wsum * abs2(mbar)
+        md -= wsum * conj(mbar) * dbar
     end
 
-    # If `scale`, determine non-trivial α
-    α = if scale
-        if iszero(u2) && iszero(v2)
-            one(ty)
-        elseif iszero(u2) || iszero(v2)
-            zero(ty)
+    # If both centered inputs vanish, then return zero loss
+    if iszero(d2) && iszero(m2)
+        return (; error=zero(rty), scale=one(rty), shift=(dbar-mbar))
+    end
+
+    # If `normalize` and first centered input vanishes (but second doesn't),
+    # then return maximal loss
+    if normalize && iszero(d2)
+        if scale
+            return (; error=one(rty), scale=zero(rty), shift=dbar)
         else
-            vu / v2
+            return (; error=rty(Inf), scale=one(rty), shift=(dbar-mbar))
         end
-    else
-        one(ty)
     end
 
-    # For reporting purposes
-    β = ubar - α * vbar
+    α = (scale && !iszero(m2)) ? md / m2 : one(ty)
+    β = dbar - α * mbar
 
-    # Renormalization factor if requested
-    c = normalize ? real(scale ? u2 : (u2 + v2) / 2) : one(rty)
-
-    # Special care for cosine-squared loss conventions in case of degenerate
-    # inputs
-    L = if iszero(u2) && iszero(v2)
-        # Both centered signals vanish; treat this as an exact match
-        zero(rty)
-    elseif iszero(c)
-        @assert scale && iszero(u2)
-        # Centered u input vanishes while centered v input does not; use maximal
-        # cosine-squared loss
-        one(rty)
-    else
-        residual_squared = real(abs2(α) * v2 + u2 - 2 * conj(α) * vu)
-        max(residual_squared / c, zero(rty))
+    error = real(abs2(α) * m2 + d2 - 2 * conj(α) * md)
+    if normalize
+        error /= d2
     end
 
-    return (; error=L, scale=α, shift=β)
+    return (; error, scale=α, shift=β)
 end
 
 
 """
-    squared_error(u, v; weights=nothing, normalize=true)
+    squared_error(d, m; weights=nothing, normalize=true)
 
-Sum of squared errors, ``L = (1/c) \\sum_i w_i \\|v_i - u_i\\|^2``. Any `NaN`
-elements ``u_i`` or ``v_i`` will be interpreted as missing data and omitted from
-the sum. Weights ``w_i`` must be nonnegative and default to one.
-
-If `normalize=false`, then set ``c = 1`` and return the raw squared error.
-Otherwise, set ``c = (\\|u\\|^2 + \\|v\\|^2) / 2``, involving the weighted norm,
+Sum of squared errors between target data ``d`` and model predictions ``m``,
 
 ```math
-\\|a\\|^2 ≡ \\sum_i w_i |a_i|^2.
+L = \\frac{1}{c} \\sum_i w_i \\|d_i - m_i\\|^2.
 ```
+
+Any `NaN` elements ``d_i`` or ``m_i`` will be interpreted as missing data and
+omitted from the sum. Weights ``w_i`` must be nonnegative and default to one.
+
+The default normalization is ``c = \\sum_i w_i \\|d_i\\|^2``. Set
+`normalize=false` for ``c = 1``.
 
 See [`squared_error_fitted`](@ref) for a generalization that can infer an
 unknown scale and shift between the inputs.
 """
-squared_error(u, v; weights=nothing, normalize=true) = squared_error_fitted(u, v; weights, normalize).error
+squared_error(d, m; weights=nothing, normalize=true) = squared_error_fitted(d, m; weights, normalize).error
 
 
 """
@@ -559,36 +534,59 @@ function squared_error_bands_smooth(Es :: Vector{Vector{Float64}},
 end
 
 """
-    squared_error_bands(Es, res)
+    squared_error_bands(Es, res; intensity_cutoff=1e-8, weights=nothing, normalize=true)
 
 Squared error between experimentally labeled intensity peaks (`Es`) and the
 discrete energies of an [`intensities_bands`](@ref) calculation (`res`) for the
 same ``𝐪``-points. Each element `Es[i]` is a list of labeled intensity peaks
-for the `i`th ``𝐪``-point. Every labeled peak will be assigned to some spin
-wave band in `res`, but the converse is not true; any "extra" spin wave bands do
-not contribute to the squared error.
+for the `i`th ``𝐪``-point. Every labeled peak will be assigned to a unique spin
+wave band in `res`, but the converse is not true; any extra spin wave bands may
+be unmatched, and do not contribute to the total error. Any bands with intensity
+below the `intensity_cutoff` threshold are effectively ignored.
 
-The return value is normalized by the squared magnitude of `Es`. For example, if
-the predicted modes are uniformly zero, then the return value is exactly 1.
+If `weights` are provided, these must be in one-to-one correspondence with the
+`Es` data, and will be used to scale the squared error terms. Default weights
+are one.
+
+If `normalize`, the return value is normalized by the weighted squared magnitude
+of `Es`. For example, if the predicted modes are uniformly zero, then the return
+value is exactly 1.
 
 Internally, this function uses the [Hungarian
 algorithm](https://github.com/Gnimuc/Hungarian.jl) for optimal assignment of
 modes to peaks.
 """
-function squared_error_bands(Es :: Vector{Vector{Float64}}, res :: Sunny.BandIntensities)
+function squared_error_bands(Es :: Vector{Vector{Float64}}, res :: Sunny.BandIntensities; intensity_cutoff=1e-8, weights=nothing, normalize=true)
     nbands = size(res.disp, 1)
     E0s = eachcol(reshape(res.disp, nbands, :))
     X0s = eachcol(reshape(res.data, nbands, :))
     length(Es) == length(E0s) || error("Mismatch in bands vs data q-length ($(length(E0s))) ≠ $(length(Es))")
+    intensity_cutoff >= 0 || error("Intensity cutoff must be non-negative")
 
-    err = sum(map(Es, E0s, X0s) do E, E0, X0
+    Ws = if isnothing(weights)
+        [one.(E) for E in Es]
+    else
+        weights
+    end
+    same_shape(Es, Ws) || error("Weights must match the shape of labeled energies")
+    all(isreal(wk) && real(wk) >= 0 for W in Ws for wk in W) || error("Weights must be non-negative")
+
+    err = sum(map(Es, Ws, E0s, X0s) do E, W, E0, X0
+        strengths = norm.(X0)
+        E0 = E0[strengths .>= intensity_cutoff]
+
         M, K = length(E0), length(E)
         M >= K || error("$M SWT modes are insufficient to match $K labeled peaks")
-        C = [(E0[m] - E[k])^2 for m in 1:M, k in 1:K]
+        C = [W[k] * (E0[m] - E[k])^2 for m in 1:M, k in 1:K]
         hungarian(C)[2]
     end)
 
-    return err / norm2(Es)
+    if normalize
+        c = sum(dot(E, Diagonal(W), E) for (W, E) in zip(Ws, Es))
+        return err / c
+    else
+        return err
+    end
 end
 
 

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -534,15 +534,14 @@ function squared_error_bands_smooth(Es :: Vector{Vector{Float64}},
 end
 
 """
-    squared_error_bands(Es, res; intensity_cutoff=1e-8, weights=nothing, normalize=true)
+    squared_error_bands(Es, res; weights=nothing, normalize=true)
 
 Squared error between experimentally labeled intensity peaks (`Es`) and the
 discrete energies of an [`intensities_bands`](@ref) calculation (`res`) for the
 same ``𝐪``-points. Each element `Es[i]` is a list of labeled intensity peaks
 for the `i`th ``𝐪``-point. Every labeled peak will be assigned to a unique spin
 wave band in `res`, but the converse is not true; any extra spin wave bands may
-be unmatched, and do not contribute to the total error. Any bands with intensity
-below the `intensity_cutoff` threshold are effectively ignored.
+be unmatched, and do not contribute to the total error.
 
 If `weights` are provided, these must be in one-to-one correspondence with the
 `Es` data, and will be used to scale the squared error terms. Default weights
@@ -556,7 +555,7 @@ Internally, this function uses the [Hungarian
 algorithm](https://github.com/Gnimuc/Hungarian.jl) for optimal assignment of
 modes to peaks.
 """
-function squared_error_bands(Es :: Vector{Vector{Float64}}, res :: Sunny.BandIntensities; intensity_cutoff=1e-8, weights=nothing, normalize=true)
+function squared_error_bands(Es :: Vector{Vector{Float64}}, res :: Sunny.BandIntensities; intensity_cutoff=0.0, weights=nothing, normalize=true)
     nbands = size(res.disp, 1)
     E0s = eachcol(reshape(res.disp, nbands, :))
     X0s = eachcol(reshape(res.data, nbands, :))

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -194,26 +194,32 @@ Otherwise, ``c`` will be selected such that the minimized ``L`` is symmetric in
 
     The final expression for ``L`` depends on whether the scale is optimized.
 
-    **Case 1, `scale=false`**: Here ``α = 1``. If `normalize=true`, choose ``c`` so that
+    **Case 1, `scale=false`**: Here ``α = 1``. If `normalize=true`, choose
 
     ```math
-    L = \\frac{\\|\\tilde v - \\tilde u\\|^2}{\\|\\tilde u\\|^2 + \\|\\tilde v\\|^2}.
+    c = (\\|\\tilde u\\|^2 + \\|\\tilde v\\|^2) / 2.
     ```
 
     **Case 2, `scale=true`**: Here the optimal scale factor is
 
     ```math
-    α = \\frac{⟨\\tilde v, \\tilde u⟩}{\\|\\tilde v\\|^2},
+    α = \\frac{⟨\\tilde v, \\tilde u⟩}{\\|\\tilde v\\|^2}.
     ```
 
-    If `normalize=true`, select ``c = \\|\\tilde u\\|^2`` so that
+    If `normalize=true`, choose
+
+    ```math
+    c = \\|\\tilde u\\|^2,
+    ```
+
+    which yields the cosine-squared loss,
 
     ```math
     L = 1 - \\frac{|⟨\\tilde u, \\tilde v⟩|^2}{\\|\\tilde u\\|^2\\,\\|\\tilde v\\|^2}.
     ```
 
-    This is a cosine-squared loss. For complex inputs, note that the optimal
-    ``α`` absorbs an arbitrary scale _and_ complex phase.
+    For complex inputs, note that the optimal ``α`` absorbs an arbitrary scale _and_
+    complex phase.
 """
 function squared_error_fitted(u, v; scale=false, shift=false, weights=nothing, normalize=true)
     same_shape(u, v) || error("Mismatched input dimensions")
@@ -278,7 +284,7 @@ function squared_error_fitted(u, v; scale=false, shift=false, weights=nothing, n
     β = ubar - α * vbar
 
     # Renormalization factor if requested
-    c = normalize ? real(scale ? u2 : u2 + v2) : one(rty)
+    c = normalize ? real(scale ? u2 : (u2 + v2) / 2) : one(rty)
 
     # Special care for cosine-squared loss conventions in case of degenerate
     # inputs
@@ -307,7 +313,7 @@ elements ``u_i`` or ``v_i`` will be interpreted as missing data and omitted from
 the sum. Weights ``w_i`` must be nonnegative and default to one.
 
 If `normalize=false`, then set ``c = 1`` and return the raw squared error.
-Otherwise, set ``c = \\|u\\|^2 + \\|v\\|^2``, involving the weighted norm,
+Otherwise, set ``c = (\\|u\\|^2 + \\|v\\|^2) / 2``, involving the weighted norm,
 
 ```math
 \\|a\\|^2 ≡ \\sum_i w_i |a_i|^2.

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -146,24 +146,25 @@ end
 
 
 """
-    squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
+    squared_error_fitted(u, v; scale=false, shift=false, weights=nothing, normalize=true)
 
-Returns the normalized sum of squared errors,
+Returns the sum of squared errors,
 
 ```math
 L = \\frac{1}{c} ∑_i w_i |(α v_i + β) - u_i|^2.
 ```
 
 By default, ``α = 1`` and ``β = 0``. If `scale=true`, then determine ``α`` by
-minimizing ``L``. If `shift=true`, then optimize ``β`` as well. Returns a named
-tuple with fields `(; error, scale, shift)` for ``(L, α, β)``, respectively.
+minimizing ``L``. If `shift=true`, then optimize ``β`` as well. The return value
+is a named tuple with fields `(; error, scale, shift)` for ``(L, α, β)``,
+respectively.
 
-Weights ``w_i`` must be nonnegative and default to one. Any `NaN` elements
-``u_i`` or ``v_i`` will be interpreted as missing data and omitted from the sum.
+Any `NaN` elements ``u_i`` or ``v_i`` will be interpreted as missing data and
+omitted from the sum. Weights ``w_i`` must be nonnegative and default to one.
 
-The normalization factor ``c`` depends on the fitting options. In all cases, the
-minimized ``L`` is symmetric in ``(u, v)`` and is of order one when the inputs
-disagree strongly.
+If `normalize=false`, then set ``c = 1`` and return the raw squared error.
+Otherwise, ``c`` will be selected such that the minimized ``L`` is symmetric in
+``(u, v)`` and is of order one when the inputs disagree strongly.
 
 !!! tip "Closed-form expressions"
 
@@ -193,7 +194,7 @@ disagree strongly.
 
     The final expression for ``L`` depends on whether the scale is optimized.
 
-    **Case 1, `scale=false`**: Here ``α = 1`` and we choose ``c`` so that
+    **Case 1, `scale=false`**: Here ``α = 1``. If `normalize=true`, choose ``c`` so that
 
     ```math
     L = \\frac{\\|\\tilde v - \\tilde u\\|^2}{\\|\\tilde u\\|^2 + \\|\\tilde v\\|^2}.
@@ -202,10 +203,10 @@ disagree strongly.
     **Case 2, `scale=true`**: Here the optimal scale factor is
 
     ```math
-    α = \\frac{⟨\\tilde v, \\tilde u⟩}{\\|\\tilde v\\|^2}.
+    α = \\frac{⟨\\tilde v, \\tilde u⟩}{\\|\\tilde v\\|^2},
     ```
 
-    Choosing ``c = ∑_i w_i \\|\\tilde u_i\\|^2`` gives
+    If `normalize=true`, select ``c = \\|\\tilde u\\|^2`` so that
 
     ```math
     L = 1 - \\frac{|⟨\\tilde u, \\tilde v⟩|^2}{\\|\\tilde u\\|^2\\,\\|\\tilde v\\|^2}.
@@ -214,8 +215,11 @@ disagree strongly.
     This is a cosine-squared loss. For complex inputs, note that the optimal
     ``α`` absorbs an arbitrary scale _and_ complex phase.
 """
-function squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
+function squared_error_fitted(u, v; scale=false, shift=false, weights=nothing, normalize=true)
     same_shape(u, v) || error("Mismatched input dimensions")
+    if !isnothing(weights)
+        same_shape(u, weights) || error("Mismatched weight dimensions")
+    end
     (u, v) = flatten_to_vec.((u, v))
     ty = promote_type(eltype(u), eltype(v))
     rty = real(ty)
@@ -223,7 +227,6 @@ function squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
     w = if isnothing(weights)
         fill(one(rty), length(u))
     else
-        same_shape(u, weights) || error("Mismatched weight dimensions")
         flatten_to_vec(weights)
     end
 
@@ -244,67 +247,76 @@ function squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
     v2 = dot(v, W, v)
     vu = dot(v, W, u)
 
-    # Effective moments of ũ, ṽ
-    u2t, v2t, vut, ubar, vbar = if shift
+    # If `shift`, replace moments by their centered variances
+    ubar = vbar = zero(ty)
+    if shift
         wsum = sum(w)
         iszero(wsum) && error("Sum of valid weights must be positive")
 
         ubar = dot(w, u) / wsum
         vbar = dot(w, v) / wsum
 
-        (
-            u2 - wsum * abs2(ubar),
-            v2 - wsum * abs2(vbar),
-            vu - wsum * conj(vbar) * ubar,
-            ubar,
-            vbar,
-        )
-    else
-        (u2, v2, vu, zero(ty), zero(ty))
+        u2 -= wsum * abs2(ubar)
+        v2 -= wsum * abs2(vbar)
+        vu -= wsum * conj(vbar) * ubar
     end
 
-    α, L = if scale
-        if iszero(u2t) && iszero(v2t)
-            (one(ty), zero(rty)) # Both centered inputs vanish; define cos² loss as 0
-        elseif iszero(u2t) || iszero(v2t)
-            (zero(ty), one(rty)) # One centered input vanishes; define cos² loss as 1
+    # If `scale`, determine non-trivial α
+    α = if scale
+        if iszero(u2) && iszero(v2)
+            one(ty)
+        elseif iszero(u2) || iszero(v2)
+            zero(ty)
         else
-            α = vut / v2t
-            L = real(1 - abs2(vut) / (u2t * v2t))
-            (α, L)
+            vu / v2
         end
     else
-        α = one(ty)
-        denom = u2t + v2t
-        L = iszero(denom) ? zero(rty) : real((v2t + u2t - 2real(vut)) / denom)
-        (α, L)
+        one(ty)
     end
 
-    L = clamp(L, 0, 1)
-    β = shift ? ubar - α * vbar : zero(ty)
+    # For reporting purposes
+    β = ubar - α * vbar
+
+    # Renormalization factor if requested
+    c = normalize ? real(scale ? u2 : u2 + v2) : one(rty)
+
+    # Special care for cosine-squared loss conventions in case of degenerate
+    # inputs
+    L = if iszero(u2) && iszero(v2)
+        # Both centered signals vanish; treat this as an exact match
+        zero(rty)
+    elseif iszero(c)
+        @assert scale && iszero(u2)
+        # Centered u input vanishes while centered v input does not; use maximal
+        # cosine-squared loss
+        one(rty)
+    else
+        residual_squared = real(abs2(α) * v2 + u2 - 2 * conj(α) * vu)
+        max(residual_squared / c, zero(rty))
+    end
+
     return (; error=L, scale=α, shift=β)
 end
 
 
 """
-    squared_error(u, v; weights=nothing)
+    squared_error(u, v; weights=nothing, normalize=true)
 
-Normalized sum of squared errors, ``L = (1/c) \\sum_i w_i \\|v_i - u_i\\|^2``.
-Weights ``w_i`` must be nonnegative and default to one.
+Sum of squared errors, ``L = (1/c) \\sum_i w_i \\|v_i - u_i\\|^2``. Any `NaN`
+elements ``u_i`` or ``v_i`` will be interpreted as missing data and omitted from
+the sum. Weights ``w_i`` must be nonnegative and default to one.
 
-The normalization factor is defined symmetrically, ``c = \\|u\\|^2 +
-\\|v\\|^2``, involving the weighted norm,
+If `normalize=false`, then set ``c = 1`` and return the raw squared error.
+Otherwise, set ``c = \\|u\\|^2 + \\|v\\|^2``, involving the weighted norm,
 
 ```math
 \\|a\\|^2 ≡ \\sum_i w_i |a_i|^2.
 ```
 
-Any NaN elements (``u_i`` or ``v_i``) will be interpreted as missing data and
-omitted from the sum.
-
-This function is a special case of [`squared_error_fitted`](@ref).
+See [`squared_error_fitted`](@ref) for a generalization that can infer an
+unknown scale and shift between the inputs.
 """
-squared_error(u, v; weights=nothing) = squared_error_fitted(u, v; weights).error
+squared_error(u, v; weights=nothing, normalize=true) = squared_error_fitted(u, v; weights, normalize).error
 
 
 """

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -146,164 +146,165 @@ end
 
 
 """
-    squared_error_fitted(x, y; weights=nothing, scale=false, shift=false)
+    squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
 
 Returns the normalized sum of squared errors,
 
 ```math
-L = \\frac{1}{c} ∑_i w_i | y_i - (α x_i + β)|^2.
+L = \\frac{1}{c} ∑_i w_i | v_i - (α u_i + β)|^2.
 ```
 
 By default, ``α = 1`` and ``β = 0``. If `scale=true`, then determine ``α`` by
-minimizing ``L``. If `shift=true`, then similarly optimize ``β``. Returns a
-named tuple with fields `(; error, scale, shift)` for ``(L, α, β)``,
-respectively.
+minimizing ``L``. If `shift=true`, then optimize ``β`` as well. Returns a named
+tuple with fields `(; error, scale, shift)` for ``(L, α, β)``, respectively.
 
 Weights ``w_i`` must be nonnegative and default to one. Any `NaN` elements
-``x_i`` or ``y_i`` will be interpreted as missing data and omitted from the sum.
+``u_i`` or ``v_i`` will be interpreted as missing data and omitted from the sum.
 
 The normalization factor ``c`` depends on the fitting options. In all cases, the
-minimized ``L`` is symmetric in ``(x, y)`` and is of order one when ``x`` and
-``y`` maximally disagree.
+minimized ``L`` is symmetric in ``(u, v)`` and is of order one when the inputs
+disagree strongly.
 
 !!! tip "Closed-form expressions"
 
-    Begin with some notation. Define the weighted inner product,
+    For arbitrary vectors ``a`` and ``b``, define the weighted inner product,
 
     ```math
-        ⟨u, v⟩ = ∑_i w_i u_i^* v_i,
+        ⟨a, b⟩ = ∑_i w_i a_i^* b_i,
     ```
 
-    and its associated norm ``\\|u\\|^2 = ⟨u, u⟩``. Define the weighted mean,
+    and associated norm ``\\|a\\|^2 = ⟨a, a⟩``. Also define the weighted mean,
 
     ```math
-    \\bar u = \\frac{∑_i w_i u_i}{∑_i w_i}.
+    \\bar a = \\frac{∑_i w_i a_i}{∑_i w_i}.
     ```
 
-    Define variables ``\\tilde u`` that optionally shift an input by its weighted
-    mean: if `shift=true` then ``\\tilde u ≡ u - \\bar u`` , otherwise ``\\tilde u ≡
-    u``.
+    Introduce a notation to optionally subtract the weighted mean from each input
+    vector. If `shift=true`, define centered variables ``\\tilde u ≡ u - \\bar u``
+    and ``\\tilde v ≡ v - \\bar v``. Otherwise, define ``\\tilde u ≡ u`` and
+    ``\\tilde v ≡ v``.
 
-    If optimized, the shift is ``β = \\bar y - α \\bar x``. Otherwise it is ``β =
-    0``. Either way,
+    When optimized, the shift is ``β = \\bar v - α \\bar u``. Otherwise,
+    ``β = 0``. In either case,
 
     ```math
-    L = \\frac{1}{c} \\|\\tilde y - α \\tilde x\\|^2.
+    L = \\frac{1}{c} \\|\\tilde v - α \\tilde u\\|^2.
     ```
 
-    There remain two possibilities for the final expression of ``L``.
+    The final expression for ``L`` depends on whether the scale is optimized.
 
-    **Case 1, `scale=false`**: Here ``α = 1`` and we choose ``c`` so that,
+    **Case 1, `scale=false`**: Here ``α = 1`` and we choose ``c`` so that
 
     ```math
-    L = \\frac{\\|\\tilde y - \\tilde x\\|^2}{\\|\\tilde x\\|^2 + \\|\\tilde y\\|^2}.
+    L = \\frac{\\|\\tilde v - \\tilde u\\|^2}{\\|\\tilde u\\|^2 + \\|\\tilde v\\|^2}.
     ```
 
     **Case 2, `scale=true`**: Here the optimal scale factor is
 
     ```math
-    α = \\frac{⟨\\tilde x, \\tilde y⟩}{\\|\\tilde x\\|^2}.
+    α = \\frac{⟨\\tilde u, \\tilde v⟩}{\\|\\tilde u\\|^2}.
     ```
 
-    We select ``c = ∑_i w_i \\|\\tilde y_i\\|^2`` so that substitution yields
+    Choosing ``c = ∑_i w_i \\|\\tilde v_i\\|^2`` gives
 
     ```math
-    L = 1 - \\frac{|⟨\\tilde x, \\tilde y⟩|^2}{\\|\\tilde x\\|^2\\,\\|\\tilde y\\|^2}.
+    L = 1 - \\frac{|⟨\\tilde u, \\tilde v⟩|^2}{\\|\\tilde u\\|^2\\,\\|\\tilde v\\|^2}.
     ```
 
-    This may be understood as a cosine-squared loss. In case of complex inputs, note
-    that the optimal ``α`` absorbs an arbitrary scale _and_ complex phase.
+    This is a cosine-squared loss. For complex inputs, note that the optimal
+    ``α`` absorbs an arbitrary scale _and_ complex phase.
 """
-function squared_error_fitted(x, y; weights=nothing, scale=false, shift=false)
-    same_shape(x, y) || error("Mismatched input dimensions")
-    (x, y) = flatten_to_vec.((x, y))
-    ty = promote_type(eltype(x), eltype(y))
+function squared_error_fitted(u, v; weights=nothing, scale=false, shift=false)
+    same_shape(u, v) || error("Mismatched input dimensions")
+    (u, v) = flatten_to_vec.((u, v))
+    ty = promote_type(eltype(u), eltype(v))
     rty = real(ty)
 
     w = if isnothing(weights)
-        fill(one(rty), length(x))
+        fill(one(rty), length(u))
     else
-        same_shape(x, weights) || error("Mismatched weight dimensions")
+        same_shape(u, weights) || error("Mismatched weight dimensions")
         flatten_to_vec(weights)
     end
 
     # Shadow the inputs by their non-NaN subarrays
-    inds = findall(i -> !isnan(x[i]) && !isnan(y[i]), eachindex(x))
+    inds = findall(i -> !isnan(u[i]) && !isnan(v[i]), eachindex(u))
     isempty(inds) && error("No valid data after removing NaNs")
     @views begin
         w = w[inds]
-        x = x[inds]
-        y = y[inds]
+        u = u[inds]
+        v = v[inds]
     end
 
     all(wi -> isreal(wi) && real(wi) >= 0, w) || error("Weights must be non-negative")
 
     # Raw weighted moments
     W = Diagonal(w)
-    x2 = dot(x, W, x)
-    y2 = dot(y, W, y)
-    xy = dot(x, W, y)
+    u2 = dot(u, W, u)
+    v2 = dot(v, W, v)
+    uv = dot(u, W, v)
 
-    # Effective moments of x̃, ỹ
-    x2t, y2t, xyt, xbar, ybar = if shift
+    # Effective moments of ũ, ṽ
+    u2t, v2t, uvt, ubar, vbar = if shift
         wsum = sum(w)
         iszero(wsum) && error("Sum of valid weights must be positive")
 
-        xbar = dot(w, x) / wsum
-        ybar = dot(w, y) / wsum
+        ubar = dot(w, u) / wsum
+        vbar = dot(w, v) / wsum
 
         (
-            x2 - wsum * abs2(xbar),
-            y2 - wsum * abs2(ybar),
-            xy - wsum * conj(xbar) * ybar,
-            xbar,
-            ybar,
+            u2 - wsum * abs2(ubar),
+            v2 - wsum * abs2(vbar),
+            uv - wsum * conj(ubar) * vbar,
+            ubar,
+            vbar,
         )
     else
-        (x2, y2, xy, zero(ty), zero(ty))
+        (u2, v2, uv, zero(ty), zero(ty))
     end
 
     α, L = if scale
-        if iszero(x2t) && iszero(y2t)
+        if iszero(u2t) && iszero(v2t)
             (one(ty), zero(rty)) # Both centered inputs vanish; define cos² loss as 0
-        elseif iszero(x2t) || iszero(y2t)
+        elseif iszero(u2t) || iszero(v2t)
             (zero(ty), one(rty)) # One centered input vanishes; define cos² loss as 1
         else
-            α = xyt / x2t
-            L = real(1 - abs2(xyt) / (x2t * y2t))
+            α = uvt / u2t
+            L = real(1 - abs2(uvt) / (u2t * v2t))
             (α, L)
         end
     else
         α = one(ty)
-        denom = x2t + y2t
-        L = iszero(denom) ? zero(rty) : real((y2t + x2t - 2real(xyt)) / denom)
+        denom = u2t + v2t
+        L = iszero(denom) ? zero(rty) : real((v2t + u2t - 2real(uvt)) / denom)
         (α, L)
     end
 
     L = clamp(L, 0, 1)
-    β = shift ? ybar - α * xbar : zero(ty)
+    β = shift ? vbar - α * ubar : zero(ty)
     return (; error=L, scale=α, shift=β)
 end
 
 
 """
-    squared_error(x, y; weights=nothing)
+    squared_error(u, v; weights=nothing)
 
-Normalized sum of squared errors, ``L = (1/c) \\sum_i w_i \\|y_i - x_i\\|^2``.
+Normalized sum of squared errors, ``L = (1/c) \\sum_i w_i \\|v_i - u_i\\|^2``.
 Weights ``w_i`` must be nonnegative and default to one.
 
-The normalization factor is defined symmetrically, ``c = \\|x\\|^2 +
-\\|y\\|^2``, involving the weighted norm,
+The normalization factor is defined symmetrically, ``c = \\|u\\|^2 +
+\\|v\\|^2``, involving the weighted norm,
+
 ```math
-\\|u\\|^2 = \\sum_i w_i |u_i|^2.
+\\|a\\|^2 ≡ \\sum_i w_i |a_i|^2.
 ```
 
-Any NaN elements (``x_i`` or ``y_i``) will be interpreted as missing data and
+Any NaN elements (``u_i`` or ``v_i``) will be interpreted as missing data and
 omitted from the sum.
 
 This function is a special case of [`squared_error_fitted`](@ref).
 """
-squared_error(x, y; weights=nothing) = squared_error_fitted(x, y; weights).error
+squared_error(u, v; weights=nothing) = squared_error_fitted(u, v; weights).error
 
 
 """

--- a/src/MagneticOrdering.jl
+++ b/src/MagneticOrdering.jl
@@ -98,7 +98,7 @@ suggest_magnetic_supercell([k1, k2])   # [1 2 2; -1 2 -2; -1 2 2]
 suggest_magnetic_supercell([[0, 0, 1/√5], [0, 0, 1/√7]]; tol=1e-2)
 
 # This prints [1 0 0; 0 1 0; 0 0 16], which becomes commensurate under the
-# approximations `1/√5 ≈ 7/16` and `1/√7 ≈ 3/8`.
+# approximations 1/√5 ≈ 7/16 and 1/√7 ≈ 3/8.
 ```
 """
 function suggest_magnetic_supercell(ks; tol=1e-12, maxsize=100)

--- a/src/MagneticOrdering.jl
+++ b/src/MagneticOrdering.jl
@@ -73,11 +73,11 @@ end
 """
     suggest_magnetic_supercell(ks; tol=1e-12, maxsize=100)
 
-Suggests a magnetic supercell, in units of the crystal lattice vectors, that is
-consistent with periodicity of the wavevectors `ks` in RLU. If the wavevectors
-are incommensurate (with respect to the maximum supercell size `maxsize`), one
-can select a larger error tolerance `tol` to find a supercell that is almost
-commensurate.
+Suggests a magnetic supercell, in integer multiples of the crystal lattice
+vectors, that is consistent with periodicity of the wavevectors `ks` in RLU. If
+the wavevectors are incommensurate (with respect to the maximum supercell size
+`maxsize`), one can select a larger error tolerance `tol` to find a supercell
+that is almost commensurate.
 
 Prints a ``3×3`` matrix of integers that is suitable for use in
 [`reshape_supercell`](@ref).
@@ -85,7 +85,7 @@ Prints a ``3×3`` matrix of integers that is suitable for use in
 # Examples
 
 ```julia
-# A magnetic supercell for a single-Q structure. Will print
+# A magnetic supercell for a single-Q structure
 k1 = [0, -1/4, 1/4]
 suggest_magnetic_supercell([k1])       # [1 0 0; 0 2 1; 0 -2 1]
 

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -483,9 +483,9 @@ end
     primitive_cell(cryst)
 
 The shape of a primitive cell in multiples of the lattice vectors for `cryst`.
-Specifically, columns of `cryst.latvecs * primitive(cryst)` define the primitive
-lattice vectors in global Cartesian coordinates. Returns `nothing` if spacegroup
-setting information is missing.
+Specifically, columns of `cryst.latvecs * primitive_cell(cryst)` define the
+primitive lattice vectors in global Cartesian coordinates. Returns `nothing` if
+spacegroup setting information is missing.
 
 This function may be useful for constructing inputs to
 [`reshape_supercell`](@ref).

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -105,8 +105,8 @@ Base.@deprecate squared_error_bands(res::Sunny.BandIntensities, Es::Vector{Vecto
     return squared_error_bands(Es, res)
 end
 
-Base.@deprecate squared_error_with_rescaling(x, y; weights=nothing) let
-    (; error, scale) = squared_error_fitted(x, y; weights, scale=true)
+Base.@deprecate squared_error_with_rescaling(u, v; weights=nothing) let
+    (; error, scale) = squared_error_fitted(u, v; weights, scale=true)
     return (; error, rescaling=1/scale)
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -107,7 +107,7 @@ end
 
 Base.@deprecate squared_error_with_rescaling(u, v; weights=nothing) let
     (; error, scale) = squared_error_fitted(u, v; weights, scale=true)
-    return (; error, rescaling=1/scale)
+    return (; error, rescaling=scale)
 end
 
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -105,8 +105,8 @@ Base.@deprecate squared_error_bands(res::Sunny.BandIntensities, Es::Vector{Vecto
     return squared_error_bands(Es, res)
 end
 
-Base.@deprecate squared_error_with_rescaling(u, v; weights=nothing) let
-    (; error, scale) = squared_error_fitted(u, v; weights, scale=true)
+Base.@deprecate squared_error_with_rescaling(d, m; weights=nothing) let
+    (; error, scale) = squared_error_fitted(d, m; weights, scale=true)
     return (; error, rescaling=scale)
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -106,8 +106,8 @@ Base.@deprecate squared_error_bands(res::Sunny.BandIntensities, Es::Vector{Vecto
 end
 
 Base.@deprecate squared_error_with_rescaling(d, m; weights=nothing) let
-    (; error, scale) = squared_error_fitted(d, m; weights, scale=true)
-    return (; error, rescaling=scale)
+    (; err, scale) = squared_error_fitted(d, m; weights, scale=true)
+    return (; error=err, rescaling=scale)
 end
 
 

--- a/test/test_fitting.jl
+++ b/test/test_fitting.jl
@@ -1,6 +1,6 @@
 @testitem "Squared error fitted" begin
     @test squared_error([1, 3], [1, 1]; normalize=false) ≈ 4 atol=1e-12
-    @test squared_error([1, 3], [1, 1]) ≈ 2/3 atol=1e-12
+    @test squared_error([1, 3], [1, 1]) ≈ 2/5 atol=1e-12
     @test squared_error([1, -1], [-1, 1]) ≈ 4 atol=1e-12
 
     r = squared_error_fitted([4, 4], [2, -1]; scale=true, weights=[0.5, 0.5])
@@ -12,7 +12,7 @@
     @test r.scale ≈ 0.8 atol=1e-12
 
     (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; shift=true)
-    @test error ≈ 2 atol=1e-12
+    @test error ≈ 1 atol=1e-12
     @test scale ≈ 1 atol=1e-12
     @test shift ≈ 1 atol=1e-12
 
@@ -36,14 +36,24 @@ end
 
 @testitem "Squared error bands" begin
     cryst = Crystal(lattice_vectors(1, 1, 1, 90, 90, 90), [[0, 0, 0]])
-    qpts = Sunny.QPoints([Sunny.Vec3([0.0, 0.0, 0.0]), Sunny.Vec3([0.0, 0.0, 0.5])])
+    qpts = convert(Sunny.AbstractQPoints, [[0.0, 0.0, 0.0], [0.0, 0.0, 0.5]])
     disp = [1.0 3.0; 2.0 4.0]
     data = ones(size(disp))
     res = Sunny.BandIntensities(cryst, qpts, disp, data)
     Es = [[2.1], [3.2]]
 
+    # Smooth variant
     @test squared_error_bands(Es, res) ≈ (0.1^2 + 0.2^2) / (2.1^2 + 3.2^2)
     @test Sunny.squared_error_bands_smooth(Es, res; σ=0.1) ≈ 0.0037726373192329475
+
+    # Ignore bands below intensity cutoff
+    qpts = convert(Sunny.AbstractQPoints, [[0.0, 0.0, 0.0]])
+    disp = [1.0, 2.0]
+    data = [1.0im, 1e-6im]
+    res = Sunny.BandIntensities(cryst, qpts, disp, data)
+    Es = [[2.1]]
+    weights = [[1.5]]
+    @test squared_error_bands(Es, res; weights, intensity_cutoff=0.1, normalize=false) ≈ 1.5 * 1.1^2
 end
 
 @testitem "Wasserstein1 distance" begin

--- a/test/test_fitting.jl
+++ b/test/test_fitting.jl
@@ -1,8 +1,8 @@
 @testitem "Squared error with rescaling" begin
-    x = ComplexF64[1 + 2im, -3 + im, 2 - 4im]
+    u = ComplexF64[1 + 2im, -3 + im, 2 - 4im]
     α = 2 - 3im
-    y = α .* x
-    (; error, scale) = squared_error_fitted(x, y; scale=true)
+    v = α .* u
+    (; error, scale) = squared_error_fitted(u, v; scale=true)
     @test error ≈ 0 atol=1e-12
     @test scale ≈ α atol=1e-12
 

--- a/test/test_fitting.jl
+++ b/test/test_fitting.jl
@@ -4,33 +4,33 @@
     @test squared_error([1, -1], [-1, 1]) ≈ 4 atol=1e-12
 
     r = squared_error_fitted([4, 4], [2, -1]; scale=true, weights=[0.5, 0.5])
-    @test r.error ≈ 0.9 atol=1e-12
+    @test r.err ≈ 0.9 atol=1e-12
     @test r.scale ≈ 0.8 atol=1e-12
 
     r = squared_error_fitted([4, 4], [2, -1]; scale=true, weights=[0.5, 0.5], normalize=false)
-    @test r.error ≈ 14.4 atol=1e-12
+    @test r.err ≈ 14.4 atol=1e-12
     @test r.scale ≈ 0.8 atol=1e-12
 
-    (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; shift=true)
-    @test error ≈ 1 atol=1e-12
+    (; err, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; shift=true)
+    @test err ≈ 1/7 atol=1e-12
     @test scale ≈ 1 atol=1e-12
     @test shift ≈ 1 atol=1e-12
 
-    (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; shift=true, normalize=false)
-    @test error ≈ 2 atol=1e-12
+    (; err, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; shift=true, normalize=false)
+    @test err ≈ 2 atol=1e-12
     @test scale ≈ 1 atol=1e-12
     @test shift ≈ 1 atol=1e-12
 
-    (; error, scale, shift) = squared_error_fitted([3, 4, 5], [1, 1, 2]; scale=true, shift=true)
-    @test error ≈ 1/4 atol=1e-12
+    (; err, scale, shift) = squared_error_fitted([3, 4, 5], [1, 1, 2]; scale=true, shift=true)
+    @test err ≈ 1/100 atol=1e-12
     @test scale ≈ 3/2 atol=1e-12
     @test shift ≈ 2 atol=1e-12
 
     # Complex scaling factor absorbs phase
     u = ComplexF64[1 + 2im, -3 + im, 2 - 4im]
     α = 2 - 3im
-    (; error, scale) = squared_error_fitted(u, u/α; scale=true)
-    @test error ≈ 0 atol=1e-12
+    (; err, scale) = squared_error_fitted(u, u/α; scale=true)
+    @test err ≈ 0 atol=1e-12
     @test scale ≈ α atol=1e-12
 end
 

--- a/test/test_fitting.jl
+++ b/test/test_fitting.jl
@@ -1,25 +1,25 @@
 @testitem "Squared error with rescaling" begin
     u = ComplexF64[1 + 2im, -3 + im, 2 - 4im]
     α = 2 - 3im
-    v = α .* u
+    v = u ./ α
     (; error, scale) = squared_error_fitted(u, v; scale=true)
     @test error ≈ 0 atol=1e-12
     @test scale ≈ α atol=1e-12
 
-    (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; scale=true, shift=true)
+    (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; scale=false, shift=true)
     @test error ≈ 1 atol=1e-12
-    @test scale ≈ 0 atol=1e-12
-    @test shift ≈ 1 atol=1e-12
-
-    (; error, scale, shift) = squared_error_fitted([2, 2, 2], [1, 1, 1]; scale=true, shift=true)
-    @test error ≈ 0 atol=1e-12
     @test scale ≈ 1 atol=1e-12
-    @test shift ≈ -1.0 atol=1e-12
+    @test shift ≈ 1 atol=1e-12
 
     (; error, scale, shift) = squared_error_fitted([2, 2, 2], [1, 1, 1]; scale=true, shift=false)
     @test error ≈ 0 atol=1e-12
-    @test scale ≈ 1/2 atol=1e-12
+    @test scale ≈ 2 atol=1e-12
     @test shift ≈ 0 atol=1e-12
+
+    (; error, scale, shift) = squared_error_fitted([3, 3, 5], [1, 1, 2]; scale=true, shift=true)
+    @test error ≈ 0 atol=1e-12
+    @test scale ≈ 2 atol=1e-12
+    @test shift ≈ 1 atol=1e-12
 end
 
 @testitem "Squared error bands" begin

--- a/test/test_fitting.jl
+++ b/test/test_fitting.jl
@@ -1,6 +1,7 @@
 @testitem "Squared error fitted" begin
     @test squared_error([1, 3], [1, 1]; normalize=false) ≈ 4 atol=1e-12
-    @test squared_error([1, 3], [1, 1]) ≈ 1/3 atol=1e-12
+    @test squared_error([1, 3], [1, 1]) ≈ 2/3 atol=1e-12
+    @test squared_error([1, -1], [-1, 1]) ≈ 4 atol=1e-12
 
     r = squared_error_fitted([4, 4], [2, -1]; scale=true, weights=[0.5, 0.5])
     @test r.error ≈ 0.9 atol=1e-12
@@ -11,7 +12,7 @@
     @test r.scale ≈ 0.8 atol=1e-12
 
     (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; shift=true)
-    @test error ≈ 1 atol=1e-12
+    @test error ≈ 2 atol=1e-12
     @test scale ≈ 1 atol=1e-12
     @test shift ≈ 1 atol=1e-12
 

--- a/test/test_fitting.jl
+++ b/test/test_fitting.jl
@@ -46,14 +46,14 @@ end
     @test squared_error_bands(Es, res) ≈ (0.1^2 + 0.2^2) / (2.1^2 + 3.2^2)
     @test Sunny.squared_error_bands_smooth(Es, res; σ=0.1) ≈ 0.0037726373192329475
 
-    # Ignore bands below intensity cutoff
+    # Dark bands are used only when there are too few bright modes
     qpts = convert(Sunny.AbstractQPoints, [[0.0, 0.0, 0.0]])
-    disp = [1.0, 2.0]
-    data = [1.0im, 1e-6im]
+    disp = [2.0, 2.05, 4.0]
+    data = [1.0im, 1e-6im, 1e-6im]
     res = Sunny.BandIntensities(cryst, qpts, disp, data)
-    Es = [[2.1]]
-    weights = [[1.5]]
-    @test squared_error_bands(Es, res; weights, intensity_cutoff=0.1, normalize=false) ≈ 1.5 * 1.1^2
+    Es = [[2.1, 4.2]]
+    weights = [[1.5, 2.0]]
+    @test squared_error_bands(Es, res; weights, intensity_cutoff=0.1, normalize=false) ≈ 1.5 * 0.1^2 + 2.0 * 0.2^2
 end
 
 @testitem "Wasserstein1 distance" begin

--- a/test/test_fitting.jl
+++ b/test/test_fitting.jl
@@ -1,25 +1,36 @@
-@testitem "Squared error with rescaling" begin
-    u = ComplexF64[1 + 2im, -3 + im, 2 - 4im]
-    α = 2 - 3im
-    v = u ./ α
-    (; error, scale) = squared_error_fitted(u, v; scale=true)
-    @test error ≈ 0 atol=1e-12
-    @test scale ≈ α atol=1e-12
+@testitem "Squared error fitted" begin
+    @test squared_error([1, 3], [1, 1]; normalize=false) ≈ 4 atol=1e-12
+    @test squared_error([1, 3], [1, 1]) ≈ 1/3 atol=1e-12
 
-    (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; scale=false, shift=true)
+    r = squared_error_fitted([4, 4], [2, -1]; scale=true, weights=[0.5, 0.5])
+    @test r.error ≈ 0.9 atol=1e-12
+    @test r.scale ≈ 0.8 atol=1e-12
+
+    r = squared_error_fitted([4, 4], [2, -1]; scale=true, weights=[0.5, 0.5], normalize=false)
+    @test r.error ≈ 14.4 atol=1e-12
+    @test r.scale ≈ 0.8 atol=1e-12
+
+    (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; shift=true)
     @test error ≈ 1 atol=1e-12
     @test scale ≈ 1 atol=1e-12
     @test shift ≈ 1 atol=1e-12
 
-    (; error, scale, shift) = squared_error_fitted([2, 2, 2], [1, 1, 1]; scale=true, shift=false)
-    @test error ≈ 0 atol=1e-12
-    @test scale ≈ 2 atol=1e-12
-    @test shift ≈ 0 atol=1e-12
-
-    (; error, scale, shift) = squared_error_fitted([3, 3, 5], [1, 1, 2]; scale=true, shift=true)
-    @test error ≈ 0 atol=1e-12
-    @test scale ≈ 2 atol=1e-12
+    (; error, scale, shift) = squared_error_fitted([1, 2, 3], [1, 1, 1]; shift=true, normalize=false)
+    @test error ≈ 2 atol=1e-12
+    @test scale ≈ 1 atol=1e-12
     @test shift ≈ 1 atol=1e-12
+
+    (; error, scale, shift) = squared_error_fitted([3, 4, 5], [1, 1, 2]; scale=true, shift=true)
+    @test error ≈ 1/4 atol=1e-12
+    @test scale ≈ 3/2 atol=1e-12
+    @test shift ≈ 2 atol=1e-12
+
+    # Complex scaling factor absorbs phase
+    u = ComplexF64[1 + 2im, -3 + im, 2 - 4im]
+    α = 2 - 3im
+    (; error, scale) = squared_error_fitted(u, u/α; scale=true)
+    @test error ≈ 0 atol=1e-12
+    @test scale ≈ α atol=1e-12
 end
 
 @testitem "Squared error bands" begin


### PR DESCRIPTION
Breaking change:

* Return value of  `squared_error_fitted` now includes `err` rather than `error` to avoid shadowing `Base.error`.

Also,

* Functions `squared_error`, `squared_error_fitted` and `squared_error_bands` accept `normalize=false` to disable normalization. Normalization factor now depends only on first argument (the target data).
* Function `squared_error_bands` accepts `weights`. Additional hidden argument `intensity_cutoff` available for testing.