### PR TITLE
Spin wave refactor

### DIFF
--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -167,7 +167,7 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
 
     # Temporary storage for pair correlations
     Ncorr = length(measure.corr_pairs)
-    corrbuf = zeros(ComplexF64, Ncorr)
+    corr = zeros(ComplexF64, Ncorr)
 
     for (iq, q) in enumerate(qpts.qs)
         q_global = cryst.recipvecs * q
@@ -200,10 +200,10 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
                 Avec[μ] = dot(view(u, :, μ), view(T, :, band))
             end
 
-            map!(corrbuf, measure.corr_pairs) do (μ, ν)
+            map!(corr, measure.corr_pairs) do (μ, ν)
                 Avec[μ] * conj(Avec[ν]) / Ncells
             end
-            intensity[band, iq] = thermal_prefactor(disp[band, iq]; kT) * measure.combiner(q_global, corrbuf)
+            intensity[band, iq] = thermal_prefactor(disp[band, iq]; kT) * measure.combiner(q_global, corr)
         end
     end
 

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -194,7 +194,7 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
                     for (subsite, inverse_info) in enumerate(inverse_infos)
                         site_original, offset = inverse_info.site, inverse_info.offset
                         ff = get_swt_formfactor(measure, 1, site_original)
-                        prefactor = exp(-2π*im*(q_reshaped ⋅ offset)) * compute_form_factor(ff, norm2(q_global))
+                        prefactor = cis(-2π * dot(q_reshaped, offset)) * compute_form_factor(ff, norm2(q_global))
                         O += prefactor * data.observables_localized[subsite, μ, i]
                     end
                     for α in 1:N-1

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -144,7 +144,6 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
 
     qpts = convert(AbstractQPoints, qpts)
     cryst = orig_crystal(sys)
-    rs_global = global_positions(sys)
 
     # Number of atoms in magnetic cell
     @assert sys.dims == (1,1,1)
@@ -158,9 +157,11 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
     Nq = length(qpts.qs)
 
     # Preallocation
+    Nobs = size(measure.observables, 1)
+
     T = zeros(ComplexF64, 2L, 2L)
     H = zeros(ComplexF64, 2L, 2L)
-    Avec_pref = zeros(ComplexF64, nunits)
+    u = zeros(ComplexF64, 2L, Nobs)
     disp = zeros(Float64, L, Nq)
     intensity = zeros(eltype(measure), L, Nq)
 
@@ -168,39 +169,35 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
     Ncorr = length(measure.corr_pairs)
     corrbuf = zeros(ComplexF64, Ncorr)
 
-    Nobs = size(measure.observables, 1)
-
     for (iq, q) in enumerate(qpts.qs)
         q_global = cryst.recipvecs * q
         q_reshaped = cryst.recipvecs \ (crystal_origin.recipvecs * q)
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)
 
-        for i in 1:nunits
-            Avec_pref[i] = exp(- im * dot(q_global, rs_global[i]))
+        O = data.observable_buf
+        N = sys.Ns[1]
+        for μ in 1:Nobs, i in 1:nunits
+            fill!(O, 0)
+            inverse_infos = contraction_info.inverse[i]
+            r_reshaped = sys.crystal.positions[i]
+            for (subsite, inverse_info) in enumerate(inverse_infos)
+                site_original, offset = inverse_info.site, inverse_info.offset
+                ff = get_swt_formfactor(measure, 1, site_original)
+                pref = cis(2π * dot(q_reshaped, r_reshaped + offset)) * compute_form_factor(ff, norm2(q_global))
+                O .+= pref * data.observables_localized[subsite, μ, i]
+            end
+            for α in 1:N-1
+                u[α + (i-1)*(N-1), μ]     = O[α, N]
+                u[α + (i-1)*(N-1) + L, μ] = O[N, α]
+            end
         end
 
         Avec = zeros(ComplexF64, Nobs)
 
         # Fill `intensity` array
-        O = data.observable_buf
         for band = 1:L
-            fill!(Avec, 0)
-            N = sys.Ns[1]
-            t = reshape(view(T, :, band), N-1, nunits, 2)
-            for i in 1:nunits
-                inverse_infos = contraction_info.inverse[i]
-                for μ in 1:Nobs
-                    fill!(O, 0)
-                    for (subsite, inverse_info) in enumerate(inverse_infos)
-                        site_original, offset = inverse_info.site, inverse_info.offset
-                        ff = get_swt_formfactor(measure, 1, site_original)
-                        prefactor = cis(-2π * dot(q_reshaped, offset)) * compute_form_factor(ff, norm2(q_global))
-                        O += prefactor * data.observables_localized[subsite, μ, i]
-                    end
-                    for α in 1:N-1
-                        Avec[μ] += Avec_pref[i] * (O[α, N] * t[α, i, 2] + O[N, α] * t[α, i, 1])
-                    end
-                end
+            for μ in 1:Nobs
+                Avec[μ] = dot(view(u, :, μ), view(T, :, band))
             end
 
             map!(corrbuf, measure.corr_pairs) do (μ, ν)

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -182,7 +182,7 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
             r_reshaped = sys.crystal.positions[i]
             for (subsite, inverse_info) in enumerate(inverse_infos)
                 site_original, offset = inverse_info.site, inverse_info.offset
-                ff = get_swt_formfactor(measure, 1, site_original)
+                ff = formfactor_for_flattened_sys(measure, 1, site_original)
                 pref = cis(2π * dot(q_reshaped, r_reshaped + offset)) * compute_form_factor(ff, norm2(q_global))
                 O .+= pref * data.observables_localized[subsite, μ, i]
             end

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -131,7 +131,7 @@ function intensities_kpm!(data, swt_kry, qpts; energies, kernel, kT, verbose)
 
     Nobs = size(measure.observables, 1)
     Ncorr = length(measure.corr_pairs)
-    corrbuf = zeros(ComplexF64, Ncorr)
+    corr = zeros(ComplexF64, Ncorr)
     moments = ElasticArray{ComplexF64}(undef, Ncorr, 0)
 
     u = zeros(ComplexF64, 2L, Nobs)
@@ -199,9 +199,9 @@ function intensities_kpm!(data, swt_kry, qpts; energies, kernel, kT, verbose)
             coefs = cheb_coefs!(M, f, (-γ, γ); buf, plan)
             # apply_jackson_kernel!(coefs)
             for i in 1:Ncorr
-                corrbuf[i] = dot(coefs, view(moments, i, :)) / Ncells
+                corr[i] = dot(coefs, view(moments, i, :)) / Ncells
             end
-            data[iω, iq] = measure.combiner(q_global, corrbuf)
+            data[iω, iq] = measure.combiner(q_global, corr)
         end
     end
 
@@ -226,7 +226,7 @@ function intensities_lanczos!(data, swt_kry, qpts; energies, kernel, kT, verbose
 
     Nobs = size(measure.observables, 1)
     Ncorr = length(measure.corr_pairs)
-    corrbuf = zeros(ComplexF64, Ncorr)
+    corr = zeros(ComplexF64, Ncorr)
 
     u = zeros(ComplexF64, 2L, Nobs)
     v = zeros(ComplexF64, 2L)
@@ -304,17 +304,17 @@ function intensities_lanczos!(data, swt_kry, qpts; energies, kernel, kT, verbose
                 # accumulate C̃[ν, ξ]* into C[μ, ν] if ξ = μ. A factor of 1/2
                 # avoids double counting. In the special case that μ = ν, this
                 # assigns real(C̃[μ, μ]) to C[μ, μ] only once.
-                corrbuf .= 0
+                corr .= 0
                 for (i, (μ, ν)) in enumerate(measure.corr_pairs)
-                    ξ == ν && (corrbuf[i] += (1/2) *     (corr_ξ[μ] / Ncells))
-                    ξ == μ && (corrbuf[i] += (1/2) * conj(corr_ξ[ν] / Ncells))
+                    ξ == ν && (corr[i] += (1/2) *     (corr_ξ[μ] / Ncells))
+                    ξ == μ && (corr[i] += (1/2) * conj(corr_ξ[ν] / Ncells))
                 end
 
                 # This step assumes that combiner is linear, so that it is valid
                 # to move the ξ loop outside the data accumulation. One could
                 # relax this assumption by preallocating an array of size (Nω,
-                # Ncorr) to accumulate into corrbuf prior to calling combiner.
-                data[iω, iq] += measure.combiner(q_global, corrbuf)
+                # Ncorr) to accumulate into corr prior to calling combiner.
+                data[iω, iq] += measure.combiner(q_global, corr)
             end
         end
     end

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -144,30 +144,7 @@ function intensities_kpm!(data, swt_kry, qpts; energies, kernel, kT, verbose)
         q_reshaped = to_reshaped_rlu(sys, q)
         q_global = cryst.recipvecs * q
 
-        # Represent each local observable A(q) = Σᵢ exp(+i q⋅rᵢ) Aᵢ as a
-        # complex vector u(q) that denotes a linear combination of HP bosons.
-
-        if sys.mode == :SUN
-            (; observables_localized) = swt.data::SWTDataSUN
-            N = sys.Ns[1]
-            for μ in 1:Nobs, i in 1:Na
-                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
-                O = observables_localized[μ, i]
-                for f in 1:Nf
-                    u[f + (i-1)*Nf, μ]     = pref * O[f, N]
-                    u[f + (i-1)*Nf + L, μ] = pref * O[N, f]
-                end
-            end
-        else
-            @assert sys.mode in (:dipole, :dipole_uncorrected)
-            (; sqrtS, observables_localized) = swt.data::SWTDataDipole
-            for μ in 1:Nobs, i in 1:Na
-                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
-                O = observables_localized[μ, i]
-                u[i, μ]   = pref * (sqrtS[i] / √2) * (O[1] + im*O[2])
-                u[i+L, μ] = pref * (sqrtS[i] / √2) * (O[1] - im*O[2])
-            end
-        end
+        set_swt_observable_vectors!(u, swt, q_reshaped, q_global)
 
         # Find extreme eigenvalues and rescaling factor
         lo, hi = eigbounds(swt, q_reshaped, niters_bounds)
@@ -260,30 +237,7 @@ function intensities_lanczos!(data, swt_kry, qpts; energies, kernel, kT, verbose
         q_reshaped = to_reshaped_rlu(sys, q)
         q_global = cryst.recipvecs * q
 
-        # Represent each local observable A(q) = Σᵢ exp(+i q⋅rᵢ) Aᵢ as a
-        # complex vector u(q) that denotes a linear combination of HP bosons.
-
-        if sys.mode == :SUN
-            (; observables_localized) = swt.data::SWTDataSUN
-            N = sys.Ns[1]
-            for μ in 1:Nobs, i in 1:Na
-                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
-                O = observables_localized[μ, i]
-                for f in 1:Nf
-                    u[f + (i-1)*Nf, μ]     = pref * O[f, N]
-                    u[f + (i-1)*Nf + L, μ] = pref * O[N, f]
-                end
-            end
-        else
-            @assert sys.mode in (:dipole, :dipole_uncorrected)
-            (; sqrtS, observables_localized) = swt.data::SWTDataDipole
-            for μ in 1:Nobs, i in 1:Na
-                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
-                O = observables_localized[μ, i]
-                u[i, μ]   = pref * (sqrtS[i] / √2) * (O[1] + im*O[2])
-                u[i+L, μ] = pref * (sqrtS[i] / √2) * (O[1] - im*O[2])
-            end
-        end
+        set_swt_observable_vectors!(u, swt, q_reshaped, q_global)
 
         # Perform Lanczos calculation
  

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -94,21 +94,21 @@ end
 
 
 function mul_Ĩ!(y, x)
-    L = size(y, 2) ÷ 2
-    view(y, :, 1:L)    .= .+view(x, :, 1:L)
-    view(y, :, L+1:2L) .= .-view(x, :, L+1:2L)
+    L = size(y, 1) ÷ 2
+    view(y, 1:L, :)    .= .+view(x, 1:L, :)
+    view(y, L+1:2L, :) .= .-view(x, L+1:2L, :)
 end
 
 function mul_A!(swt, y, x, qs_reshaped, γ)
-    L = size(y, 2) ÷ 2
-    mul_dynamical_matrix!(swt, y, x, qs_reshaped)
-    view(y, :, 1:L)    .*= +1/γ
-    view(y, :, L+1:2L) .*= -1/γ
+    L = size(y, 1) ÷ 2
+    mul_dynamical_matrix!(swt, transpose(y), transpose(x), qs_reshaped)
+    view(y, 1:L, :)    .*= +1/γ
+    view(y, L+1:2L, :) .*= -1/γ
 end
 
 function set_moments!(moments, measure, u, α)
     map!(moments, measure.corr_pairs) do (μ, ν)
-        dot(view(u, μ, :), view(α, ν, :))
+        dot(view(u, :, μ), view(α, :, ν))
     end
 end
 
@@ -128,52 +128,44 @@ function intensities_kpm!(data, swt_kry, qpts; energies, kernel, kT, verbose)
     Ncells = Na / natoms(cryst)
     Nf = nflavors(swt)
     L = Nf*Na
-    Avec_pref = zeros(ComplexF64, Na) # initialize array of some prefactors
 
     Nobs = size(measure.observables, 1)
     Ncorr = length(measure.corr_pairs)
     corrbuf = zeros(ComplexF64, Ncorr)
     moments = ElasticArray{ComplexF64}(undef, Ncorr, 0)
 
-    u = zeros(ComplexF64, Nobs, 2L)
-    α0 = zeros(ComplexF64, Nobs, 2L)
-    α1 = zeros(ComplexF64, Nobs, 2L)
-    α2 = zeros(ComplexF64, Nobs, 2L)
+    u = zeros(ComplexF64, 2L, Nobs)
+    α0 = zeros(ComplexF64, 2L, Nobs)
+    α1 = zeros(ComplexF64, 2L, Nobs)
+    α2 = zeros(ComplexF64, 2L, Nobs)
 
     for iq in CartesianIndices(qpts.qs)
         q = qpts.qs[iq]
         q_reshaped = to_reshaped_rlu(sys, q)
         q_global = cryst.recipvecs * q
 
-        # Represent each local observable A(q) as a complex vector u(q) that
-        # denotes a linear combination of HP bosons.
-
-        for i in 1:Na
-            r = sys.crystal.positions[i]
-            ff = get_swt_formfactor(measure, 1, i)
-            Avec_pref[i] = cis(2π * dot(q_reshaped, r))
-            Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
-        end
+        # Represent each local observable A(q) = Σᵢ exp(+i q⋅rᵢ) Aᵢ as a
+        # complex vector u(q) that denotes a linear combination of HP bosons.
 
         if sys.mode == :SUN
             (; observables_localized) = swt.data::SWTDataSUN
             N = sys.Ns[1]
-            for i in 1:Na, μ in 1:Nobs
+            for μ in 1:Nobs, i in 1:Na
+                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
                 O = observables_localized[μ, i]
                 for f in 1:Nf
-                    u[μ, f + (i-1)*Nf]     = Avec_pref[i] * O[f, N]
-                    u[μ, f + (i-1)*Nf + L] = Avec_pref[i] * O[N, f]
+                    u[f + (i-1)*Nf, μ]     = pref * O[f, N]
+                    u[f + (i-1)*Nf + L, μ] = pref * O[N, f]
                 end
             end
         else
             @assert sys.mode in (:dipole, :dipole_uncorrected)
             (; sqrtS, observables_localized) = swt.data::SWTDataDipole
-            for i in 1:Na
-                for μ in 1:Nobs
-                    O = observables_localized[μ, i]
-                    u[μ, i]   = Avec_pref[i] * (sqrtS[i] / √2) * (O[1] + im*O[2])
-                    u[μ, i+L] = Avec_pref[i] * (sqrtS[i] / √2) * (O[1] - im*O[2])
-                end
+            for μ in 1:Nobs, i in 1:Na
+                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+                O = observables_localized[μ, i]
+                u[i, μ]   = pref * (sqrtS[i] / √2) * (O[1] + im*O[2])
+                u[i+L, μ] = pref * (sqrtS[i] / √2) * (O[1] - im*O[2])
             end
         end
 
@@ -254,7 +246,6 @@ function intensities_lanczos!(data, swt_kry, qpts; energies, kernel, kT, verbose
     Ncells = Na / natoms(cryst)
     Nf = nflavors(swt)
     L = Nf*Na
-    Avec_pref = zeros(ComplexF64, Na)
 
     Nobs = size(measure.observables, 1)
     Ncorr = length(measure.corr_pairs)
@@ -269,33 +260,28 @@ function intensities_lanczos!(data, swt_kry, qpts; energies, kernel, kT, verbose
         q_reshaped = to_reshaped_rlu(sys, q)
         q_global = cryst.recipvecs * q
 
-        # Represent each local observable A(q) as a complex vector u(q) that
-        # denotes a linear combination of HP bosons.
-
-        for i in 1:Na
-            r = sys.crystal.positions[i]
-            ff = get_swt_formfactor(measure, 1, i)
-            Avec_pref[i] = cis(2π * dot(q_reshaped, r))
-            Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
-        end
+        # Represent each local observable A(q) = Σᵢ exp(+i q⋅rᵢ) Aᵢ as a
+        # complex vector u(q) that denotes a linear combination of HP bosons.
 
         if sys.mode == :SUN
             (; observables_localized) = swt.data::SWTDataSUN
             N = sys.Ns[1]
             for μ in 1:Nobs, i in 1:Na
+                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
                 O = observables_localized[μ, i]
                 for f in 1:Nf
-                    u[f + (i-1)*Nf, μ]     = Avec_pref[i] * O[f, N]
-                    u[f + (i-1)*Nf + L, μ] = Avec_pref[i] * O[N, f]
+                    u[f + (i-1)*Nf, μ]     = pref * O[f, N]
+                    u[f + (i-1)*Nf + L, μ] = pref * O[N, f]
                 end
             end
         else
             @assert sys.mode in (:dipole, :dipole_uncorrected)
             (; sqrtS, observables_localized) = swt.data::SWTDataDipole
             for μ in 1:Nobs, i in 1:Na
+                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
                 O = observables_localized[μ, i]
-                u[i, μ]   = Avec_pref[i] * (sqrtS[i] / √2) * (O[1] + im*O[2])
-                u[i+L, μ] = Avec_pref[i] * (sqrtS[i] / √2) * (O[1] - im*O[2])
+                u[i, μ]   = pref * (sqrtS[i] / √2) * (O[1] + im*O[2])
+                u[i+L, μ] = pref * (sqrtS[i] / √2) * (O[1] - im*O[2])
             end
         end
 

--- a/src/KPM/SpinWaveTheoryKPM.jl
+++ b/src/KPM/SpinWaveTheoryKPM.jl
@@ -151,7 +151,7 @@ function intensities_kpm!(data, swt_kry, qpts; energies, kernel, kT, verbose)
         for i in 1:Na
             r = sys.crystal.positions[i]
             ff = get_swt_formfactor(measure, 1, i)
-            Avec_pref[i] = exp(2π*im * dot(q_reshaped, r))
+            Avec_pref[i] = cis(2π * dot(q_reshaped, r))
             Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
         end
 
@@ -275,7 +275,7 @@ function intensities_lanczos!(data, swt_kry, qpts; energies, kernel, kT, verbose
         for i in 1:Na
             r = sys.crystal.positions[i]
             ff = get_swt_formfactor(measure, 1, i)
-            Avec_pref[i] = exp(2π*im * dot(q_reshaped, r))
+            Avec_pref[i] = cis(2π * dot(q_reshaped, r))
             Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
         end
 

--- a/src/Measurements/Broadening.jl
+++ b/src/Measurements/Broadening.jl
@@ -93,7 +93,7 @@ function broaden!(data::AbstractArray{Ret}, bands::BandIntensities{Ret}; energie
     for iq in CartesianIndices(bands.qpts.qs)
         for (ib, b) in enumerate(view(bands.disp, :, iq))
             norm(bands.data[ib, iq]) < cutoff && continue
-            for (iω, ω) in enumerate(energies)
+            @inbounds for (iω, ω) in enumerate(energies)
                 data[iω, iq] += kernel(b, ω) * bands.data[ib, iq]
             end
             # If this broadening is a bottleneck, one can terminate when kernel

--- a/src/SCGA/SCGA.jl
+++ b/src/SCGA/SCGA.jl
@@ -303,7 +303,7 @@ function intensities_static(scga::SCGA, qpts; measure=nothing)
         q_global = cryst.recipvecs * q
 
         for i in 1:Na, μ in 1:Nobs
-            pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+            pref = observable_prefactor(measure, μ, i, q_reshaped, q_global, sys)
             for α in 1:3
                 ur[α, i, μ] = pref * O[μ, i][α]
             end
@@ -492,7 +492,7 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
             q_global = cryst.recipvecs * q
 
             for i in 1:Na, μ in 1:Nobs
-                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+                pref = observable_prefactor(measure, μ, i, q_reshaped, q_global, sys)
                 for α in 1:3
                     ur[α, i, μ] = pref * O[μ, i][α]
                 end

--- a/src/SCGA/SCGA.jl
+++ b/src/SCGA/SCGA.jl
@@ -305,7 +305,7 @@ function intensities_static(scga::SCGA, qpts; measure=nothing)
         for i in 1:Na, μ in 1:Nobs
             r_global = rs_global[i] # + offsets[μ, i]
             ff = get_swt_formfactor(measure, μ, i)
-            c = exp(+ im * dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
+            c = cis(+ dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
             for α in 1:3
                 pref_reshaped[α, i, μ] = c * O[μ, i][α]
             end
@@ -506,7 +506,7 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
             for i in 1:Na, μ in 1:Nobs
                 r_global = rs_global[i] # + offsets[μ, i]
                 ff = get_swt_formfactor(measure, μ, i)
-                c = exp(+ im * dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
+                c = cis(+ dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
                 for α in 1:3
                     pref_reshaped[α, i, μ] = c * O[μ, i][α]
                 end

--- a/src/SCGA/SCGA.jl
+++ b/src/SCGA/SCGA.jl
@@ -246,7 +246,7 @@ function lagrange_multiplier_jacobian(sys, qs, β, λs, labels)
     Λ = Diagonal(repeat(λs, inner=3))
     A = zeros(ComplexF64, 3Na, 3Na)
     A⁻¹ = zeros(ComplexF64, 3Na, 3Na)
-    A⁻¹_block = reshape(A⁻¹, 3, Na, 3, Na)
+    A⁻¹r = reshape(A⁻¹, 3, Na, 3, Na)
     H = zeros(Float64, Na, Na)
 
     v = zeros(Float64, Na, length(labels))
@@ -257,13 +257,13 @@ function lagrange_multiplier_jacobian(sys, qs, β, λs, labels)
         A_chol = cholesky!(A, RowMaximum())
         ldiv!(A⁻¹, A_chol, I(3Na))
         for i in 1:Na, j in 1:Na
-            H[i, j] += + norm(view(A⁻¹_block, :, i, :, j))^2 / 2β
+            H[i, j] += + norm(view(A⁻¹r, :, i, :, j))^2 / 2β
         end
 
         for (k, label) in enumerate(labels)
             fourier_exchange_matrix_sensitivity!(∂J, sys, label; q)
             for i in 1:Na
-                y_i = reshape(view(A⁻¹_block, :, :, :, i), 3Na, 3)
+                y_i = reshape(view(A⁻¹r, :, :, :, i), 3Na, 3)
                 v[i, k] += real(dot(y_i, ∂J, y_i)) / 2β # TODO: remove allocation?
             end
         end
@@ -280,7 +280,6 @@ function intensities_static(scga::SCGA, qpts; measure=nothing)
 
     qpts = convert(AbstractQPoints, qpts)
     cryst = orig_crystal(sys)
-    rs_global = global_positions(sys)
 
     Na = nsites(sys)
     Ncells = Na / natoms(cryst)
@@ -293,21 +292,20 @@ function intensities_static(scga::SCGA, qpts; measure=nothing)
     # Preallocation
     A = zeros(ComplexF64, 3Na, 3Na)
     O = view(measure.observables::Array{Vec3, 5}, :, 1, 1, 1, :)
-    X = zeros(ComplexF64, 3Na, Nobs)
-    pref = zeros(ComplexF64, 3Na, Nobs)
-    pref_reshaped = reshape(pref, 3, Na, Nobs)
+    v = zeros(ComplexF64, 3Na, Nobs)
+    u = zeros(ComplexF64, 3Na, Nobs)
+    ur = reshape(u, 3, Na, Nobs)
 
     data = map(qpts.qs) do q
         any(isnan, q) && return NaN * zero(eltype(measure))
 
+        q_reshaped = to_reshaped_rlu(sys, q)
         q_global = cryst.recipvecs * q
 
         for i in 1:Na, μ in 1:Nobs
-            r_global = rs_global[i] # + offsets[μ, i]
-            ff = get_swt_formfactor(measure, μ, i)
-            c = cis(+ dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
+            pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
             for α in 1:3
-                pref_reshaped[α, i, μ] = c * O[μ, i][α]
+                ur[α, i, μ] = pref * O[μ, i][α]
             end
         end
 
@@ -317,21 +315,11 @@ function intensities_static(scga::SCGA, qpts; measure=nothing)
 
         A_chol = cholesky!(A; check=false)
         issuccess(A_chol) || InstabilityError("Self-consistency failed at q = $(vec3_to_string(q)); try raising kT or refining dq")
-        ldiv!(X, A_chol, pref)
+        ldiv!(v, A_chol, u)
         map!(corr, measure.corr_pairs) do (μ, ν)
-            return dot(view(pref, :, μ), view(X, :, ν)) / Ncells
+            # Contraction: conj(u[α, i, μ]) A⁻¹[α, i, β, j] u[β, j, ν]
+            return dot(view(u, :, μ), view(v, :, ν)) / Ncells
         end
-
-        #=
-        A⁻¹ = reshape(inv(β*Λ + β*Jq), 3, Na, 3, Na)
-        map!(corr, measure.corr_pairs) do (μ, ν)
-            acc = zero(ComplexF64)
-            for α in 1:3, β in 1:3, i in 1:Na, j in 1:Na
-                acc += conj(pref[α, i, μ]) * A⁻¹[α, i, β, j] * pref[β, j, ν]
-            end
-            return acc / Ncells
-        end
-        =#
 
         return measure.combiner(q_global, corr)
     end
@@ -469,7 +457,6 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
         (; sys, λs, β) = scga
         measure = @something measure scga.measure
         cryst = orig_crystal(sys)
-        rs_global = global_positions(sys)
 
         Na = nsites(sys)
         Ncells = Na / natoms(cryst)
@@ -480,9 +467,9 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
         # Forward-work buffers
         Λ = Diagonal(repeat(λs, inner=3))
         A = zeros(ComplexF64, 3Na, 3Na)
-        X = zeros(ComplexF64, 3Na, Nobs)
-        pref = zeros(ComplexF64, 3Na, Nobs)
-        pref_reshaped = reshape(pref, 3, Na, Nobs)
+        v = zeros(ComplexF64, 3Na, Nobs)
+        u = zeros(ComplexF64, 3Na, Nobs)
+        ur = reshape(u, 3, Na, Nobs)
         corr = zeros(ComplexF64, Ncorr)
         O = view(measure.observables::Array{Vec3,5}, :, 1, 1, 1, :)
 
@@ -490,10 +477,10 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
         Δvals = zeros(Float64, length(sys.active_labels))
         Δλs = zeros(Float64, length(λs))
 
-        ΔX = zeros(ComplexF64, 3Na, Nobs)
+        Δv = zeros(ComplexF64, 3Na, Nobs)
         G = zeros(ComplexF64, 3Na, Nobs)
         ΔA = zeros(ComplexF64, 3Na, 3Na)
-        ΔA_reshaped = reshape(ΔA, 3, Na, 3, Na)
+        ΔAr = reshape(ΔA, 3, Na, 3, Na)
         ∂J = zeros(ComplexF64, 3Na, 3Na)
 
         foreach(qpts.qs, res.data, Δdata) do q, d, Δd
@@ -501,14 +488,13 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
 
             ### REPEAT FORWARD CALCULATION (no tape to avoid memory costs)
 
+            q_reshaped = to_reshaped_rlu(sys, q)
             q_global = cryst.recipvecs * q
 
             for i in 1:Na, μ in 1:Nobs
-                r_global = rs_global[i] # + offsets[μ, i]
-                ff = get_swt_formfactor(measure, μ, i)
-                c = cis(+ dot(q_global, r_global)) * compute_form_factor(ff, norm2(q_global))
+                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
                 for α in 1:3
-                    pref_reshaped[α, i, μ] = c * O[μ, i][α]
+                    ur[α, i, μ] = pref * O[μ, i][α]
                 end
             end
 
@@ -517,14 +503,14 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
             A .+= Λ
             A .*= β
 
-            # X = A \ pref
+            # v = A \ u
             A_chol = cholesky!(A; check=false)
             issuccess(A_chol) || InstabilityError("Self-consistency failed at q = $(vec3_to_string(q)); try raising kT or refining dq")
-            ldiv!(X, A_chol, pref)
+            ldiv!(v, A_chol, u)
 
-            # corr = dot(pref_μ, X_ν) / Ncells
+            # corr = dot(u_μ, v_ν) / Ncells
             map!(corr, measure.corr_pairs) do (μ, ν)
-                return dot(view(pref, :, μ), view(X, :, ν)) / Ncells
+                return dot(view(u, :, μ), view(v, :, ν)) / Ncells
             end
 
             # data = measure.combiner(corr)
@@ -539,16 +525,16 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
                 return
             end
 
-            # Pullback on: corr = dot(pref_μ, X_ν) / Ncells
-            fill!(ΔX, 0)
+            # Pullback on: corr = dot(u_μ, v_ν) / Ncells
+            fill!(Δv, 0)
             for (k, (μ, ν)) in enumerate(measure.corr_pairs)
-                view(ΔX, :, ν) .+= Δcorr[k] .* view(pref, :, μ) ./ Ncells
+                view(Δv, :, ν) .+= Δcorr[k] .* view(u, :, μ) ./ Ncells
             end
 
-            # Pullback on: X = A \ pref
-            ldiv!(G, A_chol', ΔX) # G = A' \ ΔX
-            mul!(ΔA, G, X')       # ΔA = G * X'
-            ΔA .*= -1             # ΔA = - (A' \ ΔX) * X'
+            # Pullback on: v = A \ u
+            ldiv!(G, A_chol', Δv) # G = A' \ Δv
+            mul!(ΔA, G, v')       # ΔA = G * v'
+            ΔA .*= -1             # ΔA = - (A' \ Δv) * v'
 
             # Pullback on: A = β*(J+Λ) for J(vals)
             for (k, label) in enumerate(sys.active_labels)
@@ -558,9 +544,9 @@ function CRC.rrule(rc::CRC.RuleConfig, ::typeof(intensities_static), scga::SCGA,
 
             # Pullback on: A = β*(J+Λ) for Λ = Diagonal(repeat(λs, inner=3))
             for i in 1:length(λs)
-                Δλs[i] += β * real(ΔA_reshaped[1, i, 1, i] +
-                                   ΔA_reshaped[2, i, 2, i] +
-                                   ΔA_reshaped[3, i, 3, i])
+                Δλs[i] += β * real(ΔAr[1, i, 1, i] +
+                                   ΔAr[2, i, 2, i] +
+                                   ΔAr[3, i, 3, i])
             end
         end
 

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -167,7 +167,7 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
     # Temporary storage for pair correlations
     Nobs = num_observables(measure)
     Ncorr = num_correlations(measure)
-    corrbuf = zeros(ComplexF64, Ncorr)
+    corr = zeros(ComplexF64, Ncorr)
 
     # Preallocation
     T = zeros(ComplexF64, 2L, 2L)
@@ -191,11 +191,11 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
                 # Left matrix amplitude ⟨0|Â_μ(q)†|n⟩
                 Avec[μ] = dot(view(u, :, μ), view(T, :, band))
             end
-            map!(corrbuf, measure.corr_pairs) do (μ, ν)
+            map!(corr, measure.corr_pairs) do (μ, ν)
                 # Pair correlations ⟨0|Â_μ(q)†|n⟩⟨n|Â_ν(q)|0⟩
                 Avec[μ] * conj(Avec[ν]) / Ncells
             end
-            intensity[band, iq] = thermal_prefactor(disp[band, iq]; kT) * measure.combiner(q_global, corrbuf)
+            intensity[band, iq] = thermal_prefactor(disp[band, iq]; kT) * measure.combiner(q_global, corr)
         end
     end
 

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -173,6 +173,7 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
     T = zeros(ComplexF64, 2L, 2L)
     H = zeros(ComplexF64, 2L, 2L)
     u = zeros(ComplexF64, 2L, Nobs)
+    Avec = zeros(ComplexF64, Nobs)
     disp = zeros(Float64, L, Nq)
     intensity = zeros(eltype(measure), L, Nq)
 
@@ -181,41 +182,17 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
         q_global = cryst.recipvecs * q
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)
 
-        # Represent each local observable A(q) = Σᵢ exp(+i q⋅rᵢ) Aᵢ as a
-        # complex vector u(q) in the [b_q, b_-q†] basis, matching KPM.
-        if sys.mode == :SUN
-            data = swt.data::SWTDataSUN
-            N = sys.Ns[1]
-            for μ in 1:Nobs, i in 1:Na
-                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
-                O = data.observables_localized[μ, i]
-                for α in 1:N-1
-                    u[α + (i-1)*(N-1), μ]     = pref * O[α, N]
-                    u[α + (i-1)*(N-1) + L, μ] = pref * O[N, α]
-                end
-            end
-        else
-            @assert sys.mode in (:dipole, :dipole_uncorrected)
-            data = swt.data::SWTDataDipole
-            for μ in 1:Nobs, i in 1:Na
-                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
-                O = data.observables_localized[μ, i]
-                u[i, μ]   = pref * (data.sqrtS[i] / √2) * (O[1] + im*O[2])
-                u[i+L, μ] = pref * (data.sqrtS[i] / √2) * (O[1] - im*O[2])
-            end
-        end
-
-        Avec = zeros(ComplexF64, Nobs)
+        # Linearized observables Â_μ(q) in Holstein-Primakoff bosons
+        set_swt_observable_vectors!(u, swt, q_reshaped, q_global)
 
         # Fill `intensity` array
         for band in 1:L
             for μ in 1:Nobs
-                # dot() conjugates the first argument, yielding the left
-                # matrix element ⟨0|A_q†|n⟩ from the operator coefficients u(q).
+                # Left matrix amplitude ⟨0|Â_μ(q)†|n⟩
                 Avec[μ] = dot(view(u, :, μ), view(T, :, band))
             end
-
             map!(corrbuf, measure.corr_pairs) do (μ, ν)
+                # Pair correlations ⟨0|Â_μ(q)†|n⟩⟨n|Â_ν(q)|0⟩
                 Avec[μ] * conj(Avec[ν]) / Ncells
             end
             intensity[band, iq] = thermal_prefactor(disp[band, iq]; kT) * measure.combiner(q_global, corrbuf)

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -184,7 +184,7 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
         for i in 1:Na, μ in 1:Nobs
             r_global = rs_global[i] # + offsets[μ, i]
             ff = get_swt_formfactor(measure, μ, i)
-            Avec_pref[μ, i] = exp(- im * dot(q_global, r_global))
+            Avec_pref[μ, i] = cis(- dot(q_global, r_global))
             Avec_pref[μ, i] *= compute_form_factor(ff, norm2(q_global))
         end
 

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -153,7 +153,6 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
 
     qpts = convert(AbstractQPoints, qpts)
     cryst = orig_crystal(sys)
-    rs_global = global_positions(sys)
 
     # Number of (magnetic) atoms in magnetic cell
     @assert sys.dims == (1,1,1)
@@ -173,49 +172,47 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
     # Preallocation
     T = zeros(ComplexF64, 2L, 2L)
     H = zeros(ComplexF64, 2L, 2L)
-    Avec_pref = zeros(ComplexF64, Nobs, Na)
+    u = zeros(ComplexF64, 2L, Nobs)
     disp = zeros(Float64, L, Nq)
     intensity = zeros(eltype(measure), L, Nq)
 
     for (iq, q) in enumerate(qpts.qs)
+        q_reshaped = to_reshaped_rlu(sys, q)
         q_global = cryst.recipvecs * q
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)
 
-        for i in 1:Na, μ in 1:Nobs
-            r_global = rs_global[i] # + offsets[μ, i]
-            ff = get_swt_formfactor(measure, μ, i)
-            Avec_pref[μ, i] = cis(- dot(q_global, r_global))
-            Avec_pref[μ, i] *= compute_form_factor(ff, norm2(q_global))
+        # Represent each local observable A(q) = Σᵢ exp(+i q⋅rᵢ) Aᵢ as a
+        # complex vector u(q) in the [b_q, b_-q†] basis, matching KPM.
+        if sys.mode == :SUN
+            data = swt.data::SWTDataSUN
+            N = sys.Ns[1]
+            for μ in 1:Nobs, i in 1:Na
+                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+                O = data.observables_localized[μ, i]
+                for α in 1:N-1
+                    u[α + (i-1)*(N-1), μ]     = pref * O[α, N]
+                    u[α + (i-1)*(N-1) + L, μ] = pref * O[N, α]
+                end
+            end
+        else
+            @assert sys.mode in (:dipole, :dipole_uncorrected)
+            data = swt.data::SWTDataDipole
+            for μ in 1:Nobs, i in 1:Na
+                pref = swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+                O = data.observables_localized[μ, i]
+                u[i, μ]   = pref * (data.sqrtS[i] / √2) * (O[1] + im*O[2])
+                u[i+L, μ] = pref * (data.sqrtS[i] / √2) * (O[1] - im*O[2])
+            end
         end
 
         Avec = zeros(ComplexF64, Nobs)
 
         # Fill `intensity` array
         for band in 1:L
-            fill!(Avec, 0)
-            if sys.mode == :SUN
-                data = swt.data::SWTDataSUN
-                N = sys.Ns[1]
-                t = reshape(view(T, :, band), N-1, Na, 2)
-                for i in 1:Na, μ in 1:Nobs
-                    O = data.observables_localized[μ, i]
-                    for α in 1:N-1
-                        Avec[μ] += Avec_pref[μ, i] * (O[α, N] * t[α, i, 2] + O[N, α] * t[α, i, 1])
-                    end
-                end
-            else
-                @assert sys.mode in (:dipole, :dipole_uncorrected)
-                data = swt.data::SWTDataDipole
-                t = reshape(view(T, :, band), Na, 2)
-                for i in 1:Na, μ in 1:Nobs
-                    O = data.observables_localized[μ, i]
-                    # This is the Avec of the two transverse and one
-                    # longitudinal directions in the local frame. (In the
-                    # local frame, z is longitudinal, and we are computing
-                    # the transverse part only, so the last entry is zero)
-                    displacement_local_frame = SA[t[i, 2] + t[i, 1], im * (t[i, 2] - t[i, 1]), 0.0]
-                    Avec[μ] += Avec_pref[μ, i] * (data.sqrtS[i]/√2) * (O' * displacement_local_frame)[1]
-                end
+            for μ in 1:Nobs
+                # dot() conjugates the first argument, yielding the left
+                # matrix element ⟨0|A_q†|n⟩ from the operator coefficients u(q).
+                Avec[μ] = dot(view(u, :, μ), view(T, :, band))
             end
 
             map!(corrbuf, measure.corr_pairs) do (μ, ν)

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -40,7 +40,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
             @assert i == bond.i
             j = bond.j
 
-            phase = exp(2π*im * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
+            phase = cis(2π * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
 
             si = sqrtS[i]^2
             sj = sqrtS[j]^2

--- a/src/SpinWaveTheory/HamiltonianSUN.jl
+++ b/src/SpinWaveTheory/HamiltonianSUN.jl
@@ -38,7 +38,7 @@ function swt_hamiltonian_SUN!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_resh
             @assert i == bond.i
             j = bond.j
 
-            phase = exp(2π*im * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
+            phase = cis(2π * dot(q_reshaped, bond.n)) # Phase associated with periodic wrapping
 
             # Set "general" pair interactions of the form Aᵢ⊗Bⱼ. Note that Aᵢ
             # and Bᵢ have already been transformed according to the local frames

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -319,13 +319,47 @@ end
 # i is a site index for the flattened swt.sys. However, `measure` was originally
 # constructed for a system with nontrivial lattice dims. Use fld1(i, prod(dims))
 # to get an atom index for one cell of the unflattened sys.
-function get_swt_formfactor(measure, μ, i)
+function formfactor_for_flattened_sys(measure, μ, i)
     sys_dims = size(measure.observables)[2:4]
     measure.formfactors[μ, fld1(i, prod(sys_dims))]
 end
 
-function swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+function observable_prefactor(measure, μ, i, q_reshaped, q_global, sys)
     r_reshaped = sys.crystal.positions[i]
-    ff = get_swt_formfactor(measure, μ, i)
+    ff = formfactor_for_flattened_sys(measure, μ, i)
     cis(2π * dot(q_reshaped, r_reshaped)) * compute_form_factor(ff, norm2(q_global))
+end
+
+# Linearize each Fourier observable Â(q) = Σᵢ exp(+i q⋅rᵢ) Âᵢ as a coefficient
+# vector u in the Nambu basis of Holstein-Primakoff bosons [a_q, a_-q†].
+function set_swt_observable_vectors!(u, swt::SpinWaveTheory, q_reshaped, q_global)
+    (; sys, measure, data) = swt
+    Na = nsites(sys)
+    Nobs = size(measure.observables, 1)
+    Nf = nflavors(swt)
+    L = Nf * Na
+
+    if sys.mode == :SUN
+        (; observables_localized) = data::SWTDataSUN
+        N = sys.Ns[1]
+        for μ in 1:Nobs, i in 1:Na
+            pref = observable_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+            O = observables_localized[μ, i]
+            for f in 1:Nf
+                u[f + (i-1)*Nf, μ]     = pref * O[f, N]
+                u[f + (i-1)*Nf + L, μ] = pref * O[N, f]
+            end
+        end
+    else
+        @assert sys.mode in (:dipole, :dipole_uncorrected)
+        (; sqrtS, observables_localized) = data::SWTDataDipole
+        for μ in 1:Nobs, i in 1:Na
+            pref = observable_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+            O = observables_localized[μ, i]
+            u[i, μ]   = pref * (sqrtS[i] / √2) * (O[1] + im*O[2])
+            u[i+L, μ] = pref * (sqrtS[i] / √2) * (O[1] - im*O[2])
+        end
+    end
+
+    return u
 end

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -1,6 +1,6 @@
 struct SWTDataDipole
     local_rotations       :: Vector{Mat3}             # Rotations from global to quantization frame
-    observables_localized :: Array{Vec3, 2}           # Observables rotated to local frame (nsites, nobs)
+    observables_localized :: Array{Vec3, 2}           # Observables rotated to local frame (nobs × nsites)
     stevens_coefs         :: Vector{StevensExpansion} # Rotated onsite coupling as Steven expansion
     sqrtS                 :: Vector{Float64}          # Square root of spin magnitudes
 end
@@ -322,4 +322,10 @@ end
 function get_swt_formfactor(measure, μ, i)
     sys_dims = size(measure.observables)[2:4]
     measure.formfactors[μ, fld1(i, prod(sys_dims))]
+end
+
+function swt_prefactor(measure, μ, i, q_reshaped, q_global, sys)
+    r_reshaped = sys.crystal.positions[i]
+    ff = get_swt_formfactor(measure, μ, i)
+    cis(2π * dot(q_reshaped, r_reshaped)) * compute_form_factor(ff, norm2(q_global))
 end

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -318,8 +318,7 @@ end
 
 # i is a site index for the flattened swt.sys. However, `measure` was originally
 # constructed for a system with nontrivial lattice dims. Use fld1(i, prod(dims))
-# to get a true atom index for the unflattened sys. This is needed to index
-# measure.formfactors.
+# to get an atom index for one cell of the unflattened sys.
 function get_swt_formfactor(measure, μ, i)
     sys_dims = size(measure.observables)[2:4]
     measure.formfactors[μ, fld1(i, prod(sys_dims))]

--- a/src/Spiral/SpinWaveTheorySpiral.jl
+++ b/src/Spiral/SpinWaveTheorySpiral.jl
@@ -261,7 +261,6 @@ function intensities_bands(sswt::SpinWaveTheorySpiral, qpts; kT=0) # TODO: branc
 
     qpts = convert(AbstractQPoints, qpts)
     cryst = orig_crystal(sys)
-    rs_global = global_positions(sys)
 
     # Number of atoms in magnetic cell
     @assert sys.dims == (1,1,1)
@@ -287,12 +286,12 @@ function intensities_bands(sswt::SpinWaveTheorySpiral, qpts; kT=0) # TODO: branc
     disp_flat = reshape(disp, 3L, Nq)
     intensity_flat = reshape(intensity, 3L, Nq)
     S = zeros(CMat3, L, 3)
-    Avec_pref = zeros(ComplexF64, Na)
 
     # If g-tensors are included in observables, they must be scalar. Precompute.
     gs = gs_as_scalar(sys, measure)
 
     for (iq, q) in enumerate(qpts.qs)
+        q_reshaped = to_reshaped_rlu(sys, q)
         q_global = cryst.recipvecs * q
 
         for branch in 1:3   # (q-k, q, q+k) modes for propagation wavevector k
@@ -301,19 +300,14 @@ function intensities_bands(sswt::SpinWaveTheorySpiral, qpts; kT=0) # TODO: branc
             view(T, :, :, branch) .= T0
         end
 
-        for i in 1:Na
-            ff = get_swt_formfactor(measure, 1, i)
-            Avec_pref[i] = cis(- dot(q_global, rs_global[i]))
-            Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
-        end
-
         for branch in 1:3, band in 1:L
             Avec = zero(CVec{3})
             v = reshape(view(T, :, band, branch), Na, 2)
             for i in 1:Na
+                pref = swt_prefactor(measure, 1, i, q_reshaped, q_global, sys)
                 R = local_rotations[i]
                 displacement = R * SA[v[i, 2] + v[i, 1], im * (v[i, 2] - v[i, 1]), 0.0]
-                Avec += Avec_pref[i] * (sqrtS[i]/sqrt(2)) * gs[i] * displacement
+                Avec += conj(pref) * (sqrtS[i] / √2) * gs[i] * displacement
             end
             S[band, branch] = Avec * Avec' / Ncells
         end

--- a/src/Spiral/SpinWaveTheorySpiral.jl
+++ b/src/Spiral/SpinWaveTheorySpiral.jl
@@ -332,10 +332,10 @@ function intensities_bands(sswt::SpinWaveTheorySpiral, qpts; kT=0) # TODO: branc
         end
 
         for branch in 1:3, band in 1:L
-            corrbuf = map(measure.corr_pairs) do (α, β)
+            corr = map(measure.corr_pairs) do (α, β)
                 S[band, branch][α, β]
             end
-            intensity[band, branch, iq] = thermal_prefactor(disp[band, branch, iq]; kT) * measure.combiner(q_global, corrbuf)
+            intensity[band, branch, iq] = thermal_prefactor(disp[band, branch, iq]; kT) * measure.combiner(q_global, corr)
         end
 
         # Dispersion in descending order

--- a/src/Spiral/SpinWaveTheorySpiral.jl
+++ b/src/Spiral/SpinWaveTheorySpiral.jl
@@ -303,7 +303,7 @@ function intensities_bands(sswt::SpinWaveTheorySpiral, qpts; kT=0) # TODO: branc
 
         for i in 1:Na
             ff = get_swt_formfactor(measure, 1, i)
-            Avec_pref[i] = exp(- im * dot(q_global, rs_global[i]))
+            Avec_pref[i] = cis(- dot(q_global, rs_global[i]))
             Avec_pref[i] *= compute_form_factor(ff, norm2(q_global))
         end
 

--- a/src/Spiral/SpinWaveTheorySpiral.jl
+++ b/src/Spiral/SpinWaveTheorySpiral.jl
@@ -304,7 +304,7 @@ function intensities_bands(sswt::SpinWaveTheorySpiral, qpts; kT=0) # TODO: branc
             Avec = zero(CVec{3})
             v = reshape(view(T, :, band, branch), Na, 2)
             for i in 1:Na
-                pref = swt_prefactor(measure, 1, i, q_reshaped, q_global, sys)
+                pref = observable_prefactor(measure, 1, i, q_reshaped, q_global, sys)
                 R = local_rotations[i]
                 displacement = R * SA[v[i, 2] + v[i, 1], im * (v[i, 2] - v[i, 1]), 0.0]
                 Avec += conj(pref) * (sqrtS[i] / √2) * gs[i] * displacement


### PR DESCRIPTION
Calculate coefficients for the linear expansion of each observable $\hat{A}_q$ in the Nambu basis of Holstein-Primakoff bosons. This allows to unify observable-setup code-paths between usual linear-spin wave theory and the KPM/Lanczos solver.

The new implementation should also be a bit faster -- maybe 5-10% in some cases.

Observable-setup for the entangled units spin wave calculator does not currently fit within this revised framework. The intention is that `EntangledSpinWaveTheory.jl` will eventually be removed in favor of the ordinary spin wave theory pathway. This should be possible if each "displaced-subsite" gets its own observables within `MeasureSpec`, with appropriate `offsets`.
