### PR TITLE
Fix indexing bug in reshaped `swt.sys.crystal`

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -21,6 +21,9 @@
 * Matrix ``U`` returned by [`uncertainty_matrix`](@ref) increases by a factor of
   2. Then ``U / ν`` can be interpreted as statistical covariance, with ``ν`` the
   reduced degrees of freedom ([#484](@ref)).
+* Fix site indexing in [`SpinWaveTheory`](@ref) calculations; this bug could
+  lead to incorrect form factors for certain systems with multiple ion types
+  ([#489](@ref)).
 
 ## v0.9.0
 (Mar 4, 2026)

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -51,9 +51,9 @@ function SpinWaveTheory(sys::System; measure::Union{Nothing, MeasureSpec}, regul
         error("Size mismatch. Check that measure is built using consistent system.")
     end
 
-    # Create single enlarged chemical cell that matches the full system size.
-    new_shape = cell_shape(sys) * diagm(Vec3(sys.dims))
-    new_cryst = reshape_crystal(orig_crystal(sys), new_shape)
+    # Create a single enlarged chemical cell that matches the full system size
+    # while preserving the system's linear site order.
+    new_cryst = resize_and_flatten_crystal(sys.crystal, sys.dims)
 
     # Create a new system with dims (1,1,1). A clone happens in all cases.
     sys = reshape_supercell_aux(sys, new_cryst, (1,1,1))

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -619,8 +619,7 @@ function resize_and_flatten_crystal(cryst::Crystal, dims::NTuple{3,Int})
     all(>=(1), dims) || error("Require at least one count in each direction.")
     dims == (1, 1, 1) && return cryst
 
-    new_shape = diagm(Vec3(dims))
-    new_latvecs = cryst.latvecs * new_shape
+    new_latvecs = cryst.latvecs * diagm(Vec3(dims))
     new_recipvecs = 2π*inv(new_latvecs)'
 
     # Build arrays of size (dims × natoms)
@@ -633,6 +632,7 @@ function resize_and_flatten_crystal(cryst::Crystal, dims::NTuple{3,Int})
     new_classes = repeat(reshape(cryst.classes, 1, 1, 1, :), counts...)
 
     root = @something cryst.root cryst
+    new_shape = Mat3(root.latvecs \ new_latvecs)
     sg_setting = SymOp(root.sg.setting.R * new_shape, root.sg.setting.T)
     new_sg = Spacegroup(SymOp[], root.sg.label, root.sg.number, sg_setting)
 

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -612,6 +612,36 @@ function reshape_crystal(cryst::Crystal, new_shape::Mat3)
     return ret
 end
 
+# Like `reshape_crystal(cryst, diagm(Vec3(dims)))`, but keeps atom order
+# consistent with the linear site order of `System(cryst, ...; dims)`.
+function resize_and_flatten_crystal(cryst::Crystal, dims::NTuple{3,Int})
+    all(>=(1), dims) || error("Require at least one count in each direction.")
+    dims == (1, 1, 1) && return cryst
+
+    new_shape = diagm(Vec3(dims))
+    new_latvecs = cryst.latvecs * new_shape
+    new_recipvecs = 2π*inv(new_latvecs)'
+
+    # Build arrays of size (dims × natoms)
+    counts = (dims..., 1)
+    new_positions = repeat(reshape(cryst.positions, 1, 1, 1, :), counts...)
+    for idx in CartesianIndices(new_positions)
+        new_positions[idx] = (new_positions[idx] + Vec3(idx[1]-1, idx[2]-1, idx[3]-1)) ./ Vec3(dims)
+    end
+    new_types = repeat(reshape(cryst.types, 1, 1, 1, :), counts...)
+    new_classes = repeat(reshape(cryst.classes, 1, 1, 1, :), counts...)
+
+    root = @something cryst.root cryst
+    sg_setting = SymOp(root.sg.setting.R * new_shape, root.sg.setting.T)
+    new_sg = Spacegroup(SymOp[], root.sg.label, root.sg.number, sg_setting)
+
+    ret = Crystal(root, new_latvecs, new_recipvecs, vec(new_positions), vec(new_types), vec(new_classes), new_sg)
+    # Omit sort_sites!(ret)
+    validate_crystal(ret)
+
+    return ret
+end
+
 
 """
     subcrystal(cryst, types) :: Crystal

--- a/src/Symmetry/Crystal.jl
+++ b/src/Symmetry/Crystal.jl
@@ -612,8 +612,9 @@ function reshape_crystal(cryst::Crystal, new_shape::Mat3)
     return ret
 end
 
-# Like `reshape_crystal(cryst, diagm(Vec3(dims)))`, but keeps atom order
-# consistent with the linear site order of `System(cryst, ...; dims)`.
+# Like `reshape_crystal(cryst, diagm(Vec3(dims)))`, but chooses an atom order
+# consistent with the linear site order of `System(cryst, ...; dims)`. Required
+# for the system "flattening" performed in the SpinWaveTheory constructor.
 function resize_and_flatten_crystal(cryst::Crystal, dims::NTuple{3,Int})
     all(>=(1), dims) || error("Require at least one count in each direction.")
     dims == (1, 1, 1) && return cryst

--- a/test/test_resize.jl
+++ b/test/test_resize.jl
@@ -119,6 +119,12 @@ end
     gp_sys = vec(global_positions(sys))
     gp_swt = vec(global_positions(swt.sys))
     @test gp_sys ≈ gp_swt
+
+    sys = reshape_supercell(sys, [2 2 0; 0 2 0; 0 0 1])
+    swt = SpinWaveTheory(sys; measure=nothing)
+    gp_sys = vec(global_positions(sys))
+    gp_swt = vec(global_positions(swt.sys))
+    @test gp_sys ≈ gp_swt
 end
 
 

--- a/test/test_resize.jl
+++ b/test/test_resize.jl
@@ -111,6 +111,17 @@ end
 end
 
 
+@testitem "SpinWaveTheory flattening order" begin
+    cryst = Sunny.hexagonal_crystal()
+    sys = System(cryst, [1 => Moment(s=1, g=2)], :dipole; dims=(2, 2, 1))
+
+    swt = SpinWaveTheory(sys; measure=nothing)
+    gp_sys = vec(global_positions(sys))
+    gp_swt = vec(global_positions(swt.sys))
+    @test gp_sys ≈ gp_swt
+end
+
+
 @testitem "Interactions after reshaping" begin
     latvecs = lattice_vectors(1, 1, 1, 90, 90, 90)
     cryst = Crystal(latvecs, [[0,0,0]])


### PR DESCRIPTION
The `SpinWaveTheory` constructor "flattens" the input `sys` via construction of a single enlarged `Crystal` cell. The atom indices of this enlarged crystal must map 1-to-1 with the linear site order of `sys`. This required for consistency with the atom indexing scheme used by the `MeasureSpec` object, which was constructed from `sys`.

This PR introduces a new function `resize_and_flatten_crystal` to achieve the required atom order.
