### PR TITLE
Add shell-based truncated dipole cutoff

### DIFF
--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -74,6 +74,7 @@ export Moment, System, Site, clone_system, eachsite, nsites, position_to_site, g
     set_exchange!, dmvec, enable_dipole_dipole!, set_field!, to_inhomogeneous, set_field_at!,
     set_vacancy_at!, set_onsite_coupling_at!, set_exchange_at!, set_pair_coupling_at!,
     symmetry_equivalent_bonds, remove_periodicity!, modify_exchange_with_truncated_dipole_dipole!,
+    modify_exchange_with_truncated_dipole_dipole_by_shell!,
     get_param, set_param!, get_params, set_params!, ParamSpec
 
 include("MagneticOrdering.jl")

--- a/src/Sunny.jl
+++ b/src/Sunny.jl
@@ -74,7 +74,6 @@ export Moment, System, Site, clone_system, eachsite, nsites, position_to_site, g
     set_exchange!, dmvec, enable_dipole_dipole!, set_field!, to_inhomogeneous, set_field_at!,
     set_vacancy_at!, set_onsite_coupling_at!, set_exchange_at!, set_pair_coupling_at!,
     symmetry_equivalent_bonds, remove_periodicity!, modify_exchange_with_truncated_dipole_dipole!,
-    modify_exchange_with_truncated_dipole_dipole_by_shell!,
     get_param, set_param!, get_params, set_params!, ParamSpec
 
 include("MagneticOrdering.jl")

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -292,25 +292,8 @@ function log_truncated_dipole_dipole_cutoff(cryst::Crystal, bonds, cutoff; tol=1
           "(distance $dist_str), with $nbonds symmetry-inequivalent reference $bond_word."
 end
 
-function cutoff_for_neighbor_shell(cryst::Crystal, nshells::Integer; tol=1e-12)
-    nshells > 0 || error("Number of neighbor shells must be positive.")
-    nshells = Int(nshells)
-
-    radius = minimum(svdvals(cryst.latvecs))
-    for _ in 1:64
-        bonds = reference_bonds(cryst, radius)
-        shell_distances, _ = distance_shells(cryst, bonds; tol)
-        if length(shell_distances) >= nshells + 1
-            return (shell_distances[nshells] + shell_distances[nshells + 1]) / 2
-        end
-        radius *= 2
-    end
-
-    error("Could not find $(nshells + 1) neighbor distance shells.")
-end
-
 """
-    modify_exchange_with_truncated_dipole_dipole!(sys::System, cutoff, μ0_μB²)
+    modify_exchange_with_truncated_dipole_dipole!(sys::System, cutoff, μ0_μB²; log_shell_info=true)
 
 Like [`enable_dipole_dipole!`](@ref), the purpose of this function is to
 introduce long-range dipole-dipole interactions between magnetic moments.
@@ -318,17 +301,18 @@ Whereas `enable_dipole_dipole!` employs Ewald summation, this function instead
 employs real-space pair couplings with truncation at the specified `cutoff`
 distance. The implicit demagnetization factor is 1/3, as appropriate for a
 spherical sample in vacuum. If the cutoff is relatively small, then this
-function may be faster than `enable_dipole_dipole!`. An informational log reports
-the farthest included neighbor distance shell.
+function may be faster than `enable_dipole_dipole!`. If `log_shell_info` is
+true, an informational log reports the farthest included neighbor distance
+shell.
 """
-function modify_exchange_with_truncated_dipole_dipole!(sys::System{N}, cutoff, μ0_μB²=nothing) where N
+function modify_exchange_with_truncated_dipole_dipole!(sys::System{N}, cutoff, μ0_μB²=nothing; log_shell_info::Bool=true) where N
     if isnothing(μ0_μB²)
         @warn "Deprecated syntax! Consider `modify_exchange_with_truncated_dipole_dipole!(sys, cutoff, units.vacuum_permeability)` where `units = Units(:meV, :angstrom)`."
         μ0_μB² = Units(:meV, :angstrom).vacuum_permeability
     end
 
     if !isnothing(sys.origin)
-        modify_exchange_with_truncated_dipole_dipole!(sys.origin, cutoff, μ0_μB²)
+        modify_exchange_with_truncated_dipole_dipole!(sys.origin, cutoff, μ0_μB²; log_shell_info)
         transfer_params_from_origin!(sys)
         return
     end
@@ -339,7 +323,7 @@ function modify_exchange_with_truncated_dipole_dipole!(sys::System{N}, cutoff, �
     is_homogeneous(sys) || error("System must be homogeneous")
 
     bonds = reference_bonds(sys.crystal, cutoff)
-    log_truncated_dipole_dipole_cutoff(sys.crystal, bonds, cutoff)
+    log_shell_info && log_truncated_dipole_dipole_cutoff(sys.crystal, bonds, cutoff)
 
     pairs = PairCoupling[]
     for bond in bonds
@@ -359,18 +343,4 @@ function modify_exchange_with_truncated_dipole_dipole!(sys::System{N}, cutoff, �
     # Add to model params and repopulate couplings
     replace_model_param!(sys, :TruncatedDipoleDipole => 1.0; pairs)
     repopulate_couplings_from_params!(sys)
-end
-
-"""
-    modify_exchange_with_truncated_dipole_dipole_by_shell!(sys::System, nshells::Integer, μ0_μB²)
-
-Like [`modify_exchange_with_truncated_dipole_dipole!`](@ref), but specifies the
-truncation by the number of included neighbor distance shells. The real-space
-cutoff is chosen midway between shells `nshells` and `nshells + 1`.
-"""
-function modify_exchange_with_truncated_dipole_dipole_by_shell!(sys::System, nshells::Integer, μ0_μB²=nothing)
-    sys_orig = something(sys.origin, sys)
-    cutoff = cutoff_for_neighbor_shell(sys_orig.crystal, nshells)
-    modify_exchange_with_truncated_dipole_dipole!(sys, cutoff, μ0_μB²)
-    return
 end

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -240,6 +240,75 @@ function ewald_energy_delta(sys::System{N}, site, S::Vec3) where N
     return ΔS⋅∇E + dot(Δμ, ewald.A[1, 1, 1, i, i], Δμ) / 2
 end
 
+function ordinal_string(n::Int)
+    suffix = if n % 100 in 11:13
+        "th"
+    elseif n % 10 == 1
+        "st"
+    elseif n % 10 == 2
+        "nd"
+    elseif n % 10 == 3
+        "rd"
+    else
+        "th"
+    end
+    return string(n, suffix)
+end
+
+function distance_shells(cryst::Crystal, bonds; tol=1e-12)
+    distances = sort!(filter(>(0.0), global_distance.(Ref(cryst), bonds)))
+    shell_distances = Float64[]
+    shell_counts = Int[]
+    for d in distances
+        if !isempty(shell_distances) && isapprox(shell_distances[end], d; rtol=tol)
+            shell_counts[end] += 1
+        else
+            push!(shell_distances, d)
+            push!(shell_counts, 1)
+        end
+    end
+    return shell_distances, shell_counts
+end
+
+function log_truncated_dipole_dipole_cutoff(cryst::Crystal, bonds, cutoff; tol=1e-12)
+    shell_distances, shell_counts = distance_shells(cryst, bonds; tol)
+    if isempty(shell_distances)
+        cutoff_str = number_to_simple_string(cutoff; digits=6)
+        @info "Truncated dipole-dipole cutoff $cutoff_str includes no nonzero bonds."
+        return
+    end
+
+    nshells = length(shell_distances)
+    shell_name = if nshells == 1
+        "nearest-neighbor distance shell"
+    else
+        "$(ordinal_string(nshells))-neighbor distance shell"
+    end
+    cutoff_str = number_to_simple_string(cutoff; digits=6)
+    dist_str = number_to_simple_string(shell_distances[end]; digits=6)
+    nbonds = sum(shell_counts)
+    bond_word = nbonds == 1 ? "bond" : "bonds"
+    @info "Truncated dipole-dipole cutoff $cutoff_str includes interactions through the $shell_name " *
+          "(distance $dist_str), with $nbonds symmetry-inequivalent reference $bond_word."
+end
+
+function cutoff_for_neighbor_shell(cryst::Crystal, nshells::Integer; tol=1e-12)
+    nshells > 0 || error("Number of neighbor shells must be positive.")
+    nshells = Int(nshells)
+
+    radius = minimum(svdvals(cryst.latvecs))
+    for _ in 1:64
+        bonds = reference_bonds(cryst, radius)
+        shell_distances, _ = distance_shells(cryst, bonds; tol)
+        if length(shell_distances) >= nshells + 1
+            return (shell_distances[nshells] + shell_distances[nshells + 1]) / 2
+        end
+        radius *= 2
+    end
+
+    error("Could not find $(nshells + 1) neighbor distance shells.")
+end
+
 """
     modify_exchange_with_truncated_dipole_dipole!(sys::System, cutoff, μ0_μB²)
 
@@ -249,7 +318,8 @@ Whereas `enable_dipole_dipole!` employs Ewald summation, this function instead
 employs real-space pair couplings with truncation at the specified `cutoff`
 distance. The implicit demagnetization factor is 1/3, as appropriate for a
 spherical sample in vacuum. If the cutoff is relatively small, then this
-function may be faster than `enable_dipole_dipole!`.
+function may be faster than `enable_dipole_dipole!`. An informational log reports
+the farthest included neighbor distance shell.
 """
 function modify_exchange_with_truncated_dipole_dipole!(sys::System{N}, cutoff, μ0_μB²=nothing) where N
     if isnothing(μ0_μB²)
@@ -268,8 +338,11 @@ function modify_exchange_with_truncated_dipole_dipole!(sys::System{N}, cutoff, �
     # https://github.com/SunnySuite/Sunny.jl/pull/416).
     is_homogeneous(sys) || error("System must be homogeneous")
 
+    bonds = reference_bonds(sys.crystal, cutoff)
+    log_truncated_dipole_dipole_cutoff(sys.crystal, bonds, cutoff)
+
     pairs = PairCoupling[]
-    for bond in reference_bonds(sys.crystal, cutoff)
+    for bond in bonds
         for i in 1:natoms(sys.crystal)
             for bond′ in all_symmetry_related_bonds_for_atom(sys.crystal, i, bond)
                 (; j) = bond′
@@ -286,4 +359,18 @@ function modify_exchange_with_truncated_dipole_dipole!(sys::System{N}, cutoff, �
     # Add to model params and repopulate couplings
     replace_model_param!(sys, :TruncatedDipoleDipole => 1.0; pairs)
     repopulate_couplings_from_params!(sys)
+end
+
+"""
+    modify_exchange_with_truncated_dipole_dipole_by_shell!(sys::System, nshells::Integer, μ0_μB²)
+
+Like [`modify_exchange_with_truncated_dipole_dipole!`](@ref), but specifies the
+truncation by the number of included neighbor distance shells. The real-space
+cutoff is chosen midway between shells `nshells` and `nshells + 1`.
+"""
+function modify_exchange_with_truncated_dipole_dipole_by_shell!(sys::System, nshells::Integer, μ0_μB²=nothing)
+    sys_orig = something(sys.origin, sys)
+    cutoff = cutoff_for_neighbor_shell(sys_orig.crystal, nshells)
+    modify_exchange_with_truncated_dipole_dipole!(sys, cutoff, μ0_μB²)
+    return
 end

--- a/test/test_ewald.jl
+++ b/test/test_ewald.jl
@@ -69,3 +69,24 @@
     E = sum((1/2)d⋅b for (d, b) in zip(sys.dipoles, ∇E))
     @test isapprox(energy(sys), E; atol=1e-12)
 end
+
+
+@testitem "Truncated dipole-dipole by neighbor shell" begin
+    cryst = Sunny.chain_crystal()
+    moments = [1 => Moment(s=1, g=1)]
+
+    sys_shell1 = System(cryst, moments, :dipole)
+    sys_cutoff = System(cryst, moments, :dipole)
+    sys_shell2 = System(cryst, moments, :dipole)
+
+    msg = r"nearest-neighbor distance shell"
+    @test_logs (:info, msg) modify_exchange_with_truncated_dipole_dipole_by_shell!(sys_shell1, 1, 1.0)
+    modify_exchange_with_truncated_dipole_dipole!(sys_cutoff, 1.5, 1.0)
+    @test Sunny.get_exchange(sys_shell1, Bond(1, 1, [0, 0, 1])) ≈ Sunny.get_exchange(sys_cutoff, Bond(1, 1, [0, 0, 1]))
+    @test iszero(Sunny.get_exchange(sys_shell1, Bond(1, 1, [0, 0, 2])))
+
+    modify_exchange_with_truncated_dipole_dipole_by_shell!(sys_shell2, 2, 1.0)
+    @test !iszero(Sunny.get_exchange(sys_shell2, Bond(1, 1, [0, 0, 2])))
+    @test iszero(Sunny.get_exchange(sys_shell2, Bond(1, 1, [0, 0, 3])))
+    @test_throws "positive" modify_exchange_with_truncated_dipole_dipole_by_shell!(sys_shell1, 0, 1.0)
+end

--- a/test/test_ewald.jl
+++ b/test/test_ewald.jl
@@ -71,22 +71,19 @@
 end
 
 
-@testitem "Truncated dipole-dipole by neighbor shell" begin
+@testitem "Truncated dipole-dipole shell logging" begin
+    using Logging
+
     cryst = Sunny.chain_crystal()
     moments = [1 => Moment(s=1, g=1)]
 
-    sys_shell1 = System(cryst, moments, :dipole)
-    sys_cutoff = System(cryst, moments, :dipole)
-    sys_shell2 = System(cryst, moments, :dipole)
+    sys_log = System(cryst, moments, :dipole)
+    sys_quiet = System(cryst, moments, :dipole)
 
     msg = r"nearest-neighbor distance shell"
-    @test_logs (:info, msg) modify_exchange_with_truncated_dipole_dipole_by_shell!(sys_shell1, 1, 1.0)
-    modify_exchange_with_truncated_dipole_dipole!(sys_cutoff, 1.5, 1.0)
-    @test Sunny.get_exchange(sys_shell1, Bond(1, 1, [0, 0, 1])) ≈ Sunny.get_exchange(sys_cutoff, Bond(1, 1, [0, 0, 1]))
-    @test iszero(Sunny.get_exchange(sys_shell1, Bond(1, 1, [0, 0, 2])))
+    @test_logs (:info, msg) modify_exchange_with_truncated_dipole_dipole!(sys_log, 1.5, 1.0)
+    @test_logs min_level=Logging.Info modify_exchange_with_truncated_dipole_dipole!(sys_quiet, 1.5, 1.0; log_shell_info=false)
 
-    modify_exchange_with_truncated_dipole_dipole_by_shell!(sys_shell2, 2, 1.0)
-    @test !iszero(Sunny.get_exchange(sys_shell2, Bond(1, 1, [0, 0, 2])))
-    @test iszero(Sunny.get_exchange(sys_shell2, Bond(1, 1, [0, 0, 3])))
-    @test_throws "positive" modify_exchange_with_truncated_dipole_dipole_by_shell!(sys_shell1, 0, 1.0)
+    b = Bond(1, 1, [0, 0, 1])
+    @test Sunny.get_exchange(sys_log, b) ≈ Sunny.get_exchange(sys_quiet, b)
 end


### PR DESCRIPTION
Add `modify_exchange_with_truncated_dipole_dipole_by_shell!` for selecting a real-space dipole cutoff by neighbor distance shell. The cutoff is chosen midway between the requested shell and the next shell, then the existing distance-based modifier handles exchange replacement and reshaped-system transfer.

Reuse the shell grouping for the existing cutoff log message, export the new API, and add a focused chain-crystal test that verifies the first and second shell behavior.