### PR TITLE
Support `make_loss_fn` for `EntangledSystem`

### DIFF
--- a/docs/src/versions.md
+++ b/docs/src/versions.md
@@ -3,6 +3,8 @@
 ## v0.9.2
 (In development)
 
+* Bug fixes and improvements to entangled units ([#494](@ref)).
+
 ## v0.9.1
 (Apr 25, 2026)
 

--- a/src/EntangledUnits/EntangledReshaping.jl
+++ b/src/EntangledUnits/EntangledReshaping.jl
@@ -22,31 +22,33 @@ function units_for_reshaped_system(reshaped_sys_uncontracted, esys)
     while length(new_atoms) > 0
         # Pick any site from list of new sites
         new_atom = new_atoms[1]
-        new_site = (1, 1, 1, new_atom) # Only need to define for a single unit cell, may as well be the first
-        new_position = position_at(reshaped_sys_uncontracted, new_site)
+        new_site = (1, 1, 1, new_atom) # Any representative cell works.
+        new_site_global = global_position_at(reshaped_sys_uncontracted, new_site)
 
-        # Find corresponding original atom number.
-        site = position_to_site(sys_uncontracted, position_at(reshaped_sys_uncontracted, new_site))
-        original_atom = site[4]
-        position_of_corresponding_atom = position_at(sys_uncontracted, (1, 1, 1, original_atom))
-        offset = new_position - position_of_corresponding_atom
+        # Map the reshaped site back to an atom in the original crystal.
+        new_site_in_original_basis = sys_uncontracted.crystal.latvecs \ new_site_global
+        original_site = position_to_site(sys_uncontracted, new_site_in_original_basis)
+        original_atom = original_site[4]
 
-        # Find the unit to which this original atom belongs.
+        # Find the original unit containing this atom.
         unit = units[findfirst(unit -> original_atom in unit, units)]
 
-        # Find positions of all atoms in the unit, map into the reshaped
-        # crystal, and reject any mapping that requires a nonzero lattice
-        # offset (indicating a split across crystallographic cells).
-        unit_positions = [position_at(sys_uncontracted, (1, 1, 1, atom)) for atom in unit]
-        new_unit_sites = map(unit_positions) do position
-            position_to_atom_and_offset(
-                reshaped_sys_uncontracted.crystal,
-                reshaped_sys_uncontracted.crystal.latvecs \ orig_crystal(reshaped_sys_uncontracted).latvecs * (position + offset),
-            )
+        # Build displacements from the reference atom to every atom in the
+        # unit, then apply those displacements to the reshaped reference site.
+        original_reference_position = position_at(sys_uncontracted, (1, 1, 1, original_atom))
+        unit_displacements = [position_at(sys_uncontracted, (1, 1, 1, atom)) - original_reference_position for atom in unit]
+        unit_displacements_global = [sys_uncontracted.crystal.latvecs * displacement for displacement in unit_displacements]
+
+        # Map each target position back to a reshaped-crystal atom + lattice
+        # offset. Any nonzero offset means the unit was split across cells.
+        new_unit_sites = map(unit_displacements_global) do displacement_global
+            target_global = new_site_global + displacement_global
+            target_in_reshaped_basis = reshaped_sys_uncontracted.crystal.latvecs \ target_global
+            position_to_atom_and_offset(reshaped_sys_uncontracted.crystal, target_in_reshaped_basis)
         end
         new_unit = Int64[]
-        for (a, n) in new_unit_sites
-            if !all(==(0), n)
+        for (a, lattice_offset) in new_unit_sites
+            if !all(==(0), lattice_offset)
                 error("Given shape incompatible with entangled unit structure. Unit split between crystallographic cells.")
             end
             push!(new_unit, a)

--- a/src/EntangledUnits/EntangledReshaping.jl
+++ b/src/EntangledUnits/EntangledReshaping.jl
@@ -1,5 +1,5 @@
 #TODO: Test this rigorously -- this is key to reshaping EntangledSystems and
-# making EntangledSpinWaveTheorys. 
+# making EntangledSpinWaveTheorys.
 
 # An entangled system can be specified with a list of
 # tuples, e.g. [(1,2), (3,4)], which will group the original sites 1 and 2 into
@@ -7,7 +7,7 @@
 # sys_origin and and a reshaped sys_origin, this function returns a list of
 # tuples for specifying the corresponding entanglement of the reshaped system.
 function units_for_reshaped_system(reshaped_sys_origin, esys)
-    (; sys_origin) = esys                 
+    (; sys_origin) = esys
     units = original_unit_spec(esys)
     new_crystal = reshaped_sys_origin.crystal
     new_atoms = collect(1:natoms(new_crystal))
@@ -22,7 +22,7 @@ function units_for_reshaped_system(reshaped_sys_origin, esys)
     while length(new_atoms) > 0
         # Pick any site from list of new sites
         new_atom = new_atoms[1]
-        new_site = (1, 1, 1, new_atom) # Only need to define for a single unit cell, may as well be the first 
+        new_site = (1, 1, 1, new_atom) # Only need to define for a single unit cell, may as well be the first
         new_position = position_at(reshaped_sys_origin, new_site)
 
         # Find corresponding original atom number.
@@ -64,40 +64,25 @@ function reshape_supercell(esys::EntangledSystem, shape)
 
     # Reshape the the underlying "entangled" System.
     units_new = units_for_reshaped_system(sys_origin_new, esys)
-    _, contraction_info = contract_crystal(sys_origin_new.crystal, units_new)
+    contracted_crystal, contraction_info = contract_crystal(sys_origin_new.crystal, units_new)
     sys_new = reshape_supercell(sys, shape)
 
+    # The two reshape paths must agree on crystal positions
+    contracted_crystal.positions ≈ sys_new.crystal.positions || error("This reshaping must be performed prior to calling EntangledSystem")
+
     # Construct dipole operator field for reshaped EntangledSystem
-    dipole_operators_origin = all_dipole_observables(sys_origin_new; apply_g=false) 
+    dipole_operators_origin = all_dipole_observables(sys_origin_new; apply_g=false)
     (; observables, source_idcs) = observables_to_product_space(dipole_operators_origin, sys_origin_new, contraction_info)
 
     return EntangledSystem(sys_new, sys_origin_new, contraction_info, observables, source_idcs)
 end
 
-function repeat_periodically(esys, counts)
-    (; sys, sys_origin, contraction_info) = esys
-
-    # Repeat both entangled and original system periodically
-    sys_new = repeat_periodically(sys, counts)
-    sys_origin_new = repeat_periodically(sys_origin, counts)
-
-    # Construct dipole operator field for reshaped EntangledSystem
-    dipole_operators_origin = all_dipole_observables(sys_origin_new; apply_g=false) 
-    (; observables, source_idcs) = observables_to_product_space(dipole_operators_origin, sys_origin_new, contraction_info)
-
-    return EntangledSystem(sys_new, sys_origin_new, contraction_info, observables, source_idcs)
+function repeat_periodically(esys::EntangledSystem, counts)
+    all(>=(1), counts) || error("Require at least one count in each direction.")
+    shape = cell_shape(esys.sys) * diagm(Vec3(esys.sys.dims .* counts))
+    return reshape_supercell(esys, shape)
 end
 
 function resize_supercell(esys::EntangledSystem, dims::NTuple{3,Int})
-    (; sys, sys_origin, contraction_info) = esys
-
-    # Resize both entangled and original system periodically
-    sys_new = reshape_supercell(sys, diagm(Vec3(dims)))
-    sys_origin_new = reshape_supercell(sys_origin, diagm(Vec3(dims)))
-
-    # Construct dipole operator field for reshaped EntangledSystem
-    dipole_operators_origin = all_dipole_observables(sys_origin_new; apply_g=false) 
-    (; observables, source_idcs) = observables_to_product_space(dipole_operators_origin, sys_origin_new, contraction_info)
-
-    return EntangledSystem(sys_new, sys_origin_new, contraction_info, observables, source_idcs)
+    return reshape_supercell(esys, diagm(Vec3(dims)))
 end

--- a/src/EntangledUnits/EntangledReshaping.jl
+++ b/src/EntangledUnits/EntangledReshaping.jl
@@ -1,6 +1,3 @@
-#TODO: Test this rigorously -- this is key to reshaping EntangledSystems and
-# making EntangledSpinWaveTheorys.
-
 # An entangled system can be specified with a list of
 # tuples, e.g. [(1,2), (3,4)], which will group the original sites 1 and 2 into
 # one unit and 3 and 4 into another. Given an EntangledSystem constructed from a
@@ -16,8 +13,9 @@ function units_for_reshaped_system(reshaped_sys_uncontracted, esys)
     # Take a list of all the new atoms in the reshaped system. Pick the first.
     # Map it back to the original system to determine what unit it belongs to.
     # Then map all members of the unit forward to define the unit in terms of
-    # the atoms of the reshaped system. Remove these atoms from the list of
-    # sites left to be "entangled" and repeat until list of new atoms is
+    # the atoms of the reshaped system. In so doing ensure that the unit has not
+    # been split across multiple reshaped cells. Remove these atoms from the
+    # list of sites left to be "entangled" and repeat until list of new atoms is
     # exhausted.
     while length(new_atoms) > 0
         # Pick any site from list of new sites
@@ -48,7 +46,7 @@ function units_for_reshaped_system(reshaped_sys_uncontracted, esys)
         end
         new_unit = Int64[]
         for (a, lattice_offset) in new_unit_sites
-            if !all(==(0), lattice_offset)
+            if !allequal(lattice_offset)
                 error("Given shape incompatible with entangled unit structure. Unit split between crystallographic cells.")
             end
             push!(new_unit, a)

--- a/src/EntangledUnits/EntangledReshaping.jl
+++ b/src/EntangledUnits/EntangledReshaping.jl
@@ -4,12 +4,12 @@
 # An entangled system can be specified with a list of
 # tuples, e.g. [(1,2), (3,4)], which will group the original sites 1 and 2 into
 # one unit and 3 and 4 into another. Given an EntangledSystem constructed from a
-# sys_origin and a reshaped sys_origin, this function returns a list of
+# sys_uncontracted and a reshaped sys_uncontracted, this function returns a list of
 # tuples for specifying the corresponding entanglement of the reshaped system.
-function units_for_reshaped_system(reshaped_sys_origin, esys)
-    (; sys_origin) = esys
+function units_for_reshaped_system(reshaped_sys_uncontracted, esys)
+    (; sys_uncontracted) = esys
     units = original_unit_spec(esys)
-    new_crystal = reshaped_sys_origin.crystal
+    new_crystal = reshaped_sys_uncontracted.crystal
     new_atoms = collect(1:natoms(new_crystal))
     new_units = []
 
@@ -23,12 +23,12 @@ function units_for_reshaped_system(reshaped_sys_origin, esys)
         # Pick any site from list of new sites
         new_atom = new_atoms[1]
         new_site = (1, 1, 1, new_atom) # Only need to define for a single unit cell, may as well be the first
-        new_position = position_at(reshaped_sys_origin, new_site)
+        new_position = position_at(reshaped_sys_uncontracted, new_site)
 
         # Find corresponding original atom number.
-        site = position_to_site(sys_origin, position_at(reshaped_sys_origin, new_site))
+        site = position_to_site(sys_uncontracted, position_at(reshaped_sys_uncontracted, new_site))
         original_atom = site[4]
-        position_of_corresponding_atom = position_at(sys_origin, (1, 1, 1, original_atom))
+        position_of_corresponding_atom = position_at(sys_uncontracted, (1, 1, 1, original_atom))
         offset = new_position - position_of_corresponding_atom
 
         # Find the unit to which this original atom belongs.
@@ -37,11 +37,11 @@ function units_for_reshaped_system(reshaped_sys_origin, esys)
         # Find positions of all atoms in the unit, map into the reshaped
         # crystal, and reject any mapping that requires a nonzero lattice
         # offset (indicating a split across crystallographic cells).
-        unit_positions = [position_at(sys_origin, (1, 1, 1, atom)) for atom in unit]
+        unit_positions = [position_at(sys_uncontracted, (1, 1, 1, atom)) for atom in unit]
         new_unit_sites = map(unit_positions) do position
             position_to_atom_and_offset(
-                reshaped_sys_origin.crystal,
-                reshaped_sys_origin.crystal.latvecs \ orig_crystal(reshaped_sys_origin).latvecs * (position + offset),
+                reshaped_sys_uncontracted.crystal,
+                reshaped_sys_uncontracted.crystal.latvecs \ orig_crystal(reshaped_sys_uncontracted).latvecs * (position + offset),
             )
         end
         new_unit = Int64[]
@@ -63,29 +63,30 @@ function units_for_reshaped_system(reshaped_sys_origin, esys)
 end
 
 function reshape_supercell(esys::EntangledSystem, shape)
-    (; sys, sys_origin) = esys
+    (; sys_contracted, sys_uncontracted) = esys
 
     # Reshape the origin System.
-    sys_origin_new = reshape_supercell(sys_origin, shape)
+    sys_uncontracted_new = reshape_supercell(sys_uncontracted, shape)
 
     # Reshape the the underlying "entangled" System.
-    units_new = units_for_reshaped_system(sys_origin_new, esys)
-    contracted_crystal, contraction_info = contract_crystal(sys_origin_new.crystal, units_new)
-    sys_new = reshape_supercell(sys, shape)
+    units_new = units_for_reshaped_system(sys_uncontracted_new, esys)
+    contracted_crystal, contraction_info = contract_crystal(sys_uncontracted_new.crystal, units_new)
+    sys_contracted_new = reshape_supercell(sys_contracted, shape)
 
     # The two reshape paths must agree on crystal positions
-    contracted_crystal.positions ≈ sys_new.crystal.positions || error("Given shape incompatible with entangled unit structure.")
+    contracted_crystal.positions ≈ sys_contracted_new.crystal.positions || error("Given shape incompatible with entangled unit structure.")
 
     # Construct dipole operator field for reshaped EntangledSystem
-    dipole_operators_origin = all_dipole_observables(sys_origin_new; apply_g=false)
-    (; observables, source_idcs) = observables_to_product_space(dipole_operators_origin, sys_origin_new, contraction_info)
+    dipole_operators_origin = all_dipole_observables(sys_uncontracted_new; apply_g=false)
+    (; observables, source_idcs) = observables_to_product_space(dipole_operators_origin, sys_uncontracted_new, contraction_info)
 
-    return EntangledSystem(sys_new, sys_origin_new, contraction_info, observables, source_idcs)
+    return EntangledSystem(sys_contracted_new, sys_uncontracted_new, contraction_info, observables, source_idcs)
 end
 
 function repeat_periodically(esys::EntangledSystem, counts)
+    (; sys_contracted) = esys
     all(>=(1), counts) || error("Require at least one count in each direction.")
-    shape = cell_shape(esys.sys) * diagm(Vec3(esys.sys.dims .* counts))
+    shape = cell_shape(sys_contracted) * diagm(Vec3(sys_contracted.dims .* counts))
     return reshape_supercell(esys, shape)
 end
 

--- a/src/EntangledUnits/EntangledReshaping.jl
+++ b/src/EntangledUnits/EntangledReshaping.jl
@@ -4,7 +4,7 @@
 # An entangled system can be specified with a list of
 # tuples, e.g. [(1,2), (3,4)], which will group the original sites 1 and 2 into
 # one unit and 3 and 4 into another. Given an EntangledSystem constructed from a
-# sys_origin and and a reshaped sys_origin, this function returns a list of
+# sys_origin and a reshaped sys_origin, this function returns a list of
 # tuples for specifying the corresponding entanglement of the reshaped system.
 function units_for_reshaped_system(reshaped_sys_origin, esys)
     (; sys_origin) = esys
@@ -34,14 +34,20 @@ function units_for_reshaped_system(reshaped_sys_origin, esys)
         # Find the unit to which this original atom belongs.
         unit = units[findfirst(unit -> original_atom in unit, units)]
 
-        # Find positions of all atoms in the unit, find corresponding sites in reshape system, and define unit for reshaped system.
+        # Find positions of all atoms in the unit, map into the reshaped
+        # crystal, and reject any mapping that requires a nonzero lattice
+        # offset (indicating a split across crystallographic cells).
         unit_positions = [position_at(sys_origin, (1, 1, 1, atom)) for atom in unit]
-        new_unit_sites = [position_to_site(reshaped_sys_origin, position + offset) for position in unit_positions]
+        new_unit_sites = map(unit_positions) do position
+            position_to_atom_and_offset(
+                reshaped_sys_origin.crystal,
+                reshaped_sys_origin.crystal.latvecs \ orig_crystal(reshaped_sys_origin).latvecs * (position + offset),
+            )
+        end
         new_unit = Int64[]
-        for new_site in new_unit_sites
-            i, j, k, a = new_site.I
-            if !(i == j == k == 1)
-                error("Specified reshaping incompatible with specified entangled units. (Unit split between crystalographic unit cells.)")
+        for (a, n) in new_unit_sites
+            if !all(==(0), n)
+                error("Given shape incompatible with entangled unit structure. Unit split between crystallographic cells.")
             end
             push!(new_unit, a)
         end
@@ -68,7 +74,7 @@ function reshape_supercell(esys::EntangledSystem, shape)
     sys_new = reshape_supercell(sys, shape)
 
     # The two reshape paths must agree on crystal positions
-    contracted_crystal.positions ≈ sys_new.crystal.positions || error("This reshaping must be performed prior to calling EntangledSystem")
+    contracted_crystal.positions ≈ sys_new.crystal.positions || error("Given shape incompatible with entangled unit structure.")
 
     # Construct dipole operator field for reshaped EntangledSystem
     dipole_operators_origin = all_dipole_observables(sys_origin_new; apply_g=false)

--- a/src/EntangledUnits/EntangledReshaping.jl
+++ b/src/EntangledUnits/EntangledReshaping.jl
@@ -20,13 +20,9 @@ function units_for_reshaped_system(reshaped_sys_uncontracted, esys)
     while length(new_atoms) > 0
         # Pick any site from list of new sites
         new_atom = new_atoms[1]
-        new_site = (1, 1, 1, new_atom) # Any representative cell works.
-        new_site_global = global_position_at(reshaped_sys_uncontracted, new_site)
 
-        # Map the reshaped site back to an atom in the original crystal.
-        new_site_in_original_basis = sys_uncontracted.crystal.latvecs \ new_site_global
-        original_site = position_to_site(sys_uncontracted, new_site_in_original_basis)
-        original_atom = original_site[4]
+        # Get the corresponding atom in the original system
+        original_atom = map_atom_to_other_system(new_crystal, new_atom, sys_uncontracted)[4]
 
         # Find the original unit containing this atom.
         unit = units[findfirst(unit -> original_atom in unit, units)]
@@ -35,17 +31,16 @@ function units_for_reshaped_system(reshaped_sys_uncontracted, esys)
         # unit, then apply those displacements to the reshaped reference site.
         original_reference_position = position_at(sys_uncontracted, (1, 1, 1, original_atom))
         unit_displacements = [position_at(sys_uncontracted, (1, 1, 1, atom)) - original_reference_position for atom in unit]
-        unit_displacements_global = [sys_uncontracted.crystal.latvecs * displacement for displacement in unit_displacements]
 
         # Map each target position back to a reshaped-crystal atom + lattice
         # offset. Any nonzero offset means the unit was split across cells.
-        new_unit_sites = map(unit_displacements_global) do displacement_global
-            target_global = new_site_global + displacement_global
+        new_unit_atoms_and_offsets = map(unit_displacements) do displacement
+            target_global = orig_crystal(sys_uncontracted).latvecs*(original_reference_position + displacement)
             target_in_reshaped_basis = reshaped_sys_uncontracted.crystal.latvecs \ target_global
             position_to_atom_and_offset(reshaped_sys_uncontracted.crystal, target_in_reshaped_basis)
         end
         new_unit = Int64[]
-        for (a, lattice_offset) in new_unit_sites
+        for (a, lattice_offset) in new_unit_atoms_and_offsets
             if !allequal(lattice_offset)
                 error("Given shape incompatible with entangled unit structure. Unit split between crystallographic cells.")
             end

--- a/src/EntangledUnits/EntangledReshaping.jl
+++ b/src/EntangledUnits/EntangledReshaping.jl
@@ -6,8 +6,9 @@
 function units_for_reshaped_system(reshaped_sys_uncontracted, esys)
     (; sys_uncontracted) = esys
     units = original_unit_spec(esys)
-    new_crystal = reshaped_sys_uncontracted.crystal
-    new_atoms = collect(1:natoms(new_crystal))
+    base_crystal = sys_uncontracted.crystal # NOT orig_crystal
+    reshaped_crystal = reshaped_sys_uncontracted.crystal
+    new_atoms = collect(1:natoms(reshaped_crystal))
     new_units = []
 
     # Take a list of all the new atoms in the reshaped system. Pick the first.
@@ -17,40 +18,47 @@ function units_for_reshaped_system(reshaped_sys_uncontracted, esys)
     # been split across multiple reshaped cells. Remove these atoms from the
     # list of sites left to be "entangled" and repeat until list of new atoms is
     # exhausted.
+    #
+    # It's important here to not rely on functions that implicitly 
+    # go back to `orig_crystal` internally. This very un-Sunny-like behavior
+    # will be remedied with the big refactor, but this is the correct procedure
+    # for the current set up. This is necessitated because the "entanglement recipe"
+    # is potentially specified on the atom numbers of a reshaped crystal. (Sunny
+    # doesn't make these numbers public, but they can be determined by inspection, and
+    # must be when setting up a system in the current implementation.)
     while length(new_atoms) > 0
         # Pick any site from list of new sites
         new_atom = new_atoms[1]
+        new_site_global = reshaped_crystal.latvecs * reshaped_crystal.positions[new_atom] 
 
         # Get the corresponding atom in the original system
-        original_atom = map_atom_to_other_system(new_crystal, new_atom, sys_uncontracted)[4]
+        new_site_in_original_basis = sys_uncontracted.crystal.latvecs \ new_site_global
+        original_atom = position_to_atom(sys_uncontracted.crystal, new_site_in_original_basis)
 
         # Find the original unit containing this atom.
         unit = units[findfirst(unit -> original_atom in unit, units)]
 
         # Build displacements from the reference atom to every atom in the
         # unit, then apply those displacements to the reshaped reference site.
-        original_reference_position = position_at(sys_uncontracted, (1, 1, 1, original_atom))
-        unit_displacements = [position_at(sys_uncontracted, (1, 1, 1, atom)) - original_reference_position for atom in unit]
+        unit_displacements = [base_crystal.positions[atom] - base_crystal.positions[original_atom] for atom in unit]
 
         # Map each target position back to a reshaped-crystal atom + lattice
         # offset. Any nonzero offset means the unit was split across cells.
         new_unit_atoms_and_offsets = map(unit_displacements) do displacement
-            target_global = orig_crystal(sys_uncontracted).latvecs*(original_reference_position + displacement)
+            target_global = base_crystal.latvecs*(new_site_in_original_basis + displacement)
             target_in_reshaped_basis = reshaped_sys_uncontracted.crystal.latvecs \ target_global
             position_to_atom_and_offset(reshaped_sys_uncontracted.crystal, target_in_reshaped_basis)
         end
-        new_unit = Int64[]
-        for (a, lattice_offset) in new_unit_atoms_and_offsets
-            if !allequal(lattice_offset)
-                error("Given shape incompatible with entangled unit structure. Unit split between crystallographic cells.")
-            end
-            push!(new_unit, a)
+        new_unit_atoms   = [info[1] for info in new_unit_atoms_and_offsets]
+        new_unit_offsets = [info[2] for info in new_unit_atoms_and_offsets]
+        if !allequal(new_unit_offsets) || (length(unique(new_unit_atoms)) != length(new_unit_atoms))
+            error("Given shape incompatible with entangled unit structure. Unit split between crystallographic cells.")
         end
-        push!(new_units, Tuple(new_unit))
+        push!(new_units, Tuple(new_unit_atoms))
 
         # Delete members of newly defined unit from list of all atoms in the
         # reshaped system.
-        idcs = findall(atom -> atom in new_unit, new_atoms)
+        idcs = findall(atom -> atom in new_unit_atoms, new_atoms)
         deleteat!(new_atoms, idcs)
     end
 

--- a/src/EntangledUnits/EntangledSampledCorrelations.jl
+++ b/src/EntangledUnits/EntangledSampledCorrelations.jl
@@ -51,7 +51,7 @@ end
 function Base.setproperty!(esc::EntangledSampledCorrelations, sym::Symbol, val)
     if sym == :measure
         measure = val
-        (; observables) = observables_to_product_space(measure.observables, esc.esys.sys_origin, esc.esys.contraction_info)
+        (; observables) = observables_to_product_space(measure.observables, esc.esys.sys_uncontracted, esc.esys.contraction_info)
         @assert esc.sc.measure.observables ≈ observables "New MeasureSpec must contain identical observables."
         @assert all(x -> x == 1, esc.sc.measure.corr_pairs .== measure.corr_pairs) "New MeasureSpec must contain identical correlation pairs."
         setfield!(esc.sc, :measure, val) # Sets new combiner
@@ -67,8 +67,8 @@ Base.setproperty!(esc::EntangledSampledCorrelationsStatic, sym::Symbol, val) = s
 # a field of observables in the tensor product space, together with mapping
 # information for populating the expectation values of these operators with
 # respect to the entangled system.
-function observables_to_product_space(observables, sys_origin, contraction_info)
-    Ns_per_unit = Ns_in_units(sys_origin, contraction_info)
+function observables_to_product_space(observables, sys_uncontracted, contraction_info)
+    Ns_per_unit = Ns_in_units(sys_uncontracted, contraction_info)
     Ns_all = [prod(Ns) for Ns in Ns_per_unit]
     N = Ns_all[1]
     @assert all(==(N), Ns_all) "All entangled units must have the same dimension Hilbert space."
@@ -77,9 +77,9 @@ function observables_to_product_space(observables, sys_origin, contraction_info)
     positions = zeros(Vec3, size(observables)[2:end])
     source_idcs = zeros(Int64, size(observables)[2:end])
 
-    for site in eachsite(sys_origin)
+    for site in eachsite(sys_uncontracted)
         atom = site.I[4]
-        positions[site] = sys_origin.crystal.positions[atom]
+        positions[site] = sys_uncontracted.crystal.positions[atom]
         source_idcs[site] = contraction_info.forward[atom][1]
         for μ in axes(observables, 1)
             obs = observables[μ, site]
@@ -98,22 +98,24 @@ end
 # measure is assumed to correspond to the sites of the original "unentangled"
 # system. 
 function SampledCorrelations(esys::EntangledSystem; measure, energies, dt, calculate_errors=false)
+    (; sys_contracted, sys_uncontracted, contraction_info) = esys
+
     # Convert observables on different sites to "multiposition" observables in
     # tensor product spaces. With entangled units, the position of an operator
     # cannot be uniquely determined from the `atom` index of a `Site`. Instead,
     # the position is recorded independently, and the index of the relevant
     # coherent state (which may now be used for operators corresponding to
     # multiple positions) is recorded in `source_idcs`.
-    (; observables, positions, source_idcs) = observables_to_product_space(measure.observables, esys.sys_origin, esys.contraction_info)
+    (; observables, positions, source_idcs) = observables_to_product_space(measure.observables, sys_uncontracted, contraction_info)
 
     # Make a sampled correlations for the esys.
-    sc = SampledCorrelations(esys.sys; measure, energies, dt, calculate_errors, positions) 
+    sc = SampledCorrelations(sys_contracted; measure, energies, dt, calculate_errors, positions) 
 
     # Replace relevant fields or the resulting SampledCorrelations. Note use of
     # undocumented `positions` keyword. This can be eliminated if positions are
     # migrated into the MeasureSpec.
-    crystal = esys.sys_origin.crystal
-    origin_crystal = orig_crystal(esys.sys_origin)
+    crystal = sys_uncontracted.crystal
+    origin_crystal = orig_crystal(sys_uncontracted)
     sc_new = SampledCorrelations(sc.data, sc.M, crystal, origin_crystal, sc.Δω, measure, observables, positions, source_idcs, measure.corr_pairs,
                                  sc.integrator, sc.measperiod, sc.nsamples, sc.samplebuf, sc.corrbuf, sc.space_fft!, sc.time_fft!, sc.corr_fft!, sc.corr_ifft!)
 
@@ -121,12 +123,13 @@ function SampledCorrelations(esys::EntangledSystem; measure, energies, dt, calcu
 end
 
 function SampledCorrelationsStatic(esys::EntangledSystem; measure, calculate_errors=false)
-    (; observables, positions, source_idcs) = observables_to_product_space(measure.observables, esys.sys_origin, esys.contraction_info)
-    sc = SampledCorrelations(esys.sys; measure, energies=nothing, dt=NaN, calculate_errors, positions) 
+    (; sys_contracted, sys_uncontracted, contraction_info) = esys
+    (; observables, positions, source_idcs) = observables_to_product_space(measure.observables, sys_uncontracted, contraction_info)
+    sc = SampledCorrelations(sys_contracted; measure, energies=nothing, dt=NaN, calculate_errors, positions) 
 
     # Replace relevant fields
-    crystal = esys.sys_origin.crystal
-    origin_crystal = orig_crystal(esys.sys_origin)
+    crystal = sys_uncontracted.crystal
+    origin_crystal = orig_crystal(sys_uncontracted)
     parent = SampledCorrelations(sc.data, sc.M, crystal, origin_crystal, sc.Δω, measure, observables, positions, source_idcs, measure.corr_pairs,
                                  sc.integrator, sc.measperiod, sc.nsamples, sc.samplebuf, sc.corrbuf, sc.space_fft!, sc.time_fft!, sc.corr_fft!, sc.corr_ifft!)
 
@@ -136,12 +139,14 @@ end
 
 
 function add_sample!(esc::EntangledSampledCorrelations, esys::EntangledSystem; window=:cosine)
-    new_sample!(esc.sc, esys.sys)
+    (; sys_contracted) = esys
+    new_sample!(esc.sc, sys_contracted)
     accum_sample!(esc.sc; window)
 end
 
 function add_sample!(esc::EntangledSampledCorrelationsStatic, esys::EntangledSystem; window=:cosine)
-    add_sample!(esc.sc, esys.sys)
+    (; sys_contracted) = esys
+    add_sample!(esc.sc, sys_contracted)
 end
 
 available_energies(esc::EntangledSampledCorrelations) = available_energies(esc.sc)

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -152,10 +152,11 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
 
     # Number of atoms in magnetic cell
     @assert sys.dims == (1,1,1)
-    nunits = nsites(sys)                  # System "sites" are really entangled units
-    nunits_per_cell = natoms(sys.crystal) # Crystal "atoms" are really entangled units
+    nunits = nsites(sys)                                                # System "sites" are really entangled units
+    natoms_magcell = sum(length(el) for el in contraction_info.inverse) # Reconstruct number of atomic sites
+    natoms_crystcell = natoms(crystal_origin)                           # Number of atoms in defining crystal
     # Number of chemical cells in magnetic cell
-    Ncells = nunits / nunits_per_cell
+    Ncells = natoms_magcell / natoms_crystcell
     # Number of quasiparticle modes
     L = nbands(swt)
     # Number of wavevectors

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -4,7 +4,7 @@ struct SWTDataEntangled
     observable_buf            :: Array{ComplexF64, 2}   # Buffer for use while constructing boson rep of observables
 end
 
-struct EntangledSpinWaveTheory <: AbstractSpinWaveTheory
+struct EntangledSpinWaveTheory <: AbstractDirectSpinWaveTheory
     sys              :: System
     data             :: SWTDataEntangled
     measure          :: MeasureSpec
@@ -218,51 +218,6 @@ end
 ################################################################################
 # To be simplified, but requires editing existing code
 ################################################################################
-# No changes
-function dynamical_matrix!(H, swt::EntangledSpinWaveTheory, q_reshaped)
-    if swt.sys.mode == :SUN
-        swt_hamiltonian_SUN!(H, swt, q_reshaped)
-    else
-        @assert swt.sys.mode in (:dipole, :dipole_uncorrected)
-        swt_hamiltonian_dipole!(H, swt, q_reshaped)
-    end
-end
-
-# No changes
-function excitations!(T, tmp, swt::EntangledSpinWaveTheory, q)
-    L = nbands(swt)
-    size(T) == size(tmp) == (2L, 2L) || error("Arguments T and tmp must be $(2L)×$(2L) matrices")
-
-    q_reshaped = to_reshaped_rlu(swt.sys, q)
-    dynamical_matrix!(tmp, swt, q_reshaped)
-
-    try
-        return bogoliubov!(T, tmp)
-    catch _
-        error("Instability at wavevector q = $q")
-    end
-end
-
-# No changes
-function excitations(swt::EntangledSpinWaveTheory, q)
-    L = nbands(swt)
-    T = zeros(ComplexF64, 2L, 2L)
-    H = zeros(ComplexF64, 2L, 2L)
-    energies = excitations!(T, H, swt, q)
-    return (energies, T)
-end
-
-# No changes
-function dispersion(swt::EntangledSpinWaveTheory, qpts)
-    L = nbands(swt)
-    qpts = convert(AbstractQPoints, qpts)
-    disp = zeros(L, length(qpts.qs))
-    for (iq, q) in enumerate(qpts.qs)
-        view(disp, :, iq) .= view(excitations(swt, q)[1], 1:L)
-    end
-    return reshape(disp, L, size(qpts.qs)...)
-end
-
 # No changes
 function energy_per_site_lswt_correction(swt::EntangledSpinWaveTheory; opts...)
     any(in(keys(opts)), (:rtol, :atol, :maxevals)) || error("Must specify one of `rtol`, `atol`, or `maxevals` to control momentum-space integration.")

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -61,6 +61,11 @@ function to_reshaped_rlu(esys::EntangledSystem, q)
     return sys.crystal.recipvecs \ (orig_crystal(sys_origin).recipvecs * q)
 end
 
+function to_reshaped_rlu(eswt::EntangledSpinWaveTheory, q)
+    (; sys, crystal_origin) = eswt
+    return sys.crystal.recipvecs \ (crystal_origin.recipvecs * q)
+end
+
 # obs are observables _given in terms of `sys_original`_
 function swt_data_entangled(sys, sys_origin, Ns_unit, contraction_info, measure)
 
@@ -147,10 +152,10 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
 
     # Number of atoms in magnetic cell
     @assert sys.dims == (1,1,1)
-    nunits = nsites(sys)                                    # Each "site" corresponds to a unit, not an atomic site of the original cyrstal
-    Na = sum(length(el) for el in contraction_info.inverse) # Reconstruct number of atomic sites of reshaped entangled system from units
+    nunits = nsites(sys)                  # System "sites" are really entangled units
+    nunits_per_cell = natoms(sys.crystal) # Crystal "atoms" are really entangled units
     # Number of chemical cells in magnetic cell
-    Ncells = Na / natoms(crystal_origin)                    # `crystal_origin` is `orig_crystal(sys_origin)`, where `sys_origin` is the original unentangled system
+    Ncells = nunits / nunits_per_cell
     # Number of quasiparticle modes
     L = nbands(swt)
     # Number of wavevectors

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -143,15 +143,14 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
     isempty(measure.observables) && error("No observables! Construct SpinWaveTheory with a `measure` argument.")
 
     qpts = convert(AbstractQPoints, qpts)
-    cryst = orig_crystal(sys)
     rs_global = global_positions(sys)
 
     # Number of atoms in magnetic cell
     @assert sys.dims == (1,1,1)
-    nunits = nsites(sys)
+    nunits = nsites(sys)                                    # Each "site" corresponds to a unit, not an atomic site of the original cyrstal
+    Na = sum(length(el) for el in contraction_info.inverse) # Reconstruct number of atomic sites of reshaped entangled system from units
     # Number of chemical cells in magnetic cell
-    # Ncells = Na / natoms(cryst)         # TODO: Pass information about natoms in unreshaped, uncontracted system
-    Ncells = 1
+    Ncells = Na / natoms(crystal_origin)                    # `crystal_origin` is `orig_crystal(sys_origin)`, where `sys_origin` is the original unentangled system
     # Number of quasiparticle modes
     L = nbands(swt)
     # Number of wavevectors
@@ -171,8 +170,8 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
     Nobs = size(measure.observables, 1)
 
     for (iq, q) in enumerate(qpts.qs)
-        q_global = cryst.recipvecs * q
-        q_reshaped = cryst.recipvecs \ (crystal_origin.recipvecs * q)
+        q_global = crystal_origin.recipvecs * q
+        q_reshaped = sys.crystal.recipvecs \ (crystal_origin.recipvecs * q)
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)
 
         for i in 1:nunits
@@ -212,7 +211,7 @@ function intensities_bands(swt::EntangledSpinWaveTheory, qpts; kT=0)
 
     disp = reshape(disp, L, size(qpts.qs)...)
     intensity = reshape(intensity, L, size(qpts.qs)...)
-    return BandIntensities(cryst, qpts, disp, intensity)
+    return BandIntensities(crystal_origin, qpts, disp, intensity)
 end
 
 ################################################################################

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -320,7 +320,7 @@ function swt_hamiltonian_SUN!(H::Matrix{ComplexF64}, swt::EntangledSpinWaveTheor
     end
 
     # H must be hermitian up to round-off errors
-    @assert diffnorm2(H, H') < 1e-12
+    @assert maxdiff(H, H') < 1e-12
 
     # Make H exactly hermitian
     hermitianpart!(H)

--- a/src/EntangledUnits/EntangledSpinWaveTheory.jl
+++ b/src/EntangledUnits/EntangledSpinWaveTheory.jl
@@ -17,19 +17,19 @@ end
 
 
 function SpinWaveTheory(esys::EntangledSystem; measure, regularization=1e-8)
-    (; sys, sys_origin) = esys
-    crystal_origin = orig_crystal(sys_origin)
-    if !isnothing(sys.ewald)
+    (; sys_contracted, sys_uncontracted) = esys
+    crystal_origin = orig_crystal(sys_uncontracted)
+    if !isnothing(sys_contracted.ewald)
         error("EntangledSpinWaveTheory does not yet support long-range dipole-dipole interactions.")
     end
 
-    measure = @something measure empty_measurespec(sys)
-    if nsites(sys_origin) != prod(size(measure.observables)[2:5])
+    measure = @something measure empty_measurespec(sys_contracted)
+    if nsites(sys_uncontracted) != prod(size(measure.observables)[2:5])
         error("Size mismatch. Check that measure is built using consistent system.")
     end
 
-    # Reshape (flatten) both sys and sys_origin in corresponding ways
-    sys, sys_origin = map([sys, sys_origin]) do sys
+    # Reshape (flatten) both sys_contracted and sys_uncontracted in corresponding ways
+    sys_contracted, sys_uncontracted = map([sys_contracted, sys_uncontracted]) do sys
         new_shape = cell_shape(sys) * diagm(Vec3(sys.dims))
         new_cryst = reshape_crystal(orig_crystal(sys), new_shape)
 
@@ -39,13 +39,13 @@ function SpinWaveTheory(esys::EntangledSystem; measure, regularization=1e-8)
 
     # Construct the new contraction_info (i.e. reconstruct maps between
     # entangled and unentangled systems)
-    new_units = units_for_reshaped_system(sys_origin, esys)
-    _, new_contraction_info = contract_crystal(sys_origin.crystal, new_units)
-    new_Ns_unit = Ns_in_units(sys_origin, new_contraction_info)
+    new_units = units_for_reshaped_system(sys_uncontracted, esys)
+    _, new_contraction_info = contract_crystal(sys_uncontracted.crystal, new_units)
+    new_Ns_unit = Ns_in_units(sys_uncontracted, new_contraction_info)
 
-    data = swt_data_entangled(sys, sys_origin, new_Ns_unit, new_contraction_info, measure)
+    data = swt_data_entangled(sys_contracted, sys_uncontracted, new_Ns_unit, new_contraction_info, measure)
 
-    return EntangledSpinWaveTheory(sys, data, measure, regularization, crystal_origin, new_contraction_info, new_Ns_unit)
+    return EntangledSpinWaveTheory(sys_contracted, data, measure, regularization, crystal_origin, new_contraction_info, new_Ns_unit)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", swt::EntangledSpinWaveTheory)
@@ -57,8 +57,8 @@ end
 nbands(swt::EntangledSpinWaveTheory) = (swt.sys.Ns[1]-1)  * natoms(swt.sys.crystal)
 
 function to_reshaped_rlu(esys::EntangledSystem, q)
-    (; sys, sys_origin) = esys
-    return sys.crystal.recipvecs \ (orig_crystal(sys_origin).recipvecs * q)
+    (; sys_contracted, sys_uncontracted) = esys
+    return sys_contracted.crystal.recipvecs \ (orig_crystal(sys_uncontracted).recipvecs * q)
 end
 
 function to_reshaped_rlu(eswt::EntangledSpinWaveTheory, q)
@@ -67,12 +67,12 @@ function to_reshaped_rlu(eswt::EntangledSpinWaveTheory, q)
 end
 
 # obs are observables _given in terms of `sys_original`_
-function swt_data_entangled(sys, sys_origin, Ns_unit, contraction_info, measure)
+function swt_data_entangled(sys_contracted, sys_uncontracted, Ns_unit, contraction_info, measure)
 
     # Calculate transformation matrices into local reference frames
-    N = sys.Ns[1] # Assume uniform contraction for now
-    nunits = nsites(sys)
-    natoms = nsites(sys_origin)
+    N = sys_contracted.Ns[1] # Assume uniform contraction for now
+    nunits = nsites(sys_contracted)
+    natoms = nsites(sys_uncontracted)
     nobs = size(measure.observables, 1)
     observables = reshape(measure.observables, nobs, natoms)
 
@@ -94,7 +94,7 @@ function swt_data_entangled(sys, sys_origin, Ns_unit, contraction_info, measure)
     for i in 1:nunits
         # Create unitary that rotates [0, ..., 0, 1] into ground state direction
         # Z that defines quantization axis
-        Z = sys.coherents[i]
+        Z = sys_contracted.coherents[i]
         U = hcat(nullspace(Z'), Z)
         local_unitaries[i] = U
 
@@ -113,7 +113,7 @@ function swt_data_entangled(sys, sys_origin, Ns_unit, contraction_info, measure)
         U = local_unitaries[unit]
 
         # Rotate interactions into local reference frames
-        int = sys.interactions_union[unit]
+        int = sys_contracted.interactions_union[unit]
 
         # Rotate onsite anisotropy (not that, for entangled units, onsite already includes Zeeman)
         int.onsite = Hermitian(U' * int.onsite * U)
@@ -122,7 +122,7 @@ function swt_data_entangled(sys, sys_origin, Ns_unit, contraction_info, measure)
         pair_new = PairCoupling[]
         for pc in int.pair
             # Convert PairCoupling to a purely general (tensor decomposed) interaction.
-            pc_general = as_general_pair_coupling(pc, sys)
+            pc_general = as_general_pair_coupling(pc, sys_contracted)
 
             # Rotate tensor decomposition into local frame.
             bond = pc.bond

--- a/src/EntangledUnits/EntangledUnits.jl
+++ b/src/EntangledUnits/EntangledUnits.jl
@@ -239,7 +239,7 @@ end
 
 # More battle-tested approach. Iterates over over contracted system. Move to
 # iteration scheme of original system moving forward for clarity and support of
-# inhomogenous interactioninteractions
+# inhomogenous interactions
 function entangle_system(sys::System{M}, units) where M
     # Construct contracted crystal
     contracted_crystal, contraction_info = contract_crystal(sys.crystal, units)

--- a/src/EntangledUnits/EntangledUnits.jl
+++ b/src/EntangledUnits/EntangledUnits.jl
@@ -334,18 +334,18 @@ end
 
 
 function set_expected_dipoles_of_entangled_system!(esys)
-    for site in eachsite(esys.sys_origin)
+    for site in eachsite(esys.sys_uncontracted)
         set_expected_dipole_of_entangled_system!(esys, site)
     end
 end
 
 function set_expected_dipole_of_entangled_system!(esys, site)
-    (; sys, sys_origin, dipole_operators, source_idcs) = esys
-    (; dipoles) = sys_origin
+    (; sys_contracted, sys_uncontracted, dipole_operators, source_idcs) = esys
+    (; dipoles) = sys_uncontracted
 
     a, b, c, _ = site.I
     source_idx = source_idcs[site]
-    Z = sys.coherents[a, b, c, source_idx]
+    Z = sys_contracted.coherents[a, b, c, source_idx]
     dipoles[site] = ntuple(i -> real(dot(Z, dipole_operators[i, site], Z)), 3)
 
     nothing

--- a/src/EntangledUnits/EntangledUnits.jl
+++ b/src/EntangledUnits/EntangledUnits.jl
@@ -125,8 +125,8 @@ atoms_in_unit(contraction_info, i) = [inverse_data.site for inverse_data in cont
 # Get the list of tuples specifying the units in terms of the uncontracted
 # system.
 function original_unit_spec(esys::EntangledSystem)
-    (; sys, contraction_info) = esys
-    return [Tuple(atoms_in_unit(contraction_info, unit)) for unit in axes(sys.dipoles, 4)]
+    (; sys_contracted, contraction_info) = esys
+    return [Tuple(atoms_in_unit(contraction_info, unit)) for unit in axes(sys_contracted.coherents, 4)]
 end
 
 
@@ -256,10 +256,10 @@ function entangle_system(sys::System{M}, units) where M
     # Construct empty contracted system
     dims = size(sys.dipoles)[1:3]
     spin_infos = [i => Moment(s=(N-1)/2, g=1.0) for (i, N) in enumerate(Ns_contracted)]  # TODO: Decisions about g-factor 
-    sys_entangled = System(contracted_crystal, spin_infos, :SUN; dims)
+    sys_contracted = System(contracted_crystal, spin_infos, :SUN; dims)
 
     # Transfer rng from origin system to entangled system
-    copy!(sys_entangled.rng, sys.rng)
+    copy!(sys_contracted.rng, sys.rng)
 
     # TODO: Extend to inhomogenous systems
     # For each contracted site, scan original interactions and reconstruct as necessary.
@@ -300,7 +300,7 @@ function entangle_system(sys::System{M}, units) where M
         for pc in pcs_intra
             accum_pair_coupling_into_bond_operator_in_unit!(unit_operator, pc, sys, contracted_site, contraction_info)
         end
-        set_onsite_coupling!(sys_entangled, unit_operator, contracted_site)
+        set_onsite_coupling!(sys_contracted, unit_operator, contracted_site)
 
         ## Convert inter-unit PairCouplings into new pair couplings
         for pc in pcs_inter
@@ -326,10 +326,10 @@ function entangle_system(sys::System{M}, units) where M
     for bond in exemplars
         relevant_interactions = filter(data -> data[1] == bond, new_pair_data)
         bond_operator = sum(data[2] for data in relevant_interactions)
-        set_pair_coupling!(sys_entangled, bond_operator, bond)
+        set_pair_coupling!(sys_contracted, bond_operator, bond)
     end
 
-    return (; sys_entangled, contraction_info)
+    return (; sys_contracted, contraction_info)
 end
 
 

--- a/src/EntangledUnits/TypesAndAliasing.jl
+++ b/src/EntangledUnits/TypesAndAliasing.jl
@@ -131,14 +131,14 @@ end
 function sync_entangled_system_from_origin!(esys::EntangledSystem)
     (; sys_uncontracted) = esys
     units = original_unit_spec(esys)
-    (; sys_entangled) = entangle_system(sys_uncontracted, units)
+    (; sys_contracted) = entangle_system(sys_uncontracted, units)
 
     # Preserve the existing contracted-system object and only refresh the
     # mutable fields that depend on model parameters. This keeps the coherents
     # of the entangled system intact.
-    esys.sys_contracted.params = copy.(sys_entangled.params)
-    esys.sys_contracted.interactions_union = sys_entangled.interactions_union
-    esys.sys_contracted.ewald = sys_entangled.ewald
+    esys.sys_contracted.params = copy.(sys_contracted.params)
+    esys.sys_contracted.interactions_union = sys_contracted.interactions_union
+    esys.sys_contracted.ewald = sys_contracted.ewald
     return esys
 end
 

--- a/src/EntangledUnits/TypesAndAliasing.jl
+++ b/src/EntangledUnits/TypesAndAliasing.jl
@@ -128,6 +128,51 @@ function clone_system(esys::EntangledSystem)
     return EntangledSystem(sys, sys_origin, contraction_info, dipole_operators, source_idcs)
 end
 
+function sync_entangled_system_from_origin!(esys::EntangledSystem)
+    (; sys_origin) = esys
+    units = original_unit_spec(esys)
+    (; sys_entangled) = entangle_system(sys_origin, units)
+
+    # Preserve the existing contracted-system object and only refresh the
+    # mutable fields that depend on model parameters.
+    esys.sys.params = copy.(sys_entangled.params)
+    esys.sys.interactions_union = sys_entangled.interactions_union
+    esys.sys.ewald = sys_entangled.ewald
+    return esys
+end
+
+function set_active_labels!(esys::EntangledSystem, labels::Vector{Symbol})
+    set_active_labels!(esys.sys, labels)
+    set_active_labels!(esys.sys_origin, labels)
+    return esys
+end
+
+get_active_labels(esys::EntangledSystem) = get_active_labels(esys.sys)
+
+function get_param(esys::EntangledSystem, label::Symbol)
+    return get_param(esys.sys_origin, label)
+end
+
+function get_params(esys::EntangledSystem, labels::Vector{Symbol})
+    return get_param.(Ref(esys), labels)
+end
+
+function set_param!(esys::EntangledSystem, label::Symbol, val::Real)
+    return set_params!(esys, [label], [val])
+end
+
+function set_params!(esys::EntangledSystem, labels::Vector{Symbol}, vals::Vector{<: Real})
+    set_params!(esys.sys_origin, labels, vals)
+    sync_entangled_system_from_origin!(esys)
+    return
+end
+
+function add_auxiliary_param!(esys::EntangledSystem, paramspec::ParamSpec)
+    add_auxiliary_param!(esys.sys_origin, paramspec)
+    sync_entangled_system_from_origin!(esys)
+    return
+end
+
 function set_field!(esys::EntangledSystem, B)
     (; sys, sys_origin, dipole_operators, source_idcs) = esys 
     B_old = sys_origin.extfield[1,1,1,1] 

--- a/src/EntangledUnits/TypesAndAliasing.jl
+++ b/src/EntangledUnits/TypesAndAliasing.jl
@@ -36,9 +36,9 @@ end
 ################################################################################
 struct EntangledSystem
     # Entangled System, original system, and mapping info between systems
-    sys               :: System                         # System containing entangled units
-    sys_origin        :: System                         # Original "uncontracted" system
-    contraction_info  :: CrystalContractionInfo         # Forward and inverse mapping data for sys <-> sys_origin
+    sys_contracted    :: System                         # System containing entangled units
+    sys_uncontracted  :: System                         # Original "uncontracted" system
+    contraction_info  :: CrystalContractionInfo         # Forward and inverse mapping data for sys_contracted <-> sys_uncontracted
 
     # Observable field for dipoles and mapping information for loops
     dipole_operators  :: Array{Matrix{ComplexF64}, 5}   # An observable field corresponding to dipoles of the original system.
@@ -61,30 +61,30 @@ Interactions must be specified for the original `System`. Sunny will
 automatically reconstruct the appropriate interactions for the
 `EntangledSystem`.
 """
-function EntangledSystem(sys::System{N}, units) where {N}
+function EntangledSystem(sys_uncontracted::System{N}, units) where {N}
     # Since external field is stored in the onsite interactions in
     # EntangledSystems and EntangledSystems are always homogenous (i.e.,
     # interactions are indexed by atom/unit, not site, external field
     # information must also be tracked by atom/unit index only.
-    for atom in axes(sys.coherents, 4)
-        @assert allequal(@view sys.gs[:,:,:,atom]) "`EntangledSystem` require g-factors be uniform across unit cells" 
+    for atom in axes(sys_uncontracted.coherents, 4)
+        @assert allequal(@view sys_uncontracted.gs[:,:,:,atom]) "`EntangledSystem` require g-factors be uniform across unit cells" 
     end
 
     # Generate pair of contracted and uncontracted systems
-    (; sys_entangled, contraction_info) = entangle_system(sys, units)
-    sys_origin = clone_system(sys)
+    (; sys_contracted, contraction_info) = entangle_system(sys_uncontracted, units)
+    sys_uncontracted = clone_system(sys_uncontracted)
 
     # Generate observable field. This observable field has as many entries as
     # the uncontracted system but contains operators in the local product spaces
     # of the contracted system. `source_idcs` provides the unit index (of the
     # contracted system) in terms of the atom index (of the uncontracted
     # system).
-    dipole_operators_origin = all_dipole_observables(sys_origin; apply_g=false) 
-    (; observables, source_idcs) = observables_to_product_space(dipole_operators_origin, sys_origin, contraction_info)
+    dipole_operators_origin = all_dipole_observables(sys_uncontracted; apply_g=false) 
+    (; observables, source_idcs) = observables_to_product_space(dipole_operators_origin, sys_uncontracted, contraction_info)
 
-    esys = EntangledSystem(sys_entangled, sys_origin, contraction_info, observables, source_idcs)
+    esys = EntangledSystem(sys_contracted, sys_uncontracted, contraction_info, observables, source_idcs)
 
-    # Coordinate sys_entangled and sys_origin
+    # Coordinate sys_contracted and sys_uncontracted
     set_expected_dipoles_of_entangled_system!(esys)
 
     return esys
@@ -99,59 +99,59 @@ end
 # Aliasing 
 ################################################################################
 function Base.show(io::IO, esys::EntangledSystem)
-    print(io, "EntangledSystem($(mode_to_str(esys.sys)), $(supercell_to_str(esys.sys_origin.dims, esys.sys_origin.crystal)), $(energy_to_str(esys.sys)))")
+    print(io, "EntangledSystem($(mode_to_str(esys.sys_contracted)), $(supercell_to_str(esys.sys_uncontracted.dims, esys.sys_uncontracted.crystal)), $(energy_to_str(esys.sys_contracted)))")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", esys::EntangledSystem)
-    printstyled(io, "EntangledSystem $(mode_to_str(esys.sys))\n"; bold=true, color=:underline)
-    println(io, supercell_to_str(esys.sys_origin.dims, esys.sys_origin.crystal))
-    if !isnothing(esys.sys_origin.origin)
-        shape = number_to_math_string.(cell_shape(esys.sys_origin))
+    printstyled(io, "EntangledSystem $(mode_to_str(esys.sys_contracted))\n"; bold=true, color=:underline)
+    println(io, supercell_to_str(esys.sys_uncontracted.dims, esys.sys_uncontracted.crystal))
+    if !isnothing(esys.sys_uncontracted.origin)
+        shape = number_to_math_string.(cell_shape(esys.sys_uncontracted))
         println(io, formatted_matrix(shape; prefix="Reshaped cell "))
     end
-    println(io, energy_to_str(esys.sys))
+    println(io, energy_to_str(esys.sys_contracted))
 end
 
-eachsite(esys::EntangledSystem) = eachsite(esys.sys_origin)
-eachunit(esys::EntangledSystem) = eachsite(esys.sys)
+eachsite(esys::EntangledSystem) = eachsite(esys.sys_uncontracted)
+eachunit(esys::EntangledSystem) = eachsite(esys.sys_contracted)
 
-energy(esys::EntangledSystem) = energy(esys.sys)
-energy_per_site(esys::EntangledSystem) = energy(esys.sys) / nsites(esys.sys_origin)
+energy(esys::EntangledSystem) = energy(esys.sys_contracted)
+energy_per_site(esys::EntangledSystem) = energy(esys.sys_contracted) / nsites(esys.sys_uncontracted)
 
 function clone_system(esys::EntangledSystem)
-    sys = clone_system(esys.sys)
-    sys_origin = clone_system(esys.sys_origin)
+    sys_contracted = clone_system(esys.sys_contracted)
+    sys_uncontracted = clone_system(esys.sys_uncontracted)
     contraction_info = copy(esys.contraction_info)
     dipole_operators = copy(esys.dipole_operators)
     source_idcs = copy(esys.source_idcs)
 
-    return EntangledSystem(sys, sys_origin, contraction_info, dipole_operators, source_idcs)
+    return EntangledSystem(sys_contracted, sys_uncontracted, contraction_info, dipole_operators, source_idcs)
 end
 
 function sync_entangled_system_from_origin!(esys::EntangledSystem)
-    (; sys_origin) = esys
+    (; sys_uncontracted) = esys
     units = original_unit_spec(esys)
-    (; sys_entangled) = entangle_system(sys_origin, units)
+    (; sys_entangled) = entangle_system(sys_uncontracted, units)
 
     # Preserve the existing contracted-system object and only refresh the
     # mutable fields that depend on model parameters. This keeps the coherents
     # of the entangled system intact.
-    esys.sys.params = copy.(sys_entangled.params)
-    esys.sys.interactions_union = sys_entangled.interactions_union
-    esys.sys.ewald = sys_entangled.ewald
+    esys.sys_contracted.params = copy.(sys_entangled.params)
+    esys.sys_contracted.interactions_union = sys_entangled.interactions_union
+    esys.sys_contracted.ewald = sys_entangled.ewald
     return esys
 end
 
 function set_active_labels!(esys::EntangledSystem, labels::Vector{Symbol})
-    set_active_labels!(esys.sys, labels)
-    set_active_labels!(esys.sys_origin, labels)
+    set_active_labels!(esys.sys_contracted, labels)
+    set_active_labels!(esys.sys_uncontracted, labels)
     return esys
 end
 
-get_active_labels(esys::EntangledSystem) = get_active_labels(esys.sys)
+get_active_labels(esys::EntangledSystem) = get_active_labels(esys.sys_contracted)
 
 function get_param(esys::EntangledSystem, label::Symbol)
-    return get_param(esys.sys_origin, label)
+    return get_param(esys.sys_uncontracted, label)
 end
 
 function get_params(esys::EntangledSystem, labels::Vector{Symbol})
@@ -163,29 +163,29 @@ function set_param!(esys::EntangledSystem, label::Symbol, val::Real)
 end
 
 function set_params!(esys::EntangledSystem, labels::Vector{Symbol}, vals::Vector{<: Real})
-    set_params!(esys.sys_origin, labels, vals)
+    set_params!(esys.sys_uncontracted, labels, vals)
     sync_entangled_system_from_origin!(esys)
     return
 end
 
 function add_auxiliary_param!(esys::EntangledSystem, paramspec::ParamSpec)
-    add_auxiliary_param!(esys.sys_origin, paramspec)
+    add_auxiliary_param!(esys.sys_uncontracted, paramspec)
     sync_entangled_system_from_origin!(esys)
     return
 end
 
 function set_field!(esys::EntangledSystem, B)
-    (; sys, sys_origin, dipole_operators, source_idcs) = esys 
-    B_old = sys_origin.extfield[1,1,1,1] 
-    set_field!(sys_origin, B) 
+    (; sys_contracted, sys_uncontracted, dipole_operators, source_idcs) = esys
+    B_old = sys_uncontracted.extfield[1,1,1,1] 
+    set_field!(sys_uncontracted, B) 
 
     # Iterate through atom of original system and adjust the onsite operator of
     # corresponding unit of contracted system.
-    for atom in axes(sys_origin.coherents, 4)
+    for atom in axes(sys_uncontracted.coherents, 4)
         unit = source_idcs[1, 1, 1, atom]
         S = dipole_operators[:, 1, 1, 1, atom]
-        ΔB = sys_origin.gs[1, 1, 1, atom]' * (B - B_old) 
-        sys.interactions_union[unit].onsite += Hermitian(ΔB' * S)
+        ΔB = sys_uncontracted.gs[1, 1, 1, atom]' * (B - B_old) 
+        sys_contracted.interactions_union[unit].onsite += Hermitian(ΔB' * S)
     end
 end
 
@@ -202,7 +202,7 @@ end
 # Find the unique coherent state corresponding to a set of fully-polarized
 # dipoles on each site inside a specified entangled unit.
 function coherent_state_from_dipoles(esys::EntangledSystem, dipoles, unit)
-    (; sys_origin, contraction_info) = esys
+    (; sys_uncontracted, contraction_info) = esys
 
     # Find the atom indices (of original system) that lie in the specified unit
     # (of contracted system).
@@ -214,7 +214,7 @@ function coherent_state_from_dipoles(esys::EntangledSystem, dipoles, unit)
 
     # Retrieve the dimensions of the local Hilbert spaces corresponding to those
     # atoms.
-    Ns = Ns_in_units(sys_origin, contraction_info)[unit]
+    Ns = Ns_in_units(sys_uncontracted, contraction_info)[unit]
 
     # Generate a list of coherent states corresponding to given dipoles _in each
     # local Hilbert space_.
@@ -238,8 +238,9 @@ end
 # contracted lattice (i.e., to a "unit"). The function then updates all dipoles
 # in the uncontracted system that are determined by the coherent state. 
 function set_coherent!(esys::EntangledSystem, coherent, site)
+    (; sys_contracted) = esys
     site = to_cartesian(site)
-    set_coherent!(esys.sys, coherent, site)
+    set_coherent!(sys_contracted, coherent, site)
     a, b, c, unit = site.I
     for atom in atoms_in_unit(esys.contraction_info, unit)
         set_expected_dipole_of_entangled_system!(esys, CartesianIndex(a, b, c, atom))
@@ -247,36 +248,41 @@ function set_coherent!(esys::EntangledSystem, coherent, site)
 end
 
 function randomize_spins!(esys::EntangledSystem) 
-    randomize_spins!(esys.sys)
+    (; sys_contracted) = esys
+    randomize_spins!(sys_contracted)
     set_expected_dipoles_of_entangled_system!(esys)
 end
 
 function minimize_energy!(esys::EntangledSystem; kwargs...)
-    optout = minimize_energy!(esys.sys; kwargs...)
+    (; sys_contracted) = esys
+    optout = minimize_energy!(sys_contracted; kwargs...)
     set_expected_dipoles_of_entangled_system!(esys)
     return optout
 end
 
 function magnetic_moments(esys::EntangledSystem)
-    magnetic_moments(esys.sys_origin)
+    (; sys_uncontracted) = esys
+    magnetic_moments(sys_uncontracted)
 end
 
 function plot_spins(esys::EntangledSystem; kwargs...)
-    plot_spins(esys.sys_origin; kwargs...)
+    (; sys_uncontracted) = esys
+    plot_spins(sys_uncontracted; kwargs...)
 end
 
-ssf_custom(f, esys::EntangledSystem; kwargs...) = ssf_custom(f, esys.sys_origin; kwargs...)
-ssf_custom_bm(f, esys::EntangledSystem; kwargs...) = ssf_custom_bm(f, esys.sys_origin; kwargs...)
-ssf_trace(esys::EntangledSystem; kwargs...) = ssf_trace(esys.sys_origin; kwargs...)
-ssf_perp(esys::EntangledSystem; kwargs...) = ssf_perp(esys.sys_origin; kwargs...)
+ssf_custom(f, esys::EntangledSystem; kwargs...) = ssf_custom(f, esys.sys_uncontracted; kwargs...)
+ssf_custom_bm(f, esys::EntangledSystem; kwargs...) = ssf_custom_bm(f, esys.sys_uncontracted; kwargs...)
+ssf_trace(esys::EntangledSystem; kwargs...) = ssf_trace(esys.sys_uncontracted; kwargs...)
+ssf_perp(esys::EntangledSystem; kwargs...) = ssf_perp(esys.sys_uncontracted; kwargs...)
 
 # TODO: Note this simple wrapper makes everything work, but is not the most
 # efficient solution. `step!` currently syncs the dipoles field of the
 # EntangledSystem in a meaninless way. This field is ignored everywhere, but
 # this step represents needless computation.
 function step!(esys::EntangledSystem, integrator)
-    step!(esys.sys, integrator) 
+    (; sys_contracted) = esys
+    step!(sys_contracted, integrator) 
     set_expected_dipoles_of_entangled_system!(esys)
 end
 
-suggest_timestep(esys::EntangledSystem, integrator; kwargs...) = suggest_timestep(esys.sys, integrator; kwargs...)
+suggest_timestep(esys::EntangledSystem, integrator; kwargs...) = suggest_timestep(esys.sys_contracted, integrator; kwargs...)

--- a/src/EntangledUnits/TypesAndAliasing.jl
+++ b/src/EntangledUnits/TypesAndAliasing.jl
@@ -134,7 +134,8 @@ function sync_entangled_system_from_origin!(esys::EntangledSystem)
     (; sys_entangled) = entangle_system(sys_origin, units)
 
     # Preserve the existing contracted-system object and only refresh the
-    # mutable fields that depend on model parameters.
+    # mutable fields that depend on model parameters. This keeps the coherents
+    # of the entangled system intact.
     esys.sys.params = copy.(sys_entangled.params)
     esys.sys.interactions_union = sys_entangled.interactions_union
     esys.sys.ewald = sys_entangled.ewald

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -1,6 +1,6 @@
-struct FittingLoss
+struct FittingLoss{S}
     f :: Function
-    sys :: System
+    sys :: S
     labels :: Vector{Symbol}
     hp :: NamedTuple
 end
@@ -94,12 +94,19 @@ function make_loss_fn(f, sys, labels; hp=NamedTuple())
     return FittingLoss(f, sys, labels, hp)
 end
 
+function set_active_labels!(sys::System, labels::Vector{Symbol})
+    sys.active_labels = labels
+    return sys
+end
+
+get_active_labels(sys::System) = sys.active_labels
+
 function (fl::FittingLoss)(vals)
     (; f, sys, labels, hp) = fl
 
     sys = clone_system(sys)
     set_params!(sys, labels, vals)
-    sys.active_labels = labels
+    set_active_labels!(sys, labels)
     try
         if applicable(f, sys, hp)
             return f(sys, hp)
@@ -118,7 +125,7 @@ function CRC.rrule(rc::CRC.RuleConfig, fl::FittingLoss, vals)
 
     sys = clone_system(sys)
     set_params!(sys, labels, vals)
-    sys.active_labels = labels
+    set_active_labels!(sys, labels)
     (L, f_pb) = try
         if applicable(f, sys, hp)
             CRC.rrule_via_ad(rc, f, sys, hp)
@@ -705,7 +712,7 @@ CRC.zero_tangent(t::SystemTangent) = SystemTangent(zero(t.vals))
 CRC.unthunk(t::SystemTangent) = t
 
 function CRC.ProjectTo(sys::System)
-    n = length(sys.active_labels)
+    n = length(get_active_labels(sys))
     function project(Δsys)
         Δsys = CRC.unthunk(Δsys)
         if Δsys isa CRC.NoTangent || Δsys isa CRC.AbstractZero
@@ -727,7 +734,7 @@ end
 function with_params(sys::System, labels::Vector{Symbol}, vals::Vector{<: Real})
     sys = clone_system(sys)
     set_params!(sys, labels, vals)
-    sys.active_labels = labels
+    set_active_labels!(sys, labels)
     return sys
 end
 function CRC.rrule(::typeof(with_params), sys::System, labels, vals)

--- a/src/Operators/TensorOperators.jl
+++ b/src/Operators/TensorOperators.jl
@@ -1,84 +1,115 @@
-# Defined so that `reverse_kron(A⊗B) == B⊗A`.
+@inline vec_index(i, j, N) = i + (j - 1) * N
+
+# Converts an NxN Hermitian matrix X into a real vector of coordinates for a
+# standard Hermitian basis. This basis can be defined as follows. Given matrices
+# NxN matrices
 # 
-# To understand the implementation, note that:
-# - `A_ij B_kl = (A⊗B)_kilj`
-# - `(A⊗B)_ijkl = A_jl B_ik`
-function reverse_kron(C, N1, N2)
-    @assert length(C) == N2*N1*N2*N1
-    C = reshape(C, N2, N1, N2, N1)
-    C = permutedims(C, (2, 1, 4, 3))
-    return reshape(C, N1*N2, N1*N2)
-end
+# (E_{ij})_{ab} = \delta_{ia}\delta{jb} 
+#
+# a basis of N^2 Hermitian matrices may be formed by with N real diagonal
+# elements H_i = E_{ii}, symmetric off-diagonal matrices H_{ij}^{R} = (E_{ij} +
+# E_{ji})/\sqrt{2}, and antisymmetric off-diagonal elements H_{ij}^{I} =
+# i(E_{ji} - E_{ij})/\sqrt{2}.
+function matrix_entries_to_hermitian_coords(X::AbstractMatrix{ComplexF64}, N::Integer, ::Val{dim}) where {dim}
+    @assert dim == 1 || dim == 2
+    @assert size(X, dim) == N*N
 
-# Return list of groups of indices. Within each group, the indexed values of `S`
-# are approximately equal. Assumes S is sorted.
-function degeneracy_groups(S, tol)
-    acc = UnitRange{Int}[]
-    isempty(S) && return acc
+    Y = similar(X)
+    isqrt2 = inv(sqrt(2.0))
 
-    j0 = 1
-    for j = 2:lastindex(S)
-        if abs(S[j0] - S[j]) > tol
-            push!(acc, j0:(j-1))
-            j0 = j
-        end
+    p = 1
+
+    @views for i in 1:N
+        selectdim(Y, dim, p) .= selectdim(X, dim, vec_index(i, i, N))
+        p += 1
     end
 
-    push!(acc, j0:length(S))
-    return acc
+    @views for i in 1:N-1, j in i+1:N
+        xij = selectdim(X, dim, vec_index(i, j, N))
+        xji = selectdim(X, dim, vec_index(j, i, N))
+
+        # Coordinate along (E_ij + E_ji)/sqrt(2)
+        y = selectdim(Y, dim, p)
+        @. y = isqrt2 * (xij + xji)
+        p += 1
+
+        # Coordinate along (-im E_ij + im E_ji)/sqrt(2)
+        y = selectdim(Y, dim, p)
+        @. y = im * isqrt2 * (xij - xji)
+        p += 1
+    end
+
+    @assert p == N*N + 1
+    return Y
 end
 
-# Use SVD to find the decomposition D = ∑ₖ Aₖ ⊗ Bₖ, where Aₖ is N₁×N₁ and Bₖ is
-# N₂×N₂. Returns the list of matrices [(A₁, B₁), (A₂, B₂), ...].
-function svd_tensor_expansion(D::Matrix{T}, N1, N2) where T
-    tol = 1e-12
+# From a set of real coordinates in the basis described above, reconstruct the
+# Hermitian operator.
+function hermitian_matrix_from_coords(x::AbstractVector{<:Real}, N::Integer)
+    @assert length(x) == N*N
 
+    A = zeros(ComplexF64, N, N)
+    isqrt2 = inv(sqrt(2.0))
+
+    p = 1
+
+    for i in 1:N
+        A[i, i] = x[p]
+        p += 1
+    end
+
+    for i in 1:N-1, j in i+1:N
+        a = isqrt2 * x[p]
+        b = isqrt2 * x[p+1]
+        p += 2
+
+        A[i, j] = a - im*b
+    end
+
+    @assert p == N*N + 1
+
+    return Hermitian(A, :U)
+end
+
+# Use and SVD to find the minimal set of operator pairs necessary to represent
+# an arbitrary interaction.
+function svd_tensor_expansion(D::Matrix{T}, N1, N2; tol=1e-12) where T
     @assert size(D, 1) == size(D, 2) == N1*N2
-    D̃ = permutedims(reshape(D, N2, N1, N2, N1), (2,4,1,3))
+
+    # Reshuffle D 
+    #
+    #   D[(a,i), (b,j)] -> D̃[(i,j), (a,b)]
+    #
+    # so that D̃ is an N1^2 × N2^2 matrix.
+    D̃ = permutedims(reshape(ComplexF64.(D), N2, N1, N2, N1), (2, 4, 1, 3))
     D̃ = reshape(D̃, N1*N1, N2*N2)
-    (; S, U, V) = svd(D̃)
+
+    # Convert each tensor leg from raw matrix-entry coordinates to coordinates
+    # in an orthonormal Hermitian matrix basis.
+    C = matrix_entries_to_hermitian_coords(D̃, N1, Val(1))
+    C = matrix_entries_to_hermitian_coords(C, N2, Val(2))
+
+    # Operator in product space must be Hermitian
+    @assert diffnorm2(C, C') < 1e-12
+
+    # Project numerical noise back onto the real Hermitian-product space.
+    C = real.(C)
+
+    # Real SVD. The dimensions are the same as the original complex SVD, but
+    # the singular vectors now live in the real vector space of Hermitian matrices.
+    F = svd!(C)
+
     ret = Tuple{HermitianC64, HermitianC64}[]
 
-    # Rotate columns of U and V within each degenerate subspace so that all
-    # columns (when reshaped) are Hermitian matrices
-    for range in degeneracy_groups(S, tol)
-        abs(S[first(range)]) < tol && break
-        
-        U_sub = view(U, :, range)
-        n = length(range)
-        Q = zeros(ComplexF64, n, n)
-        for k in 1:n, k′ in 1:n
-            uk  = reshape(view(U_sub, :, k), N1, N1)
-            uk′ = reshape(view(U_sub, :, k′), N1, N1)
-            Q[k, k′] = conj(tr(uk * uk′))
-        end
-        
-        R = sqrt(Q)
-        @assert norm(R*R' - I) < 1e-12
+    for (k, σ) in enumerate(F.S)
+        σ < tol && break
 
-        @views U[:, range] = U[:, range] * R
-        @views V[:, range] = V[:, range] * R
+        A = hermitian_matrix_from_coords(view(F.U, :, k), N1)
+        B = hermitian_matrix_from_coords(view(F.V, :, k), N2)
+
+        push!(ret, (Hermitian(σ * Matrix(A), :U), B))
     end
 
-    # Check that rotation was valid
-    @assert U*diagm(S)*V' ≈ D̃
-
-    for (k, σ) in enumerate(S)
-        if abs(σ) > tol
-            u = reshape(U[:, k], N1, N1)
-            v = reshape(V[:, k], N2, N2)
-            # Check factors are really Hermitian up to empirical tolerance. It
-            # seems that numerical error can creep into the SVD when singular
-            # values are near each other.
-            hermit_dev = max(norm(u - u'), norm(v - v'))
-            if hermit_dev > 1e-9
-                @warn "Detected non-Hermiticity in SVD of order $hermit_dev"
-            end
-            u = hermitianpart(u)
-            v = hermitianpart(v)
-            push!(ret, (σ*u, conj(v)))
-        end
-    end
     return ret
 end
 

--- a/src/Operators/TensorOperators.jl
+++ b/src/Operators/TensorOperators.jl
@@ -1,16 +1,3 @@
-# Defined so that `reverse_kron(A⊗B) == B⊗A`. This is currently only used in the
-# test suite.
-# 
-# To understand the implementation, note that:
-# - `A_ij B_kl = (A⊗B)_kilj`
-# - `(A⊗B)_ijkl = A_jl B_ik`
-function reverse_kron(C, N1, N2)
-    @assert length(C) == N2*N1*N2*N1
-    C = reshape(C, N2, N1, N2, N1)
-    C = permutedims(C, (2, 1, 4, 3))
-    return reshape(C, N1*N2, N1*N2)
-end
-
 @inline vec_index(i, j, N) = i + (j - 1) * N
 
 # Converts an NxN Hermitian matrix X into a real vector of coordinates for a
@@ -84,16 +71,15 @@ function hermitian_matrix_from_coords(x::AbstractVector{<:Real}, N::Integer)
     return Hermitian(A, :U)
 end
 
-# Use and SVD to find the minimal set of operator pairs necessary to represent
-# an arbitrary interaction.
+# Given a Hermitian operator D living in tensor-product space, use SVD to find
+# the decomposition D = ∑ₖ Aₖ ⊗ Bₖ, where Aₖ is N₁×N₁ and Bₖ is N₂×N₂. Returns
+# the list of Hermitian matrix pairs [(A₁, B₁), (A₂, B₂), ...].
 function svd_tensor_expansion(D::Matrix{T}, N1, N2; tol=1e-12) where T
+    maxdiff(D, D') < 1e-12 || error("Detected non-Hermitian operator")
     @assert size(D, 1) == size(D, 2) == N1*N2
 
-    # Reshuffle D 
-    #
-    #   D[(a,i), (b,j)] -> D̃[(i,j), (a,b)]
-    #
-    # so that D̃ is an N1^2 × N2^2 matrix.
+    # Reshuffle D_{(a,i),(b,j)} -> D̃_{(i,j),(a,b)} so that D̃ is an N1^2 × N2^2
+    # matrix.
     D̃ = permutedims(reshape(ComplexF64.(D), N2, N1, N2, N1), (2, 4, 1, 3))
     D̃ = reshape(D̃, N1*N1, N2*N2)
 
@@ -102,15 +88,14 @@ function svd_tensor_expansion(D::Matrix{T}, N1, N2; tol=1e-12) where T
     C = matrix_entries_to_hermitian_coords(D̃, N1, Val(1))
     C = matrix_entries_to_hermitian_coords(C, N2, Val(2))
 
-    # In a Hermitian-product basis, Hermiticity is equivalent to real
-    # expansion coefficients, even when N1 != N2.
-    @assert norm2(imag.(C)) < 1e-12
+    # Hermiticity of D is equivalent to real expansion coefficients in C
+    @assert all(x -> abs(imag(x)) < 1e-12, C)
 
-    # Project numerical noise back onto the real Hermitian-product space.
+    # Work in exact Hermitian-product space.
     C = real.(C)
 
-    # Real SVD. The dimensions are the same as the original complex SVD, but
-    # the singular vectors now live in the real vector space of Hermitian matrices.
+    # Real SVD. Components of the singular vectors live in the real vector space
+    # of Hermitian matrices.
     F = svd!(C)
 
     ret = Tuple{HermitianC64, HermitianC64}[]

--- a/src/Operators/TensorOperators.jl
+++ b/src/Operators/TensorOperators.jl
@@ -1,3 +1,16 @@
+# Defined so that `reverse_kron(A⊗B) == B⊗A`. This is currently only used in the
+# test suite.
+# 
+# To understand the implementation, note that:
+# - `A_ij B_kl = (A⊗B)_kilj`
+# - `(A⊗B)_ijkl = A_jl B_ik`
+function reverse_kron(C, N1, N2)
+    @assert length(C) == N2*N1*N2*N1
+    C = reshape(C, N2, N1, N2, N1)
+    C = permutedims(C, (2, 1, 4, 3))
+    return reshape(C, N1*N2, N1*N2)
+end
+
 @inline vec_index(i, j, N) = i + (j - 1) * N
 
 # Converts an NxN Hermitian matrix X into a real vector of coordinates for a
@@ -89,8 +102,9 @@ function svd_tensor_expansion(D::Matrix{T}, N1, N2; tol=1e-12) where T
     C = matrix_entries_to_hermitian_coords(D̃, N1, Val(1))
     C = matrix_entries_to_hermitian_coords(C, N2, Val(2))
 
-    # Operator in product space must be Hermitian
-    @assert diffnorm2(C, C') < 1e-12
+    # In a Hermitian-product basis, Hermiticity is equivalent to real
+    # expansion coefficients, even when N1 != N2.
+    @assert norm2(imag.(C)) < 1e-12
 
     # Project numerical noise back onto the real Hermitian-product space.
     C = real.(C)

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -92,7 +92,7 @@ function excitations!(T, tmp, swt::AbstractDirectSpinWaveTheory, q)
     L = nbands(swt)
     size(T) == size(tmp) == (2L, 2L) || error("Arguments T and tmp must be $(2L)×$(2L) matrices")
 
-    q_reshaped = to_reshaped_rlu(swt.sys, q)
+    q_reshaped = to_reshaped_rlu(swt, q)
     dynamical_matrix!(tmp, swt, q_reshaped)
 
     try

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -88,7 +88,7 @@ Each branch will contribute ``L`` excitations, where ``L`` is the number of
 spins in the magnetic cell. This yields a total of ``3L`` excitations for a
 given momentum transfer ``𝐪``.
 """
-function excitations!(T, tmp, swt::SpinWaveTheory, q)
+function excitations!(T, tmp, swt::AbstractDirectSpinWaveTheory, q)
     L = nbands(swt)
     size(T) == size(tmp) == (2L, 2L) || error("Arguments T and tmp must be $(2L)×$(2L) matrices")
 
@@ -114,7 +114,7 @@ Returns a pair `(energies, T)` providing the excitation energies and
 eigenvectors. Prefer [`excitations!`](@ref) for performance, which avoids matrix
 allocations. See the documentation of [`excitations!`](@ref) for more details.
 """
-function excitations(swt::SpinWaveTheory, q)
+function excitations(swt::AbstractDirectSpinWaveTheory, q)
     L = nbands(swt)
     T = zeros(ComplexF64, 2L, 2L)
     H = zeros(ComplexF64, 2L, 2L)
@@ -129,7 +129,7 @@ Given a list of wavevectors `qpts` in reciprocal lattice units (RLU), returns
 excitation energies for each band. The return value `ret` is 2D array, and
 should be indexed as `ret[band_index, q_index]`.
 """
-function dispersion(swt::SpinWaveTheory, qpts)
+function dispersion(swt::AbstractDirectSpinWaveTheory, qpts)
     L = nbands(swt)
     qpts = convert(AbstractQPoints, qpts)
     disp = zeros(L, length(qpts.qs))

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -148,7 +148,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
     end
 
     # H must be hermitian up to round-off errors
-    @assert diffnorm2(H, H') < 1e-12
+    @assert maxdiff(H, H') < 1e-12
 
     # Make H exactly hermitian
     hermitianpart!(H)

--- a/src/SpinWaveTheory/HamiltonianSUN.jl
+++ b/src/SpinWaveTheory/HamiltonianSUN.jl
@@ -122,7 +122,7 @@ function swt_hamiltonian_SUN!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_resh
     end
 
     # H must be hermitian up to round-off errors
-    @assert diffnorm2(H, H') < 1e-12
+    @assert maxdiff(H, H') < 1e-12
 
     # Make H exactly hermitian
     hermitianpart!(H)

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -11,8 +11,10 @@ struct SWTDataSUN
     spins_localized       :: Array{HermitianC64, 2}     # Spins rotated to local frame (3 × nsites)
 end
 
-# To facilitate sharing some code with SpinWaveTheorySpiral
+# To facilitate code sharing with SpinWaveTheorySpiral
 abstract type AbstractSpinWaveTheory end
+# To facilitate code sharing with EntangledSpinWaveTheory
+abstract type AbstractDirectSpinWaveTheory <: AbstractSpinWaveTheory end
 
 """
     SpinWaveTheory(sys::System; measure, regularization=1e-8)
@@ -91,14 +93,14 @@ function to_reshaped_rlu(sys::System, q)
     return sys.crystal.recipvecs \ (orig_crystal(sys).recipvecs * q)
 end
 
-function dynamical_matrix(swt::SpinWaveTheory, q_reshaped)
+function dynamical_matrix(swt::AbstractDirectSpinWaveTheory, q_reshaped)
     L = nbands(swt)
     H = zeros(ComplexF64, 2L, 2L)
     dynamical_matrix!(H, swt, q_reshaped)
     return Hermitian(H)
 end
 
-function dynamical_matrix!(H, swt::SpinWaveTheory, q_reshaped)
+function dynamical_matrix!(H, swt::AbstractDirectSpinWaveTheory, q_reshaped)
     if swt.sys.mode == :SUN
         swt_hamiltonian_SUN!(H, swt, q_reshaped)
     else

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -93,6 +93,13 @@ function to_reshaped_rlu(sys::System, q)
     return sys.crystal.recipvecs \ (orig_crystal(sys).recipvecs * q)
 end
 
+# Give EntangledSpinWaveTheory an overloading hook. The fundamental problem is
+# that orig_crystal(eswt.sys) is not guaranteed to be the actual original
+# chemical cell.
+function to_reshaped_rlu(swt::SpinWaveTheory, q)
+    to_reshaped_rlu(swt.sys, q)
+end
+
 function dynamical_matrix(swt::AbstractDirectSpinWaveTheory, q_reshaped)
     L = nbands(swt)
     H = zeros(ComplexF64, 2L, 2L)

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -35,7 +35,7 @@ matrix to avoid numerical issues with quasi-particle modes of vanishing energy.
 Physically, this shift can be interpreted as application of an inhomogeneous
 field aligned with the magnetic ordering.
 """
-struct SpinWaveTheory <: AbstractSpinWaveTheory
+struct SpinWaveTheory <: AbstractDirectSpinWaveTheory
     sys            :: System
     data           :: Union{SWTDataDipole, SWTDataSUN}
     measure        :: MeasureSpec

--- a/src/Spiral/LuttingerTisza.jl
+++ b/src/Spiral/LuttingerTisza.jl
@@ -42,7 +42,7 @@ function fourier_exchange_matrix!(Jq::Matrix{ComplexF64}, sys::System; q)
     end
 
     Jq = reshape(Jq, 3Na, 3Na)
-    @assert diffnorm2(Jq, Jq') < 1e-15
+    @assert maxdiff(Jq, Jq') < 1e-12
     return hermitianpart!(Jq)
 end
 
@@ -80,7 +80,7 @@ function fourier_exchange_matrix_sensitivity!(Jq, sys, label; q)
     end
 
     Jq = reshape(Jq, 3Na, 3Na)
-    @assert diffnorm2(Jq, Jq') < 1e-15
+    @assert maxdiff(Jq, Jq') < 1e-15
     return hermitianpart!(Jq)
 end
 

--- a/src/Spiral/SpinWaveTheorySpiral.jl
+++ b/src/Spiral/SpinWaveTheorySpiral.jl
@@ -182,7 +182,7 @@ function swt_hamiltonian_dipole_spiral!(H::Matrix{ComplexF64}, sswt::SpinWaveThe
         H[i+L, i]   += 2s*(c2[1]-im*c2[5]) + 12s^3*(c4[3]-im*c4[7]) + 32s^5*(c6[5]-im*c6[9])
     end
 
-    @assert diffnorm2(H, H') < 1e-12
+    @assert maxdiff(H, H') < 1e-12
     hermitianpart!(H)
 
     for i in 1:2L

--- a/test/test_entangled_units.jl
+++ b/test/test_entangled_units.jl
@@ -178,3 +178,33 @@ end
 
 # @testitem "Ba3Mn2O8 Dispersion and Golden Test" begin
 # end
+
+@testitem "Entangled Unit Intensity Scaling" begin
+    latvecs = lattice_vectors(1, 1, 2, 90, 90, 90)
+    positions = [[0, 0, 0], [0, 1/2 - 1e-4, 0]]
+    crystal = Crystal(latvecs, positions)
+
+    J  = 1
+    J′ = 0.12
+    J2 = 0.1
+
+    sys = System(crystal, [1 => Moment(s=1/2, g=2)], :SUN; dims=(2,2, 1))
+    set_exchange!(sys, J, Bond(1, 2, [0, 0, 0]))
+    set_exchange!(sys, J′, Bond(1, 2, [0, -1, 0]));
+    set_exchange!(sys, J2, Bond(1, 1, [1, 0, 0]));
+
+    set_field!(sys, [0., 0., 10])
+
+    esys = Sunny.EntangledSystem(sys, [(1, 2)])
+
+    randomize_spins!(esys)
+    minimize_energy!(esys)
+    swt = SpinWaveTheory(esys; measure=ssf_trace(esys;apply_g=false))
+    qs = q_space_path(crystal, [[0, 1, 0], [1/2, 1, 0], [1, 1, 0],[0, 0, 0]], 200)
+    res = intensities_bands(swt, qs)
+
+    @test sum(res.data[:,1])/2 ≈ 1/2
+end
+
+# @testitem "Ba3Mn2O8 Dispersion and Golden Test" begin
+# end

--- a/test/test_entangled_units.jl
+++ b/test/test_entangled_units.jl
@@ -110,7 +110,7 @@ end
 
     # Test that an unsupported reshaping throws an interpretable error
     shape = [1 2 0; 0 1 0; 0 0 1]
-    @test_throws "This reshaping must be performed prior to calling EntangledSystem" reshape_supercell(esys, shape)
+    @test_throws "Given shape incompatible with entangled unit structure. Unit split between crystallographic cells." reshape_supercell(esys, shape)
 
     # Test that a carefully designed reshaping works as expected on an EntangledSystem
     shape = [1 0 0; 2 1 0; 0 0 1]

--- a/test/test_entangled_units.jl
+++ b/test/test_entangled_units.jl
@@ -106,6 +106,16 @@ end
 
     @test all(both -> isapprox(both[1], both[2]; atol=1e-12), zip(ωs_analytical, ωs_numerical))
 
+    # Test the fitting API on a minimal entangled system with a labeled bond.
+    fit_sys = System(crystal, [1 => Moment(s=1/2, g=2), 2 => Moment(s=1/2, g=2)], :SUN; seed=1)
+    set_exchange!(fit_sys, J, Bond(1, 2, [0, 0, 0]), :J => J)
+    fit_esys = Sunny.EntangledSystem(fit_sys, [(1, 2)])
+    loss = make_loss_fn(fit_esys, [:J]) do sys
+        energy(sys)
+    end
+    @test loss([J]) ≈ energy(fit_esys)
+    @test loss([2J]) ≈ 2 * loss([J])
+
     # Test static structure factor is zero (dipolar sector)
     ssf = SampledCorrelationsStatic(esys; measure=ssf_trace(esys))
     add_sample!(ssf, esys)

--- a/test/test_entangled_units.jl
+++ b/test/test_entangled_units.jl
@@ -36,7 +36,7 @@ end
     set_exchange!(sys, J′, Bond(2, 2, [1, 0, 0]))  # Needed because we broke the symmetry equivalence of the two sites
 
     esys = Sunny.EntangledSystem(sys, [(1, 2)])
-    interactions = esys.sys.interactions_union[1]
+    interactions = esys.sys_contracted.interactions_union[1]
 
     # Test on-bond exchange
     onsite_operator = interactions.onsite
@@ -47,7 +47,7 @@ end
 
     # Test external field works as expected
     set_field!(esys, [0, 0, 1])
-    onsite_operator = esys.sys.interactions_union[1].onsite
+    onsite_operator = esys.sys_contracted.interactions_union[1].onsite
     field_offset = 2*(Sl[3] + Su[3]) # 2 for g-factor
     @test onsite_operator ≈ onsite_ref + field_offset 
 
@@ -55,30 +55,30 @@ end
     dipoles = [[0, 1/2, 0], [0, -1/2, 0]] # Dipoles specifying a dimer state
     cs = Sunny.coherent_state_from_dipoles(esys, dipoles, 1)
     set_coherent!(esys, cs, CartesianIndex(1,1,1,1))
-    @test esys.sys_origin.dipoles[1,1,1,1][2] ≈ 1/2
-    @test esys.sys_origin.dipoles[1,1,1,2][2] ≈ -1/2
+    @test esys.sys_uncontracted.dipoles[1,1,1,1][2] ≈ 1/2
+    @test esys.sys_uncontracted.dipoles[1,1,1,2][2] ≈ -1/2
 
     # Test external field works in action
     set_field!(esys, [0, 0, 10])
     randomize_spins!(esys)
     minimize_energy!(esys)
-    @test esys.sys_origin.dipoles[1][3] ≈ -1/2
-    @test esys.sys_origin.dipoles[2][3] ≈ -1/2
+    @test esys.sys_uncontracted.dipoles[1][3] ≈ -1/2
+    @test esys.sys_uncontracted.dipoles[2][3] ≈ -1/2
 
     set_field!(esys, [0, 0, -10])
     randomize_spins!(esys)
     minimize_energy!(esys)
-    @test esys.sys_origin.dipoles[1][3] ≈ 1/2
-    @test esys.sys_origin.dipoles[2][3] ≈ 1/2
+    @test esys.sys_uncontracted.dipoles[1][3] ≈ 1/2
+    @test esys.sys_uncontracted.dipoles[2][3] ≈ 1/2
 
     set_field!(esys, [0, 0, 0])
     randomize_spins!(esys)
     minimize_energy!(esys)
-    @test norm(esys.sys_origin.dipoles[1]) < 1e-10
-    @test norm(esys.sys_origin.dipoles[2]) < 1e-10
+    @test norm(esys.sys_uncontracted.dipoles[1]) < 1e-10
+    @test norm(esys.sys_uncontracted.dipoles[2]) < 1e-10
 
     # Test inter-bond exchange
-    pc = Sunny.as_general_pair_coupling(interactions.pair[1], esys.sys)
+    pc = Sunny.as_general_pair_coupling(interactions.pair[1], esys.sys_contracted)
     Sl1, Sl2 = to_product_space(Sl, Sl)
     Su1, Su2 = to_product_space(Su, Su)
     bond_operator = zeros(ComplexF64, 16, 16)
@@ -151,7 +151,7 @@ end
     # For exact reproducibility, reset the random number seed and use a specific
     # initial condition.
 
-    Random.seed!(esys.sys.rng, 0)
+    Random.seed!(esys.sys_contracted.rng, 0)
     set_coherent!(esys, [0, 1/√2, -1/√2, 0], (1, 1, 1, 1))
 
     esys = repeat_periodically(esys, (8, 1, 1))

--- a/test/test_entangled_units.jl
+++ b/test/test_entangled_units.jl
@@ -17,8 +17,6 @@
     end
 end
 
-# TODO: Add reshapings tests.
-
 # TODO: Add test with magnetic unit cell larger than a single unit (i.e. not q=0
 # ordering).
 
@@ -105,6 +103,33 @@ end
     ωs_numerical = disp[1,:]
 
     @test all(both -> isapprox(both[1], both[2]; atol=1e-12), zip(ωs_analytical, ωs_numerical))
+
+    # Reference intensities calculation for use below
+    swt_bands = SpinWaveTheory(esys; measure=ssf_perp(esys))
+    res = intensities_bands(swt_bands, qs)
+
+    # Test that an unsupported reshaping throws an interpretable error
+    shape = [1 2 0; 0 1 0; 0 0 1]
+    @test_throws "This reshaping must be performed prior to calling EntangledSystem" reshape_supercell(esys, shape)
+
+    # Test that a carefully designed reshaping works as expected on an EntangledSystem
+    shape = [1 0 0; 2 1 0; 0 0 1]
+    esys_sheared = reshape_supercell(esys, shape)
+    swt_bands_sheared = SpinWaveTheory(esys_sheared; measure=ssf_perp(esys_sheared))
+    res_sheared = intensities_bands(swt_bands_sheared, qs)
+    @test res_sheared.disp ≈ res.disp atol=1e-11
+    @test sum(res_sheared.data; dims=1) ≈ sum(res.data; dims=1) atol=1e-11
+
+    # Test that a system can be reshaped first, then entangled
+    sys_sheared = reshape_supercell(sys, shape)
+    esys_sheared = Sunny.EntangledSystem(sys_sheared, [(1, 2)])
+    for unit in Sunny.eachunit(esys_sheared)
+        set_coherent!(esys_sheared, [0, 1/√2, -1/√2, 0], unit)
+    end
+    swt_bands_sheared_alt = SpinWaveTheory(esys_sheared; measure=ssf_perp(esys_sheared))
+    res_sheared_alt = intensities_bands(swt_bands_sheared_alt, qs)
+    @test res_sheared_alt.disp ≈ res.disp atol=1e-11
+    @test sum(res_sheared_alt.data; dims=1) ≈ sum(res.data; dims=1) atol=1e-11
 
     # Test the fitting API on a minimal entangled system with a labeled bond.
     fit_sys = System(crystal, [1 => Moment(s=1/2, g=2), 2 => Moment(s=1/2, g=2)], :SUN; seed=1)

--- a/test/test_tensors.jl
+++ b/test/test_tensors.jl
@@ -13,9 +13,6 @@
     @test kron(A1, B1) * kron(A2, B2) ≈ kron(A1*A2, B1*B2)
     @test kron(A1, A2, B1, B2) ≈ kron(kron(A1, A2), kron(B1, B2))
 
-    # Check transpose
-    @test Sunny.reverse_kron(kron(A1, B1), Ni, Nj) ≈ kron(B1, A1)
-
     # Check factorization: S₁ˣ⊗S₂ˣ + S₁ˣ⊗S₂ʸ == S₁ˣ⊗(S₂ˣ+S₂ʸ)
     B = Si[1] * Sj[1] + Si[1] * Sj[2]
     D = Sunny.svd_tensor_expansion(B, Ni, Nj)


### PR DESCRIPTION
This PR now includes many improvements to entangled units, fixing a set of bugs identified by Allen Scheie and Wolfgang Simeth.

- `make_loss_fn` supports EntangledUnits with simple wrappers.
- Fixes to intensity scale and RLU system for spin wave calculations with entangled units.
- Improved numerical robustness in tensor factorization, resolving occasional SVD errors.
- More informative error when a particular reshaping is not supported (would split an entangled unit across the periodic boundary).
- Additional tests to prevent regressions.