### PR TITLE
Set extract_parts to false in entangled unit system construction

### DIFF
--- a/src/EntangledUnits/EntangledUnits.jl
+++ b/src/EntangledUnits/EntangledUnits.jl
@@ -326,7 +326,7 @@ function entangle_system(sys::System{M}, units) where M
     for bond in exemplars
         relevant_interactions = filter(data -> data[1] == bond, new_pair_data)
         bond_operator = sum(data[2] for data in relevant_interactions)
-        set_pair_coupling!(sys_contracted, bond_operator, bond)
+        set_pair_coupling!(sys_contracted, bond_operator, bond; extract_parts=false)
     end
 
     return (; sys_contracted, contraction_info)


### PR DESCRIPTION
All interactions between entangle units are stored in "general" tensor product form $\sum_i A_i \otimes B_i$. Setting `extract_parts=true` was removing certain parts from this effective interaction that got lost downstream.