### PR TITLE
Ewald Powder Speedup

### DIFF
--- a/benchmarks/ewald_powder_cpu.jl
+++ b/benchmarks/ewald_powder_cpu.jl
@@ -1,0 +1,57 @@
+#!/usr/bin/env julia
+
+# Run from the repository root as:
+#   julia --project=. benchmarks/ewald_powder_cpu.jl [nq]
+
+using LinearAlgebra
+using Printf
+using Random
+using Sunny
+
+function fibonacci_sphere(n)
+    ϕ = (1 + √5) / 2
+    return [begin
+        z = 1 - 2(i - 0.5) / n
+        r = √max(0, 1 - z^2)
+        θ = 2π * (i / ϕ)
+        Sunny.Vec3(r*cos(θ), r*sin(θ), z)
+    end for i in 1:n]
+end
+
+function synthetic_dipolar_swt()
+    latvecs = lattice_vectors(10.19, 10.19, 10.19, 90, 90, 90)
+    cryst = Crystal(latvecs, [[0, 0, 0]], 227)
+    sys = System(cryst, [1 => Moment(s=7/2, g=2)], :dipole)
+    sys = reshape_supercell(sys, primitive_cell(cryst))
+    enable_dipole_dipole!(sys, Units(:K, :angstrom).vacuum_permeability)
+
+    Random.seed!(1)
+    randomize_spins!(sys)
+    return SpinWaveTheory(sys; measure=nothing)
+end
+
+function benchmark_ewald_hamiltonian(; nq=10_000, radius=0.8)
+    swt = synthetic_dipolar_swt()
+    qs = radius .* fibonacci_sphere(nq)
+    L = Sunny.nbands(swt)
+    Hs = [zeros(ComplexF64, 2L, 2L) for _ in 1:Threads.maxthreadid()]
+    checksums = zeros(Float64, Threads.maxthreadid())
+
+    for q in qs[1:min(end, 32)]
+        Sunny.swt_hamiltonian_dipole!(Hs[1], swt, q)
+    end
+
+    t = @elapsed Threads.@threads for iq in eachindex(qs)
+        tid = Threads.threadid()
+        H = Hs[tid]
+        Sunny.swt_hamiltonian_dipole!(H, swt, qs[iq])
+        checksums[tid] += real(tr(H))
+    end
+
+    @printf("synthetic_ewald_hamiltonian nq=%d threads=%d maxthreadid=%d\n",
+            nq, Threads.nthreads(), Threads.maxthreadid())
+    @printf("total %.6f per_q %.6f checksum %.12g\n", t, t/nq, sum(checksums))
+end
+
+nq = isempty(ARGS) ? 10_000 : parse(Int, ARGS[1])
+benchmark_ewald_hamiltonian(; nq)

--- a/src/SpinWaveTheory/DispersionAndIntensities.jl
+++ b/src/SpinWaveTheory/DispersionAndIntensities.jl
@@ -164,20 +164,27 @@ function intensities_bands(swt::SpinWaveTheory, qpts; kT=0, with_negative=false)
     # Number of wavevectors
     Nq = length(qpts.qs)
 
-    # Temporary storage for pair correlations
+    # Per-thread preallocation
     Nobs = num_observables(measure)
     Ncorr = num_correlations(measure)
-    corr = zeros(ComplexF64, Ncorr)
-
-    # Preallocation
-    T = zeros(ComplexF64, 2L, 2L)
-    H = zeros(ComplexF64, 2L, 2L)
-    u = zeros(ComplexF64, 2L, Nobs)
-    Avec = zeros(ComplexF64, Nobs)
+    nts = Threads.maxthreadid()
+    Ts = [zeros(ComplexF64, 2L, 2L) for _ in 1:nts]
+    Hs = [zeros(ComplexF64, 2L, 2L) for _ in 1:nts]
+    us = [zeros(ComplexF64, 2L, Nobs) for _ in 1:nts]
+    Avecs = [zeros(ComplexF64, Nobs) for _ in 1:nts]
+    corrs = [zeros(ComplexF64, Ncorr) for _ in 1:nts]
     disp = zeros(Float64, L, Nq)
     intensity = zeros(eltype(measure), L, Nq)
 
-    for (iq, q) in enumerate(qpts.qs)
+    Threads.@threads for iq in eachindex(qpts.qs)
+        tid = Threads.threadid()
+        T = Ts[tid]
+        H = Hs[tid]
+        u = us[tid]
+        Avec = Avecs[tid]
+        corr = corrs[tid]
+
+        q = qpts.qs[iq]
         q_reshaped = to_reshaped_rlu(sys, q)
         q_global = cryst.recipvecs * q
         view(disp, :, iq) .= view(excitations!(T, H, swt, q), 1:L)

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -104,13 +104,14 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
         (; ewald_q_plan, ewald_local_transform, ewald_J0_diag, ewald_buffers) = data
         @assert !isnothing(ewald_q_plan)
         buffer = ewald_buffers[Threads.threadid()]
+        sizehint!(buffer.reciprocal_terms, length(ewald_q_plan.reciprocal_ms))
         reciprocal = dipole_ewald_reciprocal_terms!(buffer.reciprocal_terms, ewald_q_plan, q_reshaped)
         real_phases = dipole_ewald_real_phases!(buffer.real_phases, ewald_q_plan, q_reshaped)
 
         nrecip = length(reciprocal.terms)
         resize_dipole_ewald_hamiltonian_buffer!(buffer, L, nrecip)
         (; site_k, site_phase, site_phase_conj) = buffer
-        for (iterm, term) in enumerate(reciprocal.terms)
+        @inbounds for (iterm, term) in enumerate(reciprocal.terms)
             for i in 1:L
                 site_k[i, iterm] = ewald_local_transform[i]' * term.k
                 phase = cis(-term.k⋅ewald_q_plan.Δrs[1, 1, i])
@@ -130,7 +131,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
             J22 = J[2, 2]
             J12 = J[1, 2]
             J21 = J[2, 1]
-            for (iterm, term) in enumerate(reciprocal.terms)
+            @inbounds for (iterm, term) in enumerate(reciprocal.terms)
                 vi = site_k[i, iterm]
                 vj = site_k[j, iterm]
                 coeff = (μ0_μB² * term.scale / 2) * site_phase[j, iterm] * site_phase_conj[i, iterm]
@@ -163,7 +164,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
 end
 
 function resize_dipole_ewald_hamiltonian_buffer!(buffer::DipoleEwaldHamiltonianBuffer, L, nrecip)
-    if size(buffer.site_k) != (L, nrecip)
+    if size(buffer.site_k, 1) != L || size(buffer.site_k, 2) < nrecip
         buffer.site_k = Array{Vec3}(undef, L, nrecip)
         buffer.site_phase = Array{ComplexF64}(undef, L, nrecip)
         buffer.site_phase_conj = Array{ComplexF64}(undef, L, nrecip)

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -101,32 +101,45 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
     # Add long-range dipole-dipole
     if !isnothing(sys.ewald)
         (; μ0_μB²) = sys.ewald
-        (; ewald_q_plan, ewald_local_transform, ewald_J0_diag) = data
+        (; ewald_q_plan, ewald_local_transform, ewald_J0_diag, ewald_buffers) = data
         @assert !isnothing(ewald_q_plan)
-        reciprocal = dipole_ewald_reciprocal_terms(ewald_q_plan, q_reshaped)
+        buffer = ewald_buffers[Threads.threadid()]
+        reciprocal = dipole_ewald_reciprocal_terms!(buffer.reciprocal_terms, ewald_q_plan, q_reshaped)
 
-        # Loop over sublattice pairs
+        nrecip = length(reciprocal.terms)
+        resize_dipole_ewald_hamiltonian_buffer!(buffer, L, nrecip)
+        (; site_k, site_phase, site_phase_conj) = buffer
+        for (iterm, term) in enumerate(reciprocal.terms)
+            for i in 1:L
+                site_k[i, iterm] = ewald_local_transform[i]' * term.k
+                phase = cis(-term.k⋅ewald_q_plan.Δrs[1, 1, i])
+                site_phase[i, iterm] = phase
+                site_phase_conj[i, iterm] = conj(phase)
+            end
+        end
+
         for i in 1:L, j in 1:L
             # An ordered pair of magnetic moments contribute (μᵢ A μⱼ)/2 to the
             # energy. A symmetric contribution will appear for the bond reversal
             # (i, j) → (j, i).  Note that μ = -μB g S.
-            Aqij = μ0_μB² * dipole_ewald_pair_at(ewald_q_plan, q_reshaped, reciprocal, 1, i, j)
+            Aqij = μ0_μB² * dipole_ewald_nonreciprocal_pair_at(ewald_q_plan, q_reshaped, reciprocal.demag_term, 1, i, j)
             J = ewald_local_transform[i]' * Aqij * ewald_local_transform[j] / 2
 
-            # Interactions for Jˣˣ, Jʸʸ, Jˣʸ, and Jʸˣ at wavevector q.
-            Q⁻ = 0.5 * (J[1, 1] + J[2, 2] - im*(J[1, 2] - J[2, 1]))
-            Q⁺ = 0.5 * (J[1, 1] + J[2, 2] + im*(J[1, 2] - J[2, 1]))
-            H11[i, j] += Q⁻
-            H11[j, i] += conj(Q⁻)
-            H22[i, j] += Q⁺
-            H22[j, i] += conj(Q⁺)
+            J11 = J[1, 1]
+            J22 = J[2, 2]
+            J12 = J[1, 2]
+            J21 = J[2, 1]
+            for (iterm, term) in enumerate(reciprocal.terms)
+                vi = site_k[i, iterm]
+                vj = site_k[j, iterm]
+                coeff = (μ0_μB² * term.scale / 2) * site_phase[j, iterm] * site_phase_conj[i, iterm]
+                J11 += coeff * vi[1] * vj[1]
+                J22 += coeff * vi[2] * vj[2]
+                J12 += coeff * vi[1] * vj[2]
+                J21 += coeff * vi[2] * vj[1]
+            end
 
-            P⁻ = 0.5 * (J[1, 1] - J[2, 2] - im*(J[1, 2] + J[2, 1]))
-            P⁺ = 0.5 * (J[1, 1] - J[2, 2] + im*(J[1, 2] + J[2, 1]))
-            H21[i, j] += P⁻
-            H21[j, i] += conj(P⁺)
-            H12[i, j] += P⁺
-            H12[j, i] += conj(P⁻)
+            add_dipole_J_to_hamiltonian!(H11, H12, H21, H22, i, j, J11, J22, J12, J21)
         end
 
         # Interactions for Jᶻᶻ at wavevector (0,0,0).
@@ -146,6 +159,32 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
     for i in 1:2L
         H[i, i] += swt.regularization
     end
+end
+
+function resize_dipole_ewald_hamiltonian_buffer!(buffer::DipoleEwaldHamiltonianBuffer, L, nrecip)
+    if size(buffer.site_k) != (L, nrecip)
+        buffer.site_k = Array{Vec3}(undef, L, nrecip)
+        buffer.site_phase = Array{ComplexF64}(undef, L, nrecip)
+        buffer.site_phase_conj = Array{ComplexF64}(undef, L, nrecip)
+    end
+    return buffer
+end
+
+@inline function add_dipole_J_to_hamiltonian!(H11, H12, H21, H22, i, j, J11, J22, J12, J21)
+    # Interactions for Jˣˣ, Jʸʸ, Jˣʸ, and Jʸˣ at wavevector q.
+    Q⁻ = 0.5 * (J11 + J22 - im*(J12 - J21))
+    Q⁺ = 0.5 * (J11 + J22 + im*(J12 - J21))
+    H11[i, j] += Q⁻
+    H11[j, i] += conj(Q⁻)
+    H22[i, j] += Q⁺
+    H22[j, i] += conj(Q⁺)
+
+    P⁻ = 0.5 * (J11 - J22 - im*(J12 + J21))
+    P⁺ = 0.5 * (J11 - J22 + im*(J12 + J21))
+    H21[i, j] += P⁻
+    H21[j, i] += conj(P⁺)
+    H12[i, j] += P⁺
+    H12[j, i] += conj(P⁻)
 end
 
 

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -100,7 +100,8 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
 
     # Add long-range dipole-dipole
     if !isnothing(sys.ewald)
-        (; demag, μ0_μB², A) = sys.ewald
+        (; μ0_μB², A) = sys.ewald
+        (; ewald_q_plan) = data
         Rs = local_rotations
 
         # Interaction matrix for wavevector (0,0,0). It could be recalculated as:
@@ -108,7 +109,8 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
         A0 = reshape(A, L, L)
 
         # Interaction matrix for wavevector q
-        Aq = precompute_dipole_ewald_at_wavevector(sys.crystal, (1,1,1), demag, q_reshaped) * μ0_μB²
+        @assert !isnothing(ewald_q_plan)
+        Aq = precompute_dipole_ewald_at_wavevector(ewald_q_plan, q_reshaped) * μ0_μB²
         Aq = reshape(Aq, L, L)
 
         # Loop over sublattice pairs

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -105,6 +105,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
         @assert !isnothing(ewald_q_plan)
         buffer = ewald_buffers[Threads.threadid()]
         reciprocal = dipole_ewald_reciprocal_terms!(buffer.reciprocal_terms, ewald_q_plan, q_reshaped)
+        real_phases = dipole_ewald_real_phases!(buffer.real_phases, ewald_q_plan, q_reshaped)
 
         nrecip = length(reciprocal.terms)
         resize_dipole_ewald_hamiltonian_buffer!(buffer, L, nrecip)
@@ -122,7 +123,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
             # An ordered pair of magnetic moments contribute (μᵢ A μⱼ)/2 to the
             # energy. A symmetric contribution will appear for the bond reversal
             # (i, j) → (j, i).  Note that μ = -μB g S.
-            Aqij = μ0_μB² * dipole_ewald_nonreciprocal_pair_at(ewald_q_plan, q_reshaped, reciprocal.demag_term, 1, i, j)
+            Aqij = μ0_μB² * dipole_ewald_nonreciprocal_pair_at(ewald_q_plan, real_phases, reciprocal.demag_term, 1, i, j)
             J = ewald_local_transform[i]' * Aqij * ewald_local_transform[j] / 2
 
             J11 = J[1, 1]

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -100,31 +100,18 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
 
     # Add long-range dipole-dipole
     if !isnothing(sys.ewald)
-        (; μ0_μB², A) = sys.ewald
-        (; ewald_q_plan) = data
-        Rs = local_rotations
-
-        # Interaction matrix for wavevector (0,0,0). It could be recalculated as:
-        # precompute_dipole_ewald(sys.crystal, (1,1,1), demag) * μ0_μB²
-        A0 = reshape(A, L, L)
-
-        # Interaction matrix for wavevector q
+        (; μ0_μB²) = sys.ewald
+        (; ewald_q_plan, ewald_local_transform, ewald_J0_diag) = data
         @assert !isnothing(ewald_q_plan)
-        Aq = precompute_dipole_ewald_at_wavevector(ewald_q_plan, q_reshaped) * μ0_μB²
-        Aq = reshape(Aq, L, L)
+        reciprocal = dipole_ewald_reciprocal_terms(ewald_q_plan, q_reshaped)
 
         # Loop over sublattice pairs
         for i in 1:L, j in 1:L
             # An ordered pair of magnetic moments contribute (μᵢ A μⱼ)/2 to the
             # energy. A symmetric contribution will appear for the bond reversal
             # (i, j) → (j, i).  Note that μ = -μB g S.
-            J = gs[i]' * Aq[i, j] * gs[j] / 2
-            J0 = gs[i]' * A0[i, j] * gs[j] / 2
-
-            # Perform same transformation as appears in usual bilinear exchange.
-            # Rⱼ denotes a rotation from ẑ to the ground state dipole Sⱼ.
-            J = sqrtS[i]*sqrtS[j] * Rs[i]' * J * Rs[j]
-            J0 = sqrtS[i]*sqrtS[j] * Rs[i]' * J0 * Rs[j]
+            Aqij = μ0_μB² * dipole_ewald_pair_at(ewald_q_plan, q_reshaped, reciprocal, 1, i, j)
+            J = ewald_local_transform[i]' * Aqij * ewald_local_transform[j] / 2
 
             # Interactions for Jˣˣ, Jʸʸ, Jˣʸ, and Jʸˣ at wavevector q.
             Q⁻ = 0.5 * (J[1, 1] + J[2, 2] - im*(J[1, 2] - J[2, 1]))
@@ -140,12 +127,12 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
             H21[j, i] += conj(P⁺)
             H12[i, j] += P⁺
             H12[j, i] += conj(P⁻)
+        end
 
-            # Interactions for Jᶻᶻ at wavevector (0,0,0).
-            H11[i, i] -= J0[3, 3]
-            H11[j, j] -= J0[3, 3]
-            H22[i, i] -= J0[3, 3]
-            H22[j, j] -= J0[3, 3]
+        # Interactions for Jᶻᶻ at wavevector (0,0,0).
+        for i in 1:L
+            H11[i, i] -= ewald_J0_diag[i]
+            H22[i, i] -= ewald_J0_diag[i]
         end
     end
 

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -106,7 +106,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
         @assert !isnothing(ewald_q_plan)
         buffer = ewald_buffers[Threads.threadid()]
         sizehint!(buffer.reciprocal_terms, length(ewald_q_plan.reciprocal_ms))
-        reciprocal = dipole_ewald_reciprocal_terms!(buffer.reciprocal_terms, ewald_q_plan, q_reshaped)
+        reciprocal = dipole_ewald_reciprocal_kernel_terms!(buffer.reciprocal_terms, ewald_q_plan, q_reshaped)
         real_phases = dipole_ewald_real_phases!(buffer.real_phases, ewald_q_plan, q_reshaped)
         has_demag = !iszero(reciprocal.demag_term)
 

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -101,12 +101,14 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
     # Add long-range dipole-dipole
     if !isnothing(sys.ewald)
         (; μ0_μB²) = sys.ewald
-        (; ewald_q_plan, ewald_local_transform, ewald_J0_diag, ewald_buffers) = data
+        (; ewald_q_plan, ewald_local_transform, ewald_J0_diag, ewald_buffers,
+           ewald_real_local, ewald_self_local, ewald_demag_local) = data
         @assert !isnothing(ewald_q_plan)
         buffer = ewald_buffers[Threads.threadid()]
         sizehint!(buffer.reciprocal_terms, length(ewald_q_plan.reciprocal_ms))
         reciprocal = dipole_ewald_reciprocal_terms!(buffer.reciprocal_terms, ewald_q_plan, q_reshaped)
         real_phases = dipole_ewald_real_phases!(buffer.real_phases, ewald_q_plan, q_reshaped)
+        has_demag = !iszero(reciprocal.demag_term)
 
         nrecip = length(reciprocal.terms)
         resize_dipole_ewald_hamiltonian_buffer!(buffer, L, nrecip)
@@ -124,13 +126,22 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
             # An ordered pair of magnetic moments contribute (μᵢ A μⱼ)/2 to the
             # energy. A symmetric contribution will appear for the bond reversal
             # (i, j) → (j, i).  Note that μ = -μB g S.
-            Aqij = μ0_μB² * dipole_ewald_nonreciprocal_pair_at(ewald_q_plan, real_phases, reciprocal.demag_term, 1, i, j)
-            J = ewald_local_transform[i]' * Aqij * ewald_local_transform[j] / 2
+            J = ewald_self_local[i, j]
+            has_demag && (J += ewald_demag_local[i, j])
 
-            J11 = J[1, 1]
-            J22 = J[2, 2]
-            J12 = J[1, 2]
-            J21 = J[2, 1]
+            J11 = ComplexF64(J[1])
+            J22 = ComplexF64(J[2])
+            J12 = ComplexF64(J[3])
+            J21 = ComplexF64(J[4])
+            @inbounds for term in ewald_real_local[i, j]
+                phase = real_phases[term.phase_index]
+                c = term.components
+                J11 += phase * c[1]
+                J22 += phase * c[2]
+                J12 += phase * c[3]
+                J21 += phase * c[4]
+            end
+
             @inbounds for (iterm, term) in enumerate(reciprocal.terms)
                 vi = site_k[i, iterm]
                 vj = site_k[j, iterm]

--- a/src/SpinWaveTheory/HamiltonianDipole.jl
+++ b/src/SpinWaveTheory/HamiltonianDipole.jl
@@ -106,7 +106,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
         @assert !isnothing(ewald_q_plan)
         buffer = ewald_buffers[Threads.threadid()]
         sizehint!(buffer.reciprocal_terms, length(ewald_q_plan.reciprocal_ms))
-        reciprocal = dipole_ewald_reciprocal_kernel_terms!(buffer.reciprocal_terms, ewald_q_plan, q_reshaped)
+        reciprocal = dipole_ewald_reciprocal_kernel_terms!(buffer.reciprocal_terms, ewald_q_plan, q_reshaped, μ0_μB² / 2)
         real_phases = dipole_ewald_real_phases!(buffer.real_phases, ewald_q_plan, q_reshaped)
         has_demag = !iszero(reciprocal.demag_term)
 
@@ -116,7 +116,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
         @inbounds for (iterm, term) in enumerate(reciprocal.terms)
             for i in 1:L
                 site_k[i, iterm] = ewald_local_transform[i]' * term.k
-                phase = cis(-term.k⋅ewald_q_plan.Δrs[1, 1, i])
+                phase = cis(-term.k⋅ewald_q_plan.site_Δrs[i])
                 site_phase[i, iterm] = phase
                 site_phase_conj[i, iterm] = conj(phase)
             end
@@ -145,7 +145,7 @@ function swt_hamiltonian_dipole!(H::Matrix{ComplexF64}, swt::SpinWaveTheory, q_r
             @inbounds for (iterm, term) in enumerate(reciprocal.terms)
                 vi = site_k[i, iterm]
                 vj = site_k[j, iterm]
-                coeff = (μ0_μB² * term.scale / 2) * site_phase[j, iterm] * site_phase_conj[i, iterm]
+                coeff = term.scale * site_phase[j, iterm] * site_phase_conj[i, iterm]
                 J11 += coeff * vi[1] * vj[1]
                 J22 += coeff * vi[2] * vj[2]
                 J12 += coeff * vi[1] * vj[2]

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -1,3 +1,6 @@
+# Per-thread scratch for q-dependent Ewald LSWT assembly. These buffers avoid
+# allocation in powder calculations, where many q points are evaluated in
+# parallel.
 mutable struct DipoleEwaldHamiltonianBuffer
     reciprocal_terms :: Vector{DipoleEwaldReciprocalKernelTerm}
     real_phases      :: Vector{ComplexF64}

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -3,6 +3,7 @@ struct SWTDataDipole
     observables           :: Array{Vec3, 2}           # Observables rotated to local frame (nobs × nsites)
     stevens_coefs         :: Vector{StevensExpansion} # Rotated onsite coupling as Steven expansion
     sqrtS                 :: Vector{Float64}          # Square root of spin magnitudes
+    ewald_q_plan          :: Union{Nothing, DipoleEwaldQPlan}
 end
 
 
@@ -283,7 +284,9 @@ function swt_data!(sys::System{0}, measure)
     # Square root of spin magnitudes
     sqrtS = sqrt.(vec(sys.κs))
 
-    return SWTDataDipole(Rs, obs_localized, cs, sqrtS)
+    ewald_q_plan = isnothing(sys.ewald) ? nothing : DipoleEwaldQPlan(sys.crystal, (1, 1, 1), sys.ewald.demag)
+
+    return SWTDataDipole(Rs, obs_localized, cs, sqrtS, ewald_q_plan)
 end
 
 # Fourier prefactor for observable μ acting on a flattened unit i of swt.sys,

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -1,3 +1,17 @@
+mutable struct DipoleEwaldHamiltonianBuffer
+    reciprocal_terms :: Vector{DipoleEwaldReciprocalTerm}
+    site_k           :: Matrix{Vec3}
+    site_phase       :: Matrix{ComplexF64}
+    site_phase_conj  :: Matrix{ComplexF64}
+end
+
+function DipoleEwaldHamiltonianBuffer()
+    return DipoleEwaldHamiltonianBuffer(DipoleEwaldReciprocalTerm[],
+                                        Array{Vec3}(undef, 0, 0),
+                                        Array{ComplexF64}(undef, 0, 0),
+                                        Array{ComplexF64}(undef, 0, 0))
+end
+
 struct SWTDataDipole
     local_rotations       :: Vector{Mat3}             # Rotations from global to quantization frame
     observables           :: Array{Vec3, 2}           # Observables rotated to local frame (nobs × nsites)
@@ -6,6 +20,7 @@ struct SWTDataDipole
     ewald_q_plan          :: Union{Nothing, DipoleEwaldQPlan}
     ewald_local_transform :: Vector{Mat3}
     ewald_J0_diag         :: Vector{Float64}
+    ewald_buffers         :: Vector{DipoleEwaldHamiltonianBuffer}
 end
 
 
@@ -289,9 +304,11 @@ function swt_data!(sys::System{0}, measure)
     ewald_q_plan = nothing
     ewald_local_transform = Mat3[]
     ewald_J0_diag = Float64[]
+    ewald_buffers = DipoleEwaldHamiltonianBuffer[]
     if !isnothing(sys.ewald)
         ewald_q_plan = DipoleEwaldQPlan(sys.crystal, (1, 1, 1), sys.ewald.demag)
         ewald_local_transform = [sqrtS[i] * sys.gs[i] * Rs[i] for i in 1:Na]
+        ewald_buffers = [DipoleEwaldHamiltonianBuffer() for _ in 1:Threads.maxthreadid()]
 
         A0 = reshape(sys.ewald.A, Na, Na)
         ewald_J0_diag = zeros(Float64, Na)
@@ -304,7 +321,7 @@ function swt_data!(sys::System{0}, measure)
     end
 
     return SWTDataDipole(Rs, obs_localized, cs, sqrtS, ewald_q_plan,
-                         ewald_local_transform, ewald_J0_diag)
+                         ewald_local_transform, ewald_J0_diag, ewald_buffers)
 end
 
 # Fourier prefactor for observable μ acting on a flattened unit i of swt.sys,

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -14,6 +14,11 @@ function DipoleEwaldHamiltonianBuffer()
                                         Array{ComplexF64}(undef, 0, 0))
 end
 
+struct DipoleEwaldLocalTerm
+    phase_index :: Int
+    components  :: SVector{4, Float64}
+end
+
 struct SWTDataDipole
     local_rotations       :: Vector{Mat3}             # Rotations from global to quantization frame
     observables           :: Array{Vec3, 2}           # Observables rotated to local frame (nobs × nsites)
@@ -23,6 +28,9 @@ struct SWTDataDipole
     ewald_local_transform :: Vector{Mat3}
     ewald_J0_diag         :: Vector{Float64}
     ewald_buffers         :: Vector{DipoleEwaldHamiltonianBuffer}
+    ewald_real_local      :: Array{Vector{DipoleEwaldLocalTerm}, 2}
+    ewald_self_local      :: Matrix{SVector{4, Float64}}
+    ewald_demag_local     :: Matrix{SVector{4, Float64}}
 end
 
 
@@ -307,10 +315,29 @@ function swt_data!(sys::System{0}, measure)
     ewald_local_transform = Mat3[]
     ewald_J0_diag = Float64[]
     ewald_buffers = DipoleEwaldHamiltonianBuffer[]
+    ewald_real_local = Array{Vector{DipoleEwaldLocalTerm}, 2}(undef, 0, 0)
+    ewald_self_local = Array{SVector{4, Float64}}(undef, 0, 0)
+    ewald_demag_local = Array{SVector{4, Float64}}(undef, 0, 0)
     if !isnothing(sys.ewald)
+        μ0_μB² = sys.ewald.μ0_μB²
         ewald_q_plan = DipoleEwaldQPlan(sys.crystal, (1, 1, 1), sys.ewald.demag)
         ewald_local_transform = [sqrtS[i] * sys.gs[i] * Rs[i] for i in 1:Na]
         ewald_buffers = [DipoleEwaldHamiltonianBuffer() for _ in 1:Threads.maxthreadid()]
+
+        ewald_real_local = Array{Vector{DipoleEwaldLocalTerm}, 2}(undef, Na, Na)
+        ewald_self_local = zeros(SVector{4, Float64}, Na, Na)
+        ewald_demag_local = Array{SVector{4, Float64}}(undef, Na, Na)
+        for i in 1:Na, j in 1:Na
+            Ti = ewald_local_transform[i]
+            Tj = ewald_local_transform[j]
+            ewald_real_local[i, j] =
+                [DipoleEwaldLocalTerm(term.phase_index, dipole_ewald_local_components(Ti, term.A, Tj, μ0_μB²/2))
+                 for term in ewald_q_plan.real_terms[1, i, j]]
+            if iszero(ewald_q_plan.Δrs[1, i, j])
+                ewald_self_local[i, j] = dipole_ewald_local_components(Ti, ewald_q_plan.self_energy, Tj, μ0_μB²/2)
+            end
+            ewald_demag_local[i, j] = dipole_ewald_local_components(Ti, ewald_q_plan.demag / ewald_q_plan.V, Tj, μ0_μB²/2)
+        end
 
         A0 = reshape(sys.ewald.A, Na, Na)
         ewald_J0_diag = zeros(Float64, Na)
@@ -323,7 +350,13 @@ function swt_data!(sys::System{0}, measure)
     end
 
     return SWTDataDipole(Rs, obs_localized, cs, sqrtS, ewald_q_plan,
-                         ewald_local_transform, ewald_J0_diag, ewald_buffers)
+                         ewald_local_transform, ewald_J0_diag, ewald_buffers,
+                         ewald_real_local, ewald_self_local, ewald_demag_local)
+end
+
+function dipole_ewald_local_components(Ti::Mat3, A::Mat3, Tj::Mat3, scale)
+    J = scale * (Ti' * A * Tj)
+    return SVector{4, Float64}(J[1, 1], J[2, 2], J[1, 2], J[2, 1])
 end
 
 # Fourier prefactor for observable μ acting on a flattened unit i of swt.sys,

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -4,6 +4,8 @@ struct SWTDataDipole
     stevens_coefs         :: Vector{StevensExpansion} # Rotated onsite coupling as Steven expansion
     sqrtS                 :: Vector{Float64}          # Square root of spin magnitudes
     ewald_q_plan          :: Union{Nothing, DipoleEwaldQPlan}
+    ewald_local_transform :: Vector{Mat3}
+    ewald_J0_diag         :: Vector{Float64}
 end
 
 
@@ -284,9 +286,25 @@ function swt_data!(sys::System{0}, measure)
     # Square root of spin magnitudes
     sqrtS = sqrt.(vec(sys.κs))
 
-    ewald_q_plan = isnothing(sys.ewald) ? nothing : DipoleEwaldQPlan(sys.crystal, (1, 1, 1), sys.ewald.demag)
+    ewald_q_plan = nothing
+    ewald_local_transform = Mat3[]
+    ewald_J0_diag = Float64[]
+    if !isnothing(sys.ewald)
+        ewald_q_plan = DipoleEwaldQPlan(sys.crystal, (1, 1, 1), sys.ewald.demag)
+        ewald_local_transform = [sqrtS[i] * sys.gs[i] * Rs[i] for i in 1:Na]
 
-    return SWTDataDipole(Rs, obs_localized, cs, sqrtS, ewald_q_plan)
+        A0 = reshape(sys.ewald.A, Na, Na)
+        ewald_J0_diag = zeros(Float64, Na)
+        for i in 1:Na, j in 1:Na
+            J0 = ewald_local_transform[i]' * A0[i, j] * ewald_local_transform[j] / 2
+            J0zz = real(J0[3, 3])
+            ewald_J0_diag[i] += J0zz
+            ewald_J0_diag[j] += J0zz
+        end
+    end
+
+    return SWTDataDipole(Rs, obs_localized, cs, sqrtS, ewald_q_plan,
+                         ewald_local_transform, ewald_J0_diag)
 end
 
 # Fourier prefactor for observable μ acting on a flattened unit i of swt.sys,

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -1,5 +1,5 @@
 mutable struct DipoleEwaldHamiltonianBuffer
-    reciprocal_terms :: Vector{DipoleEwaldReciprocalTerm}
+    reciprocal_terms :: Vector{DipoleEwaldReciprocalKernelTerm}
     real_phases      :: Vector{ComplexF64}
     site_k           :: Matrix{Vec3}
     site_phase       :: Matrix{ComplexF64}
@@ -7,7 +7,7 @@ mutable struct DipoleEwaldHamiltonianBuffer
 end
 
 function DipoleEwaldHamiltonianBuffer()
-    return DipoleEwaldHamiltonianBuffer(DipoleEwaldReciprocalTerm[],
+    return DipoleEwaldHamiltonianBuffer(DipoleEwaldReciprocalKernelTerm[],
                                         ComplexF64[],
                                         Array{Vec3}(undef, 0, 0),
                                         Array{ComplexF64}(undef, 0, 0),

--- a/src/SpinWaveTheory/SpinWaveTheory.jl
+++ b/src/SpinWaveTheory/SpinWaveTheory.jl
@@ -1,5 +1,6 @@
 mutable struct DipoleEwaldHamiltonianBuffer
     reciprocal_terms :: Vector{DipoleEwaldReciprocalTerm}
+    real_phases      :: Vector{ComplexF64}
     site_k           :: Matrix{Vec3}
     site_phase       :: Matrix{ComplexF64}
     site_phase_conj  :: Matrix{ComplexF64}
@@ -7,6 +8,7 @@ end
 
 function DipoleEwaldHamiltonianBuffer()
     return DipoleEwaldHamiltonianBuffer(DipoleEwaldReciprocalTerm[],
+                                        ComplexF64[],
                                         Array{Vec3}(undef, 0, 0),
                                         Array{ComplexF64}(undef, 0, 0),
                                         Array{ComplexF64}(undef, 0, 0))

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -48,6 +48,11 @@ struct DipoleEwaldRealTerm
     A :: Mat3
 end
 
+struct DipoleEwaldReciprocalTerm
+    k :: Vec3
+    A :: Mat3
+end
+
 struct DipoleEwaldQPlan
     dims          :: NTuple{3, Int}
     demag         :: Mat3
@@ -149,8 +154,9 @@ function precompute_dipole_ewald_at_wavevector!(A::Array{CMat3, 5}, plan::Dipole
     na = size(Δrs, 2)
     size(A)[4:5] == (na, na) || error("Ewald output atom dimensions do not match plan")
 
+    reciprocal = dipole_ewald_reciprocal_terms(plan, q_reshaped)
     for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
-        A[cell, i, j] = dipole_ewald_pair_at(plan, q_reshaped, icell, i, j)
+        A[cell, i, j] = dipole_ewald_pair_at(plan, q_reshaped, reciprocal, icell, i, j)
     end
 
     return A
@@ -170,8 +176,9 @@ function precompute_dipole_ewald_at_wavevectors!(A::Array{CMat3, 6}, plan::Dipol
 
     Threads.@threads for iq in eachindex(qs)
         q = qs[iq]
+        reciprocal = dipole_ewald_reciprocal_terms(plan, q)
         for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
-            A[cell, i, j, iq] = dipole_ewald_pair_at(plan, q, icell, i, j)
+            A[cell, i, j, iq] = dipole_ewald_pair_at(plan, q, reciprocal, icell, i, j)
         end
     end
 
@@ -179,13 +186,13 @@ function precompute_dipole_ewald_at_wavevectors!(A::Array{CMat3, 6}, plan::Dipol
 end
 
 function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, icell, i, j)
-    (; demag, recipvecs, V, σ, kmax², Δrs, real_terms, reciprocal_ms, self_energy) = plan
-    acc = zero(CMat3)
-    Δr = Δrs[icell, i, j]
+    return dipole_ewald_pair_at(plan, q_reshaped, dipole_ewald_reciprocal_terms(plan, q_reshaped), icell, i, j)
+end
 
-    for term in real_terms[icell, i, j]
-        acc += cis(2π * dot(q_reshaped, term.n)) * term.A
-    end
+function dipole_ewald_reciprocal_terms(plan::DipoleEwaldQPlan, q_reshaped::Vec3)
+    (; demag, recipvecs, V, σ, kmax², reciprocal_ms) = plan
+    terms = DipoleEwaldReciprocalTerm[]
+    demag_term = zero(Mat3)
 
     ϵ² = 1e-16
     q_shift = q_reshaped - round.(q_reshaped)
@@ -193,11 +200,28 @@ function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, icell, i
         k = recipvecs * (m + q_shift)
         k² = k⋅k
         if k² <= ϵ²
-            acc += demag / V
+            demag_term += demag / V
         elseif k² <= kmax²
-            phase = cis(-k⋅Δr)
-            acc += phase * (1/V) * (exp(-σ^2*k²/2) / k²) * (k⊗k)
+            A = (1/V) * (exp(-σ^2*k²/2) / k²) * (k⊗k)
+            push!(terms, DipoleEwaldReciprocalTerm(k, A))
         end
+    end
+
+    return (; demag_term, terms)
+end
+
+function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, reciprocal, icell, i, j)
+    (; Δrs, real_terms, self_energy) = plan
+    acc = zero(CMat3)
+    Δr = Δrs[icell, i, j]
+
+    for term in real_terms[icell, i, j]
+        acc += cis(2π * dot(q_reshaped, term.n)) * term.A
+    end
+
+    acc += reciprocal.demag_term
+    for term in reciprocal.terms
+        acc += cis(-term.k⋅Δr) * term.A
     end
 
     if iszero(Δr)

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -43,6 +43,92 @@ function point_dipole_tensor(r::Vec3)
     return (I - 3(r̂⊗r̂)) / (4π * norm(r)^3)
 end
 
+struct DipoleEwaldRealTerm
+    n :: Vec3
+    A :: Mat3
+end
+
+struct DipoleEwaldQPlan
+    dims          :: NTuple{3, Int}
+    demag         :: Mat3
+    latvecs       :: Mat3
+    recipvecs     :: Mat3
+    V             :: Float64
+    σ             :: Float64
+    σ³            :: Float64
+    kmax²         :: Float64
+    cells         :: Vector{CartesianIndex{3}}
+    Δrs           :: Array{Vec3, 3}
+    real_terms    :: Array{Vector{DipoleEwaldRealTerm}, 3}
+    reciprocal_ms :: Vector{Vec3}
+    self_energy   :: Mat3
+end
+
+function DipoleEwaldQPlan(cryst::Crystal, dims::NTuple{3, Int}, demag::Mat3)
+    na = natoms(cryst)
+
+    # Superlattice vectors and reciprocals for the full system volume.
+    sys_size = diagm(Vec3(dims))
+    latvecs = cryst.latvecs * sys_size
+    recipvecs = cryst.recipvecs / sys_size
+
+    # Precalculate constants. Roughly balances the real and Fourier space costs.
+    I₃ = Mat3(I)
+    V = abs(det(latvecs))
+    L = cbrt(V)
+    σ = L/3
+    σ² = σ*σ
+    σ³ = σ^3
+    rmax = 6√2 * σ
+    rmax² = rmax*rmax
+    kmax = 6√2 / σ
+    kmax² = kmax*kmax
+
+    nmax = map(eachcol(latvecs), eachcol(recipvecs)) do a, b
+        round(Int, rmax / (a⋅normalize(b)) + 1e-6) + 1
+    end
+    mmax = map(eachcol(latvecs), eachcol(recipvecs)) do a, b
+        round(Int, kmax / (b⋅normalize(a)) + 1e-6)
+    end
+
+    cells = vec(collect(CartesianIndices(dims)))
+    Δrs = Array{Vec3, 3}(undef, length(cells), na, na)
+    real_terms = Array{Vector{DipoleEwaldRealTerm}, 3}(undef, length(cells), na, na)
+
+    for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
+        cell_offset = Vec3(cell[1]-1, cell[2]-1, cell[3]-1)
+        Δr = cryst.latvecs * (cell_offset + cryst.positions[j] - cryst.positions[i])
+        Δrs[icell, i, j] = Δr
+
+        terms = DipoleEwaldRealTerm[]
+        for n1 in -nmax[1]:nmax[1], n2 in -nmax[2]:nmax[2], n3 in -nmax[3]:nmax[3]
+            n = Vec3(n1, n2, n3)
+            rvec = Δr + latvecs * n
+            r² = rvec⋅rvec
+            if 0 < r² <= rmax²
+                r = √r²
+                r³ = r²*r
+                rhat = rvec/r
+                erfc0 = erfc(r/(√2*σ))
+                gauss0 = √(2/π) * (r/σ) * exp(-r²/2σ²)
+                A = (1/4π) * ((I₃/r³) * (erfc0 + gauss0) - (3(rhat⊗rhat)/r³) * (erfc0 + (1+r²/3σ²) * gauss0))
+                push!(terms, DipoleEwaldRealTerm(n, A))
+            end
+        end
+        real_terms[icell, i, j] = terms
+    end
+
+    reciprocal_ms = Vec3[]
+    for m1 in -mmax[1]:mmax[1], m2 in -mmax[2]:mmax[2], m3 in -mmax[3]:mmax[3]
+        push!(reciprocal_ms, Vec3(m1, m2, m3))
+    end
+
+    self_energy = -I₃/(3(2π)^(3/2)*σ³)
+
+    return DipoleEwaldQPlan(dims, demag, latvecs, recipvecs, V, σ, σ³, kmax²,
+                            cells, Δrs, real_terms, reciprocal_ms, self_energy)
+end
+
 
 function precompute_dipole_ewald(cryst::Crystal, dims::NTuple{3,Int}, demag::Mat3)
     precompute_dipole_ewald_aux(cryst, dims, demag, Vec3(0,0,0), cos, Val{Float64}())
@@ -50,6 +136,75 @@ end
 
 function precompute_dipole_ewald_at_wavevector(cryst::Crystal, dims::NTuple{3,Int}, demag::Mat3, q_reshaped::Vec3)
     precompute_dipole_ewald_aux(cryst, dims, demag, q_reshaped, cis, Val{ComplexF64}())
+end
+
+function precompute_dipole_ewald_at_wavevector(plan::DipoleEwaldQPlan, q_reshaped::Vec3)
+    A = zeros(CMat3, plan.dims..., size(plan.Δrs, 2), size(plan.Δrs, 3))
+    return precompute_dipole_ewald_at_wavevector!(A, plan, q_reshaped)
+end
+
+function precompute_dipole_ewald_at_wavevector!(A::Array{CMat3, 5}, plan::DipoleEwaldQPlan, q_reshaped::Vec3)
+    (; dims, cells, Δrs) = plan
+    size(A)[1:3] == dims || error("Ewald output dimensions do not match plan")
+    na = size(Δrs, 2)
+    size(A)[4:5] == (na, na) || error("Ewald output atom dimensions do not match plan")
+
+    for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
+        A[cell, i, j] = dipole_ewald_pair_at(plan, q_reshaped, icell, i, j)
+    end
+
+    return A
+end
+
+function precompute_dipole_ewald_at_wavevectors(plan::DipoleEwaldQPlan, qs::AbstractVector{Vec3})
+    A = zeros(CMat3, plan.dims..., size(plan.Δrs, 2), size(plan.Δrs, 3), length(qs))
+    return precompute_dipole_ewald_at_wavevectors!(A, plan, qs)
+end
+
+function precompute_dipole_ewald_at_wavevectors!(A::Array{CMat3, 6}, plan::DipoleEwaldQPlan, qs::AbstractVector{Vec3})
+    (; dims, cells, Δrs) = plan
+    size(A)[1:3] == dims || error("Ewald output dimensions do not match plan")
+    na = size(Δrs, 2)
+    size(A)[4:5] == (na, na) || error("Ewald output atom dimensions do not match plan")
+    size(A, 6) == length(qs) || error("Ewald output q dimension does not match input")
+
+    Threads.@threads for iq in eachindex(qs)
+        q = qs[iq]
+        for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
+            A[cell, i, j, iq] = dipole_ewald_pair_at(plan, q, icell, i, j)
+        end
+    end
+
+    return A
+end
+
+function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, icell, i, j)
+    (; demag, recipvecs, V, σ, kmax², Δrs, real_terms, reciprocal_ms, self_energy) = plan
+    acc = zero(CMat3)
+    Δr = Δrs[icell, i, j]
+
+    for term in real_terms[icell, i, j]
+        acc += cis(2π * dot(q_reshaped, term.n)) * term.A
+    end
+
+    ϵ² = 1e-16
+    q_shift = q_reshaped - round.(q_reshaped)
+    for m in reciprocal_ms
+        k = recipvecs * (m + q_shift)
+        k² = k⋅k
+        if k² <= ϵ²
+            acc += demag / V
+        elseif k² <= kmax²
+            phase = cis(-k⋅Δr)
+            acc += phase * (1/V) * (exp(-σ^2*k²/2) / k²) * (k⊗k)
+        end
+    end
+
+    if iszero(Δr)
+        acc += self_energy
+    end
+
+    return acc
 end
 
 # Precompute the pairwise interaction matrix A between magnetic moments μ. For

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -260,7 +260,7 @@ end
 
 function dipole_ewald_real_phases!(phases::Vector{ComplexF64}, plan::DipoleEwaldQPlan, q_reshaped::Vec3)
     resize!(phases, length(plan.real_ns))
-    for i in eachindex(plan.real_ns)
+    @inbounds for i in eachindex(plan.real_ns)
         phases[i] = cis(2π * dot(q_reshaped, plan.real_ns[i]))
     end
     return phases
@@ -271,7 +271,7 @@ function dipole_ewald_nonreciprocal_pair_at(plan::DipoleEwaldQPlan, real_phases:
     acc = zero(CMat3)
     Δr = Δrs[icell, i, j]
 
-    for term in real_terms[icell, i, j]
+    @inbounds for term in real_terms[icell, i, j]
         acc += real_phases[term.phase_index] * term.A
     end
 

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -48,17 +48,22 @@ struct DipoleEwaldRealTerm
     A           :: Mat3
 end
 
+# Full reciprocal term used by q-dependent Ewald tensor materialization.
 struct DipoleEwaldReciprocalTerm
     k :: Vec3
     scale :: Float64
     A :: Mat3
 end
 
+# Lighter reciprocal term for LSWT Hamiltonian assembly, which exploits the
+# rank-one form `scale * k * k'` without materializing the full tensor.
 struct DipoleEwaldReciprocalKernelTerm
     k :: Vec3
     scale :: Float64
 end
 
+# Reusable q-dependent Ewald plan. Expensive q-independent real-space terms are
+# stored once, while q-dependent real-space phases are indexed through `real_ns`.
 struct DipoleEwaldQPlan
     dims          :: NTuple{3, Int}
     demag         :: Mat3

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -75,6 +75,7 @@ struct DipoleEwaldQPlan
     kmax²         :: Float64
     cells         :: Vector{CartesianIndex{3}}
     Δrs           :: Array{Vec3, 3}
+    site_Δrs      :: Vector{Vec3}
     real_ns       :: Vector{Vec3}
     real_terms    :: Array{Vector{DipoleEwaldRealTerm}, 3}
     reciprocal_ms :: Vector{Vec3}
@@ -144,6 +145,7 @@ function DipoleEwaldQPlan(cryst::Crystal, dims::NTuple{3, Int}, demag::Mat3)
         end
         real_terms[icell, i, j] = terms
     end
+    site_Δrs = [Δrs[1, 1, i] for i in 1:na]
 
     reciprocal_ms = Vec3[]
     for m1 in -mmax[1]:mmax[1], m2 in -mmax[2]:mmax[2], m3 in -mmax[3]:mmax[3]
@@ -153,7 +155,7 @@ function DipoleEwaldQPlan(cryst::Crystal, dims::NTuple{3, Int}, demag::Mat3)
     self_energy = -I₃/(3(2π)^(3/2)*σ³)
 
     return DipoleEwaldQPlan(dims, demag, latvecs, recipvecs, V, σ, σ³, kmax²,
-                            cells, Δrs, real_ns, real_terms, reciprocal_ms, self_energy)
+                            cells, Δrs, site_Δrs, real_ns, real_terms, reciprocal_ms, self_energy)
 end
 
 
@@ -243,6 +245,10 @@ function dipole_ewald_reciprocal_terms!(terms::Vector{DipoleEwaldReciprocalTerm}
 end
 
 function dipole_ewald_reciprocal_kernel_terms!(terms::Vector{DipoleEwaldReciprocalKernelTerm}, plan::DipoleEwaldQPlan, q_reshaped::Vec3)
+    return dipole_ewald_reciprocal_kernel_terms!(terms, plan, q_reshaped, 1.0)
+end
+
+function dipole_ewald_reciprocal_kernel_terms!(terms::Vector{DipoleEwaldReciprocalKernelTerm}, plan::DipoleEwaldQPlan, q_reshaped::Vec3, scale_prefactor::Float64)
     (; demag, recipvecs, V, σ, kmax², reciprocal_ms) = plan
     empty!(terms)
     demag_term = zero(Mat3)
@@ -256,7 +262,7 @@ function dipole_ewald_reciprocal_kernel_terms!(terms::Vector{DipoleEwaldReciproc
             demag_term += demag / V
         elseif k² <= kmax²
             scale = (1/V) * (exp(-σ^2*k²/2) / k²)
-            push!(terms, DipoleEwaldReciprocalKernelTerm(k, scale))
+            push!(terms, DipoleEwaldReciprocalKernelTerm(k, scale_prefactor * scale))
         end
     end
 

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -50,6 +50,7 @@ end
 
 struct DipoleEwaldReciprocalTerm
     k :: Vec3
+    scale :: Float64
     A :: Mat3
 end
 
@@ -174,9 +175,10 @@ function precompute_dipole_ewald_at_wavevectors!(A::Array{CMat3, 6}, plan::Dipol
     size(A)[4:5] == (na, na) || error("Ewald output atom dimensions do not match plan")
     size(A, 6) == length(qs) || error("Ewald output q dimension does not match input")
 
+    reciprocal_term_buffers = [DipoleEwaldReciprocalTerm[] for _ in 1:Threads.maxthreadid()]
     Threads.@threads for iq in eachindex(qs)
         q = qs[iq]
-        reciprocal = dipole_ewald_reciprocal_terms(plan, q)
+        reciprocal = dipole_ewald_reciprocal_terms!(reciprocal_term_buffers[Threads.threadid()], plan, q)
         for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
             A[cell, i, j, iq] = dipole_ewald_pair_at(plan, q, reciprocal, icell, i, j)
         end
@@ -190,8 +192,12 @@ function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, icell, i
 end
 
 function dipole_ewald_reciprocal_terms(plan::DipoleEwaldQPlan, q_reshaped::Vec3)
+    return dipole_ewald_reciprocal_terms!(DipoleEwaldReciprocalTerm[], plan, q_reshaped)
+end
+
+function dipole_ewald_reciprocal_terms!(terms::Vector{DipoleEwaldReciprocalTerm}, plan::DipoleEwaldQPlan, q_reshaped::Vec3)
     (; demag, recipvecs, V, σ, kmax², reciprocal_ms) = plan
-    terms = DipoleEwaldReciprocalTerm[]
+    empty!(terms)
     demag_term = zero(Mat3)
 
     ϵ² = 1e-16
@@ -202,8 +208,9 @@ function dipole_ewald_reciprocal_terms(plan::DipoleEwaldQPlan, q_reshaped::Vec3)
         if k² <= ϵ²
             demag_term += demag / V
         elseif k² <= kmax²
-            A = (1/V) * (exp(-σ^2*k²/2) / k²) * (k⊗k)
-            push!(terms, DipoleEwaldReciprocalTerm(k, A))
+            scale = (1/V) * (exp(-σ^2*k²/2) / k²)
+            A = scale * (k⊗k)
+            push!(terms, DipoleEwaldReciprocalTerm(k, scale, A))
         end
     end
 
@@ -211,6 +218,17 @@ function dipole_ewald_reciprocal_terms(plan::DipoleEwaldQPlan, q_reshaped::Vec3)
 end
 
 function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, reciprocal, icell, i, j)
+    acc = dipole_ewald_nonreciprocal_pair_at(plan, q_reshaped, reciprocal.demag_term, icell, i, j)
+
+    for term in reciprocal.terms
+        Δr = plan.Δrs[icell, i, j]
+        acc += cis(-term.k⋅Δr) * term.A
+    end
+
+    return acc
+end
+
+function dipole_ewald_nonreciprocal_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, demag_term::Mat3, icell, i, j)
     (; Δrs, real_terms, self_energy) = plan
     acc = zero(CMat3)
     Δr = Δrs[icell, i, j]
@@ -219,10 +237,7 @@ function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, reciproc
         acc += cis(2π * dot(q_reshaped, term.n)) * term.A
     end
 
-    acc += reciprocal.demag_term
-    for term in reciprocal.terms
-        acc += cis(-term.k⋅Δr) * term.A
-    end
+    acc += demag_term
 
     if iszero(Δr)
         acc += self_energy

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -54,6 +54,11 @@ struct DipoleEwaldReciprocalTerm
     A :: Mat3
 end
 
+struct DipoleEwaldReciprocalKernelTerm
+    k :: Vec3
+    scale :: Float64
+end
+
 struct DipoleEwaldQPlan
     dims          :: NTuple{3, Int}
     demag         :: Mat3
@@ -226,6 +231,27 @@ function dipole_ewald_reciprocal_terms!(terms::Vector{DipoleEwaldReciprocalTerm}
             scale = (1/V) * (exp(-σ^2*k²/2) / k²)
             A = scale * (k⊗k)
             push!(terms, DipoleEwaldReciprocalTerm(k, scale, A))
+        end
+    end
+
+    return (; demag_term, terms)
+end
+
+function dipole_ewald_reciprocal_kernel_terms!(terms::Vector{DipoleEwaldReciprocalKernelTerm}, plan::DipoleEwaldQPlan, q_reshaped::Vec3)
+    (; demag, recipvecs, V, σ, kmax², reciprocal_ms) = plan
+    empty!(terms)
+    demag_term = zero(Mat3)
+
+    ϵ² = 1e-16
+    q_shift = q_reshaped - round.(q_reshaped)
+    for m in reciprocal_ms
+        k = recipvecs * (m + q_shift)
+        k² = k⋅k
+        if k² <= ϵ²
+            demag_term += demag / V
+        elseif k² <= kmax²
+            scale = (1/V) * (exp(-σ^2*k²/2) / k²)
+            push!(terms, DipoleEwaldReciprocalKernelTerm(k, scale))
         end
     end
 

--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -44,8 +44,8 @@ function point_dipole_tensor(r::Vec3)
 end
 
 struct DipoleEwaldRealTerm
-    n :: Vec3
-    A :: Mat3
+    phase_index :: Int
+    A           :: Mat3
 end
 
 struct DipoleEwaldReciprocalTerm
@@ -65,6 +65,7 @@ struct DipoleEwaldQPlan
     kmax²         :: Float64
     cells         :: Vector{CartesianIndex{3}}
     Δrs           :: Array{Vec3, 3}
+    real_ns       :: Vector{Vec3}
     real_terms    :: Array{Vector{DipoleEwaldRealTerm}, 3}
     reciprocal_ms :: Vector{Vec3}
     self_energy   :: Mat3
@@ -99,6 +100,8 @@ function DipoleEwaldQPlan(cryst::Crystal, dims::NTuple{3, Int}, demag::Mat3)
 
     cells = vec(collect(CartesianIndices(dims)))
     Δrs = Array{Vec3, 3}(undef, length(cells), na, na)
+    real_ns = Vec3[]
+    real_n_indices = Dict{NTuple{3, Int}, Int}()
     real_terms = Array{Vector{DipoleEwaldRealTerm}, 3}(undef, length(cells), na, na)
 
     for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
@@ -112,13 +115,21 @@ function DipoleEwaldQPlan(cryst::Crystal, dims::NTuple{3, Int}, demag::Mat3)
             rvec = Δr + latvecs * n
             r² = rvec⋅rvec
             if 0 < r² <= rmax²
+                key = (n1, n2, n3)
+                phase_index = get(real_n_indices, key, 0)
+                if iszero(phase_index)
+                    push!(real_ns, n)
+                    phase_index = length(real_ns)
+                    real_n_indices[key] = phase_index
+                end
+
                 r = √r²
                 r³ = r²*r
                 rhat = rvec/r
                 erfc0 = erfc(r/(√2*σ))
                 gauss0 = √(2/π) * (r/σ) * exp(-r²/2σ²)
                 A = (1/4π) * ((I₃/r³) * (erfc0 + gauss0) - (3(rhat⊗rhat)/r³) * (erfc0 + (1+r²/3σ²) * gauss0))
-                push!(terms, DipoleEwaldRealTerm(n, A))
+                push!(terms, DipoleEwaldRealTerm(phase_index, A))
             end
         end
         real_terms[icell, i, j] = terms
@@ -132,7 +143,7 @@ function DipoleEwaldQPlan(cryst::Crystal, dims::NTuple{3, Int}, demag::Mat3)
     self_energy = -I₃/(3(2π)^(3/2)*σ³)
 
     return DipoleEwaldQPlan(dims, demag, latvecs, recipvecs, V, σ, σ³, kmax²,
-                            cells, Δrs, real_terms, reciprocal_ms, self_energy)
+                            cells, Δrs, real_ns, real_terms, reciprocal_ms, self_energy)
 end
 
 
@@ -156,8 +167,9 @@ function precompute_dipole_ewald_at_wavevector!(A::Array{CMat3, 5}, plan::Dipole
     size(A)[4:5] == (na, na) || error("Ewald output atom dimensions do not match plan")
 
     reciprocal = dipole_ewald_reciprocal_terms(plan, q_reshaped)
+    real_phases = dipole_ewald_real_phases(plan, q_reshaped)
     for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
-        A[cell, i, j] = dipole_ewald_pair_at(plan, q_reshaped, reciprocal, icell, i, j)
+        A[cell, i, j] = dipole_ewald_pair_at(plan, real_phases, reciprocal, icell, i, j)
     end
 
     return A
@@ -176,11 +188,14 @@ function precompute_dipole_ewald_at_wavevectors!(A::Array{CMat3, 6}, plan::Dipol
     size(A, 6) == length(qs) || error("Ewald output q dimension does not match input")
 
     reciprocal_term_buffers = [DipoleEwaldReciprocalTerm[] for _ in 1:Threads.maxthreadid()]
+    real_phase_buffers = [ComplexF64[] for _ in 1:Threads.maxthreadid()]
     Threads.@threads for iq in eachindex(qs)
         q = qs[iq]
-        reciprocal = dipole_ewald_reciprocal_terms!(reciprocal_term_buffers[Threads.threadid()], plan, q)
+        tid = Threads.threadid()
+        reciprocal = dipole_ewald_reciprocal_terms!(reciprocal_term_buffers[tid], plan, q)
+        real_phases = dipole_ewald_real_phases!(real_phase_buffers[tid], plan, q)
         for (icell, cell) in enumerate(cells), j in 1:na, i in 1:na
-            A[cell, i, j, iq] = dipole_ewald_pair_at(plan, q, reciprocal, icell, i, j)
+            A[cell, i, j, iq] = dipole_ewald_pair_at(plan, real_phases, reciprocal, icell, i, j)
         end
     end
 
@@ -218,7 +233,12 @@ function dipole_ewald_reciprocal_terms!(terms::Vector{DipoleEwaldReciprocalTerm}
 end
 
 function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, reciprocal, icell, i, j)
-    acc = dipole_ewald_nonreciprocal_pair_at(plan, q_reshaped, reciprocal.demag_term, icell, i, j)
+    real_phases = dipole_ewald_real_phases(plan, q_reshaped)
+    return dipole_ewald_pair_at(plan, real_phases, reciprocal, icell, i, j)
+end
+
+function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, real_phases::Vector{ComplexF64}, reciprocal, icell, i, j)
+    acc = dipole_ewald_nonreciprocal_pair_at(plan, real_phases, reciprocal.demag_term, icell, i, j)
 
     for term in reciprocal.terms
         Δr = plan.Δrs[icell, i, j]
@@ -229,12 +249,30 @@ function dipole_ewald_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, reciproc
 end
 
 function dipole_ewald_nonreciprocal_pair_at(plan::DipoleEwaldQPlan, q_reshaped::Vec3, demag_term::Mat3, icell, i, j)
+    real_phases = dipole_ewald_real_phases(plan, q_reshaped)
+    return dipole_ewald_nonreciprocal_pair_at(plan, real_phases, demag_term, icell, i, j)
+end
+
+function dipole_ewald_real_phases(plan::DipoleEwaldQPlan, q_reshaped::Vec3)
+    phases = Vector{ComplexF64}(undef, length(plan.real_ns))
+    return dipole_ewald_real_phases!(phases, plan, q_reshaped)
+end
+
+function dipole_ewald_real_phases!(phases::Vector{ComplexF64}, plan::DipoleEwaldQPlan, q_reshaped::Vec3)
+    resize!(phases, length(plan.real_ns))
+    for i in eachindex(plan.real_ns)
+        phases[i] = cis(2π * dot(q_reshaped, plan.real_ns[i]))
+    end
+    return phases
+end
+
+function dipole_ewald_nonreciprocal_pair_at(plan::DipoleEwaldQPlan, real_phases::Vector{ComplexF64}, demag_term::Mat3, icell, i, j)
     (; Δrs, real_terms, self_energy) = plan
     acc = zero(CMat3)
     Δr = Δrs[icell, i, j]
 
     for term in real_terms[icell, i, j]
-        acc += cis(2π * dot(q_reshaped, term.n)) * term.A
+        acc += real_phases[term.phase_index] * term.A
     end
 
     acc += demag_term

--- a/test/test_ewald.jl
+++ b/test/test_ewald.jl
@@ -73,3 +73,29 @@
     E = sum((1/2)d⋅b for (d, b) in zip(sys.dipoles, ∇E))
     @test isapprox(energy(sys), E; atol=1e-12)
 end
+
+@testitem "Planned q-dependent Ewald matches direct implementation" begin
+    using LinearAlgebra
+    using Sunny
+
+    latvecs = lattice_vectors(1.1, 0.9, 0.8, 92, 85, 95)
+    positions = [[0, 0.01, 0.01], [0.1, 0.01, 0.01], [0.6, 0.4, 0.5]]
+    cryst = Crystal(latvecs, positions)
+    demag = Sunny.Mat3(I) / 3
+    plan = Sunny.DipoleEwaldQPlan(cryst, (1, 1, 1), demag)
+
+    qs = [
+        Sunny.Vec3(0, 0, 0),
+        Sunny.Vec3(0.2, -0.3, 0.4),
+        Sunny.Vec3(0.999999, 0.1, -0.2),
+    ]
+
+    planned_batch = Sunny.precompute_dipole_ewald_at_wavevectors(plan, qs)
+
+    for (iq, q) in enumerate(qs)
+        direct = Sunny.precompute_dipole_ewald_aux(cryst, (1, 1, 1), demag, q, cis, Val{ComplexF64}())
+        planned = Sunny.precompute_dipole_ewald_at_wavevector(plan, q)
+        @test maximum(norm.(direct .- planned)) < 1e-12
+        @test maximum(norm.(direct .- planned_batch[:, :, :, :, :, iq])) < 1e-12
+    end
+end

--- a/test/test_ewald.jl
+++ b/test/test_ewald.jl
@@ -99,3 +99,88 @@ end
         @test maximum(norm.(direct .- planned_batch[:, :, :, :, :, iq])) < 1e-12
     end
 end
+
+@testitem "Optimized dipole spin-wave Hamiltonian matches full Ewald matrix" begin
+    using LinearAlgebra
+    using Sunny
+
+    function reference_ewald_block(swt, q_reshaped)
+        (; sys, data) = swt
+        (; local_rotations, sqrtS) = data
+        (; gs) = sys
+        (; demag, μ0_μB², A) = sys.ewald
+
+        L = Sunny.nbands(swt)
+        H = zeros(ComplexF64, 2L, 2L)
+        H11 = view(H, 1:L, 1:L)
+        H12 = view(H, 1:L, L+1:2L)
+        H21 = view(H, L+1:2L, 1:L)
+        H22 = view(H, L+1:2L, L+1:2L)
+
+        Rs = local_rotations
+        A0 = reshape(A, L, L)
+        Aq = Sunny.precompute_dipole_ewald_at_wavevector(sys.crystal, (1, 1, 1), demag, q_reshaped) * μ0_μB²
+        Aq = reshape(Aq, L, L)
+
+        for i in 1:L, j in 1:L
+            J = gs[i]' * Aq[i, j] * gs[j] / 2
+            J0 = gs[i]' * A0[i, j] * gs[j] / 2
+            J = sqrtS[i]*sqrtS[j] * Rs[i]' * J * Rs[j]
+            J0 = sqrtS[i]*sqrtS[j] * Rs[i]' * J0 * Rs[j]
+
+            Q⁻ = 0.5 * (J[1, 1] + J[2, 2] - im*(J[1, 2] - J[2, 1]))
+            Q⁺ = 0.5 * (J[1, 1] + J[2, 2] + im*(J[1, 2] - J[2, 1]))
+            H11[i, j] += Q⁻
+            H11[j, i] += conj(Q⁻)
+            H22[i, j] += Q⁺
+            H22[j, i] += conj(Q⁺)
+
+            P⁻ = 0.5 * (J[1, 1] - J[2, 2] - im*(J[1, 2] + J[2, 1]))
+            P⁺ = 0.5 * (J[1, 1] - J[2, 2] + im*(J[1, 2] + J[2, 1]))
+            H21[i, j] += P⁻
+            H21[j, i] += conj(P⁺)
+            H12[i, j] += P⁺
+            H12[j, i] += conj(P⁻)
+
+            H11[i, i] -= J0[3, 3]
+            H11[j, j] -= J0[3, 3]
+            H22[i, i] -= J0[3, 3]
+            H22[j, j] -= J0[3, 3]
+        end
+
+        return H
+    end
+
+    function optimized_ewald_block(swt, q_reshaped)
+        (; sys) = swt
+        L = Sunny.nbands(swt)
+        Hfull = zeros(ComplexF64, 2L, 2L)
+        Hbase = zeros(ComplexF64, 2L, 2L)
+
+        Sunny.dynamical_matrix!(Hfull, swt, q_reshaped)
+        ewald = sys.ewald
+        sys.ewald = nothing
+        try
+            Sunny.dynamical_matrix!(Hbase, swt, q_reshaped)
+        finally
+            sys.ewald = ewald
+        end
+        return Hfull - Hbase
+    end
+
+    latvecs = lattice_vectors(10.19, 10.19, 10.19, 90, 90, 90)
+    cryst = Crystal(latvecs, [[0, 0, 0]], 227)
+    sys = System(cryst, [1 => Moment(s=7/2, g=2)], :dipole)
+    sys = reshape_supercell(sys, primitive_cell(cryst))
+    enable_dipole_dipole!(sys, Units(:K, :angstrom).vacuum_permeability)
+    randomize_spins!(sys)
+    swt = SpinWaveTheory(sys; measure=nothing)
+
+    qs = [
+        Sunny.Vec3(0.1, 0.2, 0.3),
+        Sunny.Vec3(0.999999, 0.25, -0.1),
+    ]
+    for q in qs
+        @test maximum(abs.(reference_ewald_block(swt, q) .- optimized_ewald_block(swt, q))) < 1e-12
+    end
+end


### PR DESCRIPTION
Reorganized the code for powder averages using dipole-dipole interactions evaluated via Ewald sums. The previous code re-calculated some heavy terms, which can actually be pre-computed and re-used.

In cases with 24 atoms per unit cell, the new code is about 60 times faster.