### PR TITLE
Vectorize the Ewald dipole-dipole gradient contraction

### DIFF
--- a/src/System/Ewald.jl
+++ b/src/System/Ewald.jl
@@ -204,9 +204,14 @@ function accum_ewald_grad!(∇E, dipoles, @nospecialize(sys::System))
     # performance degrades by ~50%
     fill!(Fϕ, 0.0)
     (_, m1, m2, m3, na) = size(Fμ)
-    ms = CartesianIndices((m1, m2, m3))
-    @inbounds for j in 1:na, i in 1:na, m in ms, α in 1:3, β in 1:3
-        Fϕ[α,m,i] += conj(FA[α,β,m,i,j]) * Fμ[β,m,j]
+    nspatial = m1 * m2 * m3
+    Fϕr = reshape(Fϕ, 3, nspatial, na)
+    Fμr = reshape(Fμ, 3, nspatial, na)
+    FAr = reshape(FA, 3, 3, nspatial, na, na)
+    @inbounds for j in 1:na, i in 1:na, α in 1:3, β in 1:3
+        @simd for s in 1:nspatial
+            Fϕr[α, s, i] += conj(FAr[α, β, s, i, j]) * Fμr[β, s, j]
+        end
     end
 
     # Inverse Fourier transform to get ϕ in real space


### PR DESCRIPTION
**Speedup: 2.76x on the isolated contraction loop, 1.58x on the full dipole-dipole gradient, measured on AMD EPYC 9654 (Zen 4, AVX-512), single-threaded.**

## Summary

The Fourier-space contraction in `accum_ewald_grad!` (`src/System/Ewald.jl`) is the dominant cost of the
long-range dipole-dipole gradient, which is evaluated on every gradient call during spin dynamics. The loop
indexes the long spatial axis with a middle `CartesianIndex` while keeping the two size-3 component indices
innermost, so it does not vectorize and spends a substantial fraction of its time on index arithmetic. The
FFTs themselves are a small part of the dipole-dipole cost; this contraction is the hot spot.

This reorders the loop so the three Fourier-space cell axes are collapsed into one linear axis carried by an
innermost `@simd` loop, with the component and sublattice indices moved outward. The `reshape`s share memory
with the originals, and the accumulation order into each element of `Fϕ` is unchanged.

## Benchmarks

Hardware: AMD EPYC 9654 (Zen 4, AVX-512), single-threaded, Julia 1.12.

Isolated contraction loop, at the Fourier-space array sizes produced by a 10x10x10-cell diamond lattice with
8 sublattices (minimum over 30 samples):

| | time |
|---|---|
| before | 1600.8 us |
| after | 580.7 us |
| speedup | **2.76x** |

End-to-end gradient (`set_energy_grad_dipoles!`) on the same system with dipole-dipole enabled, which is
dominated by this contraction:

| | time |
|---|---|
| before | 4839.2 us |
| after | 3060.6 us |
| speedup | **1.58x** |