### PR TITLE
Inline the bilinear exchange energy contraction

### DIFF
--- a/src/System/Interactions.jl
+++ b/src/System/Interactions.jl
@@ -392,7 +392,7 @@ function local_energy_change(sys::System, site, state::SpinState)
 
         # Bilinear (dipole sector, both modes)
         J = pc.bilin
-        ΔE += dot(ΔS, J, Sⱼ)
+        ΔE += dot(ΔS, J*Sⱼ)
 
         # Biquadratic. Dipole sector (quadrupole of S) in dipole mode, else
         # coherent sector (quadrupole of Z).
@@ -508,7 +508,7 @@ function dipole_sector_energy_aux(int::Interactions, @nospecialize(sys::System),
             Sᵢ = sys.dipoles[siteᵢ]
             Sⱼ = sys.dipoles[siteⱼ]
 
-            E += dot(Sᵢ, pc.bilin, Sⱼ)
+            E += dot(Sᵢ, pc.bilin*Sⱼ)
             sys.mode == :SUN && continue
 
             E += pc.scalar


### PR DESCRIPTION
**Speedup: 8.29x on the isolated bilinear-dot loop (matrix exchange), 1.51x on full energy() with dipole-dipole.**

## Summary

The bilinear exchange energy is computed as `dot(Sᵢ, J, Sⱼ)` in the energy accumulation
(`dipole_sector_energy_aux`) and in `local_energy_change` (`src/System/Interactions.jl`). The
three-argument `dot` dispatches to a generic `LinearAlgebra` method that is not inlined here, so it emits an
out-of-line call inside the hot loop over pair couplings. Rewriting it as `dot(Sᵢ, J*Sⱼ)` lowers to a
`StaticArrays` matrix-vector product followed by a two-argument `dot`, both of which inline.

This affects only the matrix (`Mat3`) exchange case. For scalar exchange the two forms generate equivalent
code, so there is no change there.

## Benchmarks

Hardware: AMD EPYC 9654 (Zen 4, AVX-512), single-threaded, Julia 1.12.

Isolated loop of `dot` over 50,000 pair terms (minimum over 30 samples):

| exchange type | before | after | speedup |
|---|---|---|---|
| matrix (`Mat3`) | 760.5 us | 91.7 us | **8.29x** |
| scalar (`Float64`) | 41.0 us | 41.1 us | 1.00x (unchanged) |

End-to-end `energy()` on a 10x10x10-cell diamond lattice with dipole-dipole enabled (matrix exchange):

| | time |
|---|---|
| before | 2518.7 us |
| after | 1670.9 us |
| speedup | **1.51x** |