### PR TITLE
Print exception from ExplicitImports before failing

### DIFF
--- a/docs/src/why.md
+++ b/docs/src/why.md
@@ -43,7 +43,7 @@
   summation, as illustrated in the [pyrochlore SWT tutorial](@ref "7. Long-range
   dipole interactions"). Dipole-dipole interactions in classical dynamics are
   accelerated with the fast Fourier transform (FFT).
-- Self-consistent Gaussian Approximation ([SCGA](@ref)) for calculating static
+- Self-consistent Gaussian Approximation ([`SCGA`](@ref)) for calculating static
   observables, e.g. ``\mathcal{S}(𝐪)`` and ``χ``, in the paramagnetic phase.
   Magnetic ions on symmetry-inequivalent sublattices are properly handled.
 - Tools for comparing to experimental data: [form factors](@ref FormFactor),

--- a/test/test_pkg_analysis.jl
+++ b/test/test_pkg_analysis.jl
@@ -21,7 +21,11 @@ end
     import ExplicitImports, LinearAlgebra
     try
         ExplicitImports.check_no_implicit_imports(Sunny; skip=(mod, Base, Core, LinearAlgebra))
-    catch _
+    catch e
+        print("An error occurred: ")
+        Base.showerror(stdout, e)
+        println() # Add a newline
         @test false
     end
 end
+

--- a/test/test_pkg_analysis.jl
+++ b/test/test_pkg_analysis.jl
@@ -19,13 +19,6 @@ end
 
 @testitem "ExplicitImports" begin
     import ExplicitImports, LinearAlgebra
-    try
-        ExplicitImports.check_no_implicit_imports(Sunny; skip=(mod, Base, Core, LinearAlgebra))
-    catch e
-        print("An error occurred: ")
-        Base.showerror(stdout, e)
-        println() # Add a newline
-        @test false
-    end
+    @test ExplicitImports.check_no_implicit_imports(Sunny; skip=(mod, Base, Core, LinearAlgebra)) === nothing
 end
 


### PR DESCRIPTION
Printing the exception made it easier to fix without setting a breakpoint or modifying code.